### PR TITLE
feat: client.get uses unpackStream with blockstore

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10791,6 +10791,18 @@
         "node": ">=8"
       }
     },
+    "node_modules/nyc/node_modules/strip-ansi": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+      "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/nyc/node_modules/wrap-ansi": {
       "version": "6.2.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",

--- a/packages/client/package-lock.json
+++ b/packages/client/package-lock.json
@@ -12,8 +12,13 @@
         "@ipld/car": "^3.1.2",
         "@web-std/blob": "^2.1.0",
         "@web-std/fetch": "^2.0.1",
+        "@web-std/file": "^1.1.0",
         "browser-readablestream-to-it": "^1.0.2",
-        "ipfs-car": "^0.3.5"
+        "carbites": "^1.0.6",
+        "ipfs-car": "^0.4.1",
+        "p-retry": "^4.5.0",
+        "streaming-iterables": "^6.0.0",
+        "web3-file": "^0.2.0"
       },
       "devDependencies": {
         "@rollup/plugin-commonjs": "^19.0.0",
@@ -3241,6 +3246,11 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/retry": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.0.tgz",
+      "integrity": "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA=="
+    },
     "node_modules/@types/varint": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/@types/varint/-/varint-6.0.0.tgz",
@@ -3281,9 +3291,9 @@
       "dev": true
     },
     "node_modules/@vascosantos/ipfs-unixfs-exporter": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/@vascosantos/ipfs-unixfs-exporter/-/ipfs-unixfs-exporter-7.0.0.tgz",
-      "integrity": "sha512-2lt5wbmVq5wPiY89mGyVQ+z7HuEH4V6hbrwe/dCZOMZdZ1tat6uFvelHd6llHMxvlKalmcU2/QtUPjSDKX+/KQ==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@vascosantos/ipfs-unixfs-exporter/-/ipfs-unixfs-exporter-8.0.0.tgz",
+      "integrity": "sha512-NaPI4ybu8EqsDw3EiLLJfVtxw3uXLWeyfmS/CGRfwl82Ue6lVm2L0Ebquf1h3K1YdXhfNiaL4TKKa/ZrCX+1eA==",
       "dependencies": {
         "@ipld/dag-cbor": "^6.0.0",
         "@ipld/dag-pb": "^2.0.2",
@@ -3301,14 +3311,14 @@
       }
     },
     "node_modules/@vascosantos/ipfs-unixfs-exporter/node_modules/multiformats": {
-      "version": "9.1.0",
-      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-9.1.0.tgz",
-      "integrity": "sha512-NhIM1NI9O2BSgWQWRsf8qEkRjKgNwEtwPb+gJKNMZW4xM/l1HbRktjXJvcG936QL/hrUh54T959JuLMF65Cbhw=="
+      "version": "9.1.1",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-9.1.1.tgz",
+      "integrity": "sha512-JkIoxg+QIZwkGxuPFEo5QlI5c8T4aEIgJ6pxiiOvSkjekc4JUGxb6oS1uHzjEQQdmDvBmJJF80Za5cSGtJl5Ng=="
     },
     "node_modules/@vascosantos/ipfs-unixfs-importer": {
-      "version": "9.0.3",
-      "resolved": "https://registry.npmjs.org/@vascosantos/ipfs-unixfs-importer/-/ipfs-unixfs-importer-9.0.3.tgz",
-      "integrity": "sha512-kVcp+yZavn5Tn5EL7RHH51kSoO+gx1Yz22NtzmPFVNRx/cZ039VNZFI5XHkFT4FkFiskLv97nEzM/rOyug0wRw==",
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@vascosantos/ipfs-unixfs-importer/-/ipfs-unixfs-importer-10.0.0.tgz",
+      "integrity": "sha512-rtvX3GkdWp74tmT8anPiYQgM3GtqmEQPHn+9IdZTl7KcjpjlmpwwBvM21Vqv0Oby2CjYAtQqSq9Az0dmABRqSA==",
       "dependencies": {
         "@ipld/dag-pb": "^2.1.1",
         "bl": "^5.0.0",
@@ -3332,9 +3342,9 @@
       }
     },
     "node_modules/@vascosantos/ipfs-unixfs-importer/node_modules/multiformats": {
-      "version": "9.1.0",
-      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-9.1.0.tgz",
-      "integrity": "sha512-NhIM1NI9O2BSgWQWRsf8qEkRjKgNwEtwPb+gJKNMZW4xM/l1HbRktjXJvcG936QL/hrUh54T959JuLMF65Cbhw=="
+      "version": "9.1.1",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-9.1.1.tgz",
+      "integrity": "sha512-JkIoxg+QIZwkGxuPFEo5QlI5c8T4aEIgJ6pxiiOvSkjekc4JUGxb6oS1uHzjEQQdmDvBmJJF80Za5cSGtJl5Ng=="
     },
     "node_modules/@web-std/blob": {
       "version": "2.1.1",
@@ -3356,6 +3366,14 @@
       },
       "engines": {
         "node": "^10.17 || >=12.3"
+      }
+    },
+    "node_modules/@web-std/file": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@web-std/file/-/file-1.1.0.tgz",
+      "integrity": "sha512-VyKHE0eN713xBoRe7wrUjamct1KoALrkxCPEHiAusdBvOw7bSu4nmP+1i7b8L0cBUDawUEQyT7+7kPIykUla6A==",
+      "dependencies": {
+        "@web-std/blob": "^2.1.0"
       }
     },
     "node_modules/@zxing/text-encoding": {
@@ -4397,6 +4415,22 @@
       "engines": {
         "node": "6.* || 8.* || >= 10.*"
       }
+    },
+    "node_modules/carbites": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/carbites/-/carbites-1.0.6.tgz",
+      "integrity": "sha512-dS9IQvnrb5VIRvSTNz5Ff+mB9d2MFfi5mojtJi7Rlss79VeF190jr0sZdA7eW0CGHotvHkZaWuM6wgfD9PEFRg==",
+      "dependencies": {
+        "@ipld/car": "^3.0.1",
+        "@ipld/dag-cbor": "^6.0.3",
+        "@ipld/dag-pb": "^2.0.2",
+        "multiformats": "^9.0.4"
+      }
+    },
+    "node_modules/carbites/node_modules/multiformats": {
+      "version": "9.1.1",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-9.1.1.tgz",
+      "integrity": "sha512-JkIoxg+QIZwkGxuPFEo5QlI5c8T4aEIgJ6pxiiOvSkjekc4JUGxb6oS1uHzjEQQdmDvBmJJF80Za5cSGtJl5Ng=="
     },
     "node_modules/cborg": {
       "version": "1.3.4",
@@ -6890,6 +6924,11 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/idb-keyval": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/idb-keyval/-/idb-keyval-5.0.6.tgz",
+      "integrity": "sha512-6lJuVbwyo82mKSH6Wq2eHkt9LcbwHAelMIcMe0tP4p20Pod7tTxq9zf0ge2n/YDfMOpDryerfmmYyuQiaFaKOg=="
+    },
     "node_modules/ieee754": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
@@ -7064,15 +7103,16 @@
       }
     },
     "node_modules/ipfs-car": {
-      "version": "0.3.5",
-      "resolved": "https://registry.npmjs.org/ipfs-car/-/ipfs-car-0.3.5.tgz",
-      "integrity": "sha512-tlg7T+Bhh4o4e61Z1zj2EpQ0fMNj7+qiR44+46Hpl4pMAls9hm2PZLvUW5UzaN8txK5OW/BYQ4BQ0S9UHsTcSw==",
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/ipfs-car/-/ipfs-car-0.4.1.tgz",
+      "integrity": "sha512-K3fHUFlRJkdNFW1pGrEHcOE9nbEIJPQjlLe9unScZ7L01CxCngpPcwYMK0aIX1w1d1y4Oo64V1YHChD05K/I2g==",
       "dependencies": {
         "@ipld/car": "^3.0.3",
-        "@vascosantos/ipfs-unixfs-exporter": "^7.0.0",
-        "@vascosantos/ipfs-unixfs-importer": "^9.0.0",
+        "@vascosantos/ipfs-unixfs-exporter": "^8.0.0",
+        "@vascosantos/ipfs-unixfs-importer": "^10.0.0",
         "@web-std/blob": "^2.1.1",
         "bl": "^5.0.0",
+        "idb-keyval": "^5.0.6",
         "ipfs-core-types": "^0.5.0",
         "ipfs-core-utils": "^0.8.0",
         "ipfs-utils": "^8.0.0",
@@ -7095,6 +7135,14 @@
       "version": "9.1.0",
       "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-9.1.0.tgz",
       "integrity": "sha512-NhIM1NI9O2BSgWQWRsf8qEkRjKgNwEtwPb+gJKNMZW4xM/l1HbRktjXJvcG936QL/hrUh54T959JuLMF65Cbhw=="
+    },
+    "node_modules/ipfs-car/node_modules/streaming-iterables": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/streaming-iterables/-/streaming-iterables-5.0.4.tgz",
+      "integrity": "sha512-nEs6hBGIPsVz6uq6pscGGKfoPDQWrDQW0b0UHurtSDysekfKLmkPg7FQVRE2sj3Rad6yUo9E1sGTxOWyYsHQ/g==",
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/ipfs-core-types": {
       "version": "0.5.2",
@@ -10917,6 +10965,26 @@
         "node": ">=8"
       }
     },
+    "node_modules/p-retry": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-4.6.0.tgz",
+      "integrity": "sha512-SAHbQEwg3X5DRNaLmWjT+DlGc93ba5i+aP3QLfVNDncQEQO4xjbYW4N/lcVTSuP0aJietGfx2t94dJLzfBMpXw==",
+      "dependencies": {
+        "@types/retry": "^0.12.0",
+        "retry": "^0.13.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/p-retry/node_modules/retry": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
+      "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
     "node_modules/p-timeout": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-3.2.0.tgz",
@@ -13619,9 +13687,9 @@
       }
     },
     "node_modules/streaming-iterables": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/streaming-iterables/-/streaming-iterables-5.0.4.tgz",
-      "integrity": "sha512-nEs6hBGIPsVz6uq6pscGGKfoPDQWrDQW0b0UHurtSDysekfKLmkPg7FQVRE2sj3Rad6yUo9E1sGTxOWyYsHQ/g==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/streaming-iterables/-/streaming-iterables-6.0.0.tgz",
+      "integrity": "sha512-GYbJh0ife8PvryWSyFifY1m1uj6zO12d9duuP6xltiOolUz44eKasp5gbFhRbFbLy50ik6hcKn4Pbxl9AkxB+Q==",
       "engines": {
         "node": ">=10"
       }
@@ -14706,6 +14774,15 @@
       "integrity": "sha512-d2H/t0eqRNM4w2WvmTdoeIvzAUSpK7JmATB8Nr2lb7nQ9BTIJVjbQ/TRFVEh2gUH1HwclPdoPtfMoFfetXaZnA==",
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/web3-file": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/web3-file/-/web3-file-0.2.0.tgz",
+      "integrity": "sha512-O3t4B44dXZbL+9eGbkyn8k9upUCE7ICuzvjDSPuCYdec4r7Ds6IrzhMm72YbuOGYzHYsnfLIhAZzuXKCSdfk8w==",
+      "dependencies": {
+        "@web-std/blob": "2.1.1",
+        "browser-readablestream-to-it": "^1.0.2"
       }
     },
     "node_modules/whatwg-fetch": {
@@ -17489,6 +17566,11 @@
         "@types/node": "*"
       }
     },
+    "@types/retry": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.0.tgz",
+      "integrity": "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA=="
+    },
     "@types/varint": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/@types/varint/-/varint-6.0.0.tgz",
@@ -17529,9 +17611,9 @@
       "dev": true
     },
     "@vascosantos/ipfs-unixfs-exporter": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/@vascosantos/ipfs-unixfs-exporter/-/ipfs-unixfs-exporter-7.0.0.tgz",
-      "integrity": "sha512-2lt5wbmVq5wPiY89mGyVQ+z7HuEH4V6hbrwe/dCZOMZdZ1tat6uFvelHd6llHMxvlKalmcU2/QtUPjSDKX+/KQ==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@vascosantos/ipfs-unixfs-exporter/-/ipfs-unixfs-exporter-8.0.0.tgz",
+      "integrity": "sha512-NaPI4ybu8EqsDw3EiLLJfVtxw3uXLWeyfmS/CGRfwl82Ue6lVm2L0Ebquf1h3K1YdXhfNiaL4TKKa/ZrCX+1eA==",
       "requires": {
         "@ipld/dag-cbor": "^6.0.0",
         "@ipld/dag-pb": "^2.0.2",
@@ -17545,16 +17627,16 @@
       },
       "dependencies": {
         "multiformats": {
-          "version": "9.1.0",
-          "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-9.1.0.tgz",
-          "integrity": "sha512-NhIM1NI9O2BSgWQWRsf8qEkRjKgNwEtwPb+gJKNMZW4xM/l1HbRktjXJvcG936QL/hrUh54T959JuLMF65Cbhw=="
+          "version": "9.1.1",
+          "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-9.1.1.tgz",
+          "integrity": "sha512-JkIoxg+QIZwkGxuPFEo5QlI5c8T4aEIgJ6pxiiOvSkjekc4JUGxb6oS1uHzjEQQdmDvBmJJF80Za5cSGtJl5Ng=="
         }
       }
     },
     "@vascosantos/ipfs-unixfs-importer": {
-      "version": "9.0.3",
-      "resolved": "https://registry.npmjs.org/@vascosantos/ipfs-unixfs-importer/-/ipfs-unixfs-importer-9.0.3.tgz",
-      "integrity": "sha512-kVcp+yZavn5Tn5EL7RHH51kSoO+gx1Yz22NtzmPFVNRx/cZ039VNZFI5XHkFT4FkFiskLv97nEzM/rOyug0wRw==",
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@vascosantos/ipfs-unixfs-importer/-/ipfs-unixfs-importer-10.0.0.tgz",
+      "integrity": "sha512-rtvX3GkdWp74tmT8anPiYQgM3GtqmEQPHn+9IdZTl7KcjpjlmpwwBvM21Vqv0Oby2CjYAtQqSq9Az0dmABRqSA==",
       "requires": {
         "@ipld/dag-pb": "^2.1.1",
         "bl": "^5.0.0",
@@ -17574,9 +17656,9 @@
       },
       "dependencies": {
         "multiformats": {
-          "version": "9.1.0",
-          "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-9.1.0.tgz",
-          "integrity": "sha512-NhIM1NI9O2BSgWQWRsf8qEkRjKgNwEtwPb+gJKNMZW4xM/l1HbRktjXJvcG936QL/hrUh54T959JuLMF65Cbhw=="
+          "version": "9.1.1",
+          "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-9.1.1.tgz",
+          "integrity": "sha512-JkIoxg+QIZwkGxuPFEo5QlI5c8T4aEIgJ6pxiiOvSkjekc4JUGxb6oS1uHzjEQQdmDvBmJJF80Za5cSGtJl5Ng=="
         }
       }
     },
@@ -17597,6 +17679,14 @@
         "@web-std/blob": "^2.1.0",
         "data-uri-to-buffer": "^3.0.1",
         "web-streams-polyfill": "^3.0.2"
+      }
+    },
+    "@web-std/file": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@web-std/file/-/file-1.1.0.tgz",
+      "integrity": "sha512-VyKHE0eN713xBoRe7wrUjamct1KoALrkxCPEHiAusdBvOw7bSu4nmP+1i7b8L0cBUDawUEQyT7+7kPIykUla6A==",
+      "requires": {
+        "@web-std/blob": "^2.1.0"
       }
     },
     "@zxing/text-encoding": {
@@ -18424,6 +18514,24 @@
       "peer": true,
       "requires": {
         "rsvp": "^4.8.4"
+      }
+    },
+    "carbites": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/carbites/-/carbites-1.0.6.tgz",
+      "integrity": "sha512-dS9IQvnrb5VIRvSTNz5Ff+mB9d2MFfi5mojtJi7Rlss79VeF190jr0sZdA7eW0CGHotvHkZaWuM6wgfD9PEFRg==",
+      "requires": {
+        "@ipld/car": "^3.0.1",
+        "@ipld/dag-cbor": "^6.0.3",
+        "@ipld/dag-pb": "^2.0.2",
+        "multiformats": "^9.0.4"
+      },
+      "dependencies": {
+        "multiformats": {
+          "version": "9.1.1",
+          "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-9.1.1.tgz",
+          "integrity": "sha512-JkIoxg+QIZwkGxuPFEo5QlI5c8T4aEIgJ6pxiiOvSkjekc4JUGxb6oS1uHzjEQQdmDvBmJJF80Za5cSGtJl5Ng=="
+        }
       }
     },
     "cborg": {
@@ -20389,6 +20497,11 @@
         "safer-buffer": ">= 2.1.2 < 3.0.0"
       }
     },
+    "idb-keyval": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/idb-keyval/-/idb-keyval-5.0.6.tgz",
+      "integrity": "sha512-6lJuVbwyo82mKSH6Wq2eHkt9LcbwHAelMIcMe0tP4p20Pod7tTxq9zf0ge2n/YDfMOpDryerfmmYyuQiaFaKOg=="
+    },
     "ieee754": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
@@ -20519,15 +20632,16 @@
       "dev": true
     },
     "ipfs-car": {
-      "version": "0.3.5",
-      "resolved": "https://registry.npmjs.org/ipfs-car/-/ipfs-car-0.3.5.tgz",
-      "integrity": "sha512-tlg7T+Bhh4o4e61Z1zj2EpQ0fMNj7+qiR44+46Hpl4pMAls9hm2PZLvUW5UzaN8txK5OW/BYQ4BQ0S9UHsTcSw==",
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/ipfs-car/-/ipfs-car-0.4.1.tgz",
+      "integrity": "sha512-K3fHUFlRJkdNFW1pGrEHcOE9nbEIJPQjlLe9unScZ7L01CxCngpPcwYMK0aIX1w1d1y4Oo64V1YHChD05K/I2g==",
       "requires": {
         "@ipld/car": "^3.0.3",
-        "@vascosantos/ipfs-unixfs-exporter": "^7.0.0",
-        "@vascosantos/ipfs-unixfs-importer": "^9.0.0",
+        "@vascosantos/ipfs-unixfs-exporter": "^8.0.0",
+        "@vascosantos/ipfs-unixfs-importer": "^10.0.0",
         "@web-std/blob": "^2.1.1",
         "bl": "^5.0.0",
+        "idb-keyval": "^5.0.6",
         "ipfs-core-types": "^0.5.0",
         "ipfs-core-utils": "^0.8.0",
         "ipfs-utils": "^8.0.0",
@@ -20546,6 +20660,11 @@
           "version": "9.1.0",
           "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-9.1.0.tgz",
           "integrity": "sha512-NhIM1NI9O2BSgWQWRsf8qEkRjKgNwEtwPb+gJKNMZW4xM/l1HbRktjXJvcG936QL/hrUh54T959JuLMF65Cbhw=="
+        },
+        "streaming-iterables": {
+          "version": "5.0.4",
+          "resolved": "https://registry.npmjs.org/streaming-iterables/-/streaming-iterables-5.0.4.tgz",
+          "integrity": "sha512-nEs6hBGIPsVz6uq6pscGGKfoPDQWrDQW0b0UHurtSDysekfKLmkPg7FQVRE2sj3Rad6yUo9E1sGTxOWyYsHQ/g=="
         }
       }
     },
@@ -23580,6 +23699,22 @@
         "aggregate-error": "^3.0.0"
       }
     },
+    "p-retry": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-4.6.0.tgz",
+      "integrity": "sha512-SAHbQEwg3X5DRNaLmWjT+DlGc93ba5i+aP3QLfVNDncQEQO4xjbYW4N/lcVTSuP0aJietGfx2t94dJLzfBMpXw==",
+      "requires": {
+        "@types/retry": "^0.12.0",
+        "retry": "^0.13.1"
+      },
+      "dependencies": {
+        "retry": {
+          "version": "0.13.1",
+          "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
+          "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg=="
+        }
+      }
+    },
     "p-timeout": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-3.2.0.tgz",
@@ -25754,9 +25889,9 @@
       }
     },
     "streaming-iterables": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/streaming-iterables/-/streaming-iterables-5.0.4.tgz",
-      "integrity": "sha512-nEs6hBGIPsVz6uq6pscGGKfoPDQWrDQW0b0UHurtSDysekfKLmkPg7FQVRE2sj3Rad6yUo9E1sGTxOWyYsHQ/g=="
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/streaming-iterables/-/streaming-iterables-6.0.0.tgz",
+      "integrity": "sha512-GYbJh0ife8PvryWSyFifY1m1uj6zO12d9duuP6xltiOolUz44eKasp5gbFhRbFbLy50ik6hcKn4Pbxl9AkxB+Q=="
     },
     "streamsearch": {
       "version": "0.1.2",
@@ -26595,6 +26730,15 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.0.3.tgz",
       "integrity": "sha512-d2H/t0eqRNM4w2WvmTdoeIvzAUSpK7JmATB8Nr2lb7nQ9BTIJVjbQ/TRFVEh2gUH1HwclPdoPtfMoFfetXaZnA=="
+    },
+    "web3-file": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/web3-file/-/web3-file-0.2.0.tgz",
+      "integrity": "sha512-O3t4B44dXZbL+9eGbkyn8k9upUCE7ICuzvjDSPuCYdec4r7Ds6IrzhMm72YbuOGYzHYsnfLIhAZzuXKCSdfk8w==",
+      "requires": {
+        "@web-std/blob": "2.1.1",
+        "browser-readablestream-to-it": "^1.0.2"
+      }
     },
     "whatwg-fetch": {
       "version": "3.6.2",

--- a/packages/client/package-lock.json
+++ b/packages/client/package-lock.json
@@ -25,6 +25,7 @@
         "@rollup/plugin-node-resolve": "^13.0.0",
         "@types/mocha": "8.2.2",
         "bundlesize": "^0.18.1",
+        "del-cli": "^4.0.0",
         "hundreds": "0.0.9",
         "mocha": "8.3.2",
         "multiformats": "^7.0.0",
@@ -5264,6 +5265,184 @@
         "rimraf": "^3.0.2",
         "slash": "^3.0.0"
       },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/del-cli": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/del-cli/-/del-cli-4.0.0.tgz",
+      "integrity": "sha512-G6FD38YZ28nkI34J+oxiYGbJg/t2hCkUgg9di9311gHZWWe9hY4CphewtU5l3RO1LTYxNMxla2D/we4CbBMHcA==",
+      "dev": true,
+      "dependencies": {
+        "del": "^6.0.0",
+        "meow": "^10.0.1"
+      },
+      "bin": {
+        "del": "cli.js",
+        "del-cli": "cli.js"
+      },
+      "engines": {
+        "node": ">=12.20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/del-cli/node_modules/decamelize": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-5.0.0.tgz",
+      "integrity": "sha512-U75DcT5hrio3KNtvdULAWnLiAPbFUC4191ldxMmj4FA/mRuBnmDwU0boNfPyFRhnan+Jm+haLeSn3P0afcBn4w==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/del-cli/node_modules/indent-string": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-5.0.0.tgz",
+      "integrity": "sha512-m6FAo/spmsW2Ab2fU35JTYwtOKa2yAwXSwgjSv1TJzh4Mh7mC3lzAOVLBprb72XsTrgkEIsl7YrFNAiDiRhIGg==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/del-cli/node_modules/meow": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/meow/-/meow-10.0.1.tgz",
+      "integrity": "sha512-65vCCdUI8wS5upK24fDFo25FcViNExdTGAR/vaWN4E6fXsWQ8fGdbkjCWp3nDTuJMlIYuEoAEMiB2/b81DBJjg==",
+      "dev": true,
+      "dependencies": {
+        "@types/minimist": "^1.2.1",
+        "camelcase-keys": "^6.2.2",
+        "decamelize": "^5.0.0",
+        "decamelize-keys": "^1.1.0",
+        "hard-rejection": "^2.1.0",
+        "minimist-options": "4.1.0",
+        "normalize-package-data": "^3.0.2",
+        "read-pkg-up": "^8.0.0",
+        "redent": "^4.0.0",
+        "trim-newlines": "^4.0.1",
+        "type-fest": "^1.0.2",
+        "yargs-parser": "^20.2.7"
+      },
+      "engines": {
+        "node": ">=12.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/del-cli/node_modules/parse-json": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
+      "integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
+      "dev": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.0.0",
+        "error-ex": "^1.3.1",
+        "json-parse-even-better-errors": "^2.3.0",
+        "lines-and-columns": "^1.1.6"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/del-cli/node_modules/read-pkg": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-6.0.0.tgz",
+      "integrity": "sha512-X1Fu3dPuk/8ZLsMhEj5f4wFAF0DWoK7qhGJvgaijocXxBmSToKfbFtqbxMO7bVjNA1dmE5huAzjXj/ey86iw9Q==",
+      "dev": true,
+      "dependencies": {
+        "@types/normalize-package-data": "^2.4.0",
+        "normalize-package-data": "^3.0.2",
+        "parse-json": "^5.2.0",
+        "type-fest": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/del-cli/node_modules/read-pkg-up": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-8.0.0.tgz",
+      "integrity": "sha512-snVCqPczksT0HS2EC+SxUndvSzn6LRCwpfSvLrIfR5BKDQQZMaI6jPRC9dYvYFDRAuFEAnkwww8kBBNE/3VvzQ==",
+      "dev": true,
+      "dependencies": {
+        "find-up": "^5.0.0",
+        "read-pkg": "^6.0.0",
+        "type-fest": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/del-cli/node_modules/redent": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/redent/-/redent-4.0.0.tgz",
+      "integrity": "sha512-tYkDkVVtYkSVhuQ4zBgfvciymHaeuel+zFKXShfDnFP5SyVEP7qo70Rf1jTOTCx3vGNAbnEi/xFkcfQVMIBWag==",
+      "dev": true,
+      "dependencies": {
+        "indent-string": "^5.0.0",
+        "strip-indent": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/del-cli/node_modules/strip-indent": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-4.0.0.tgz",
+      "integrity": "sha512-mnVSV2l+Zv6BLpSD/8V87CW/y9EmmbYzGCIavsnsI6/nwn26DwffM/yztm30Z/I2DY9wdS3vXVCMnHDgZaVNoA==",
+      "dev": true,
+      "dependencies": {
+        "min-indent": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/del-cli/node_modules/trim-newlines": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-4.0.2.tgz",
+      "integrity": "sha512-GJtWyq9InR/2HRiLZgpIKv+ufIKrVrvjQWEj7PxAXNc5dwbNJkqhAUoAGgzRmULAnoOM5EIpveYd3J2VeSAIew==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/del-cli/node_modules/type-fest": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-1.2.1.tgz",
+      "integrity": "sha512-SbmIRuXhJs8KTneu77Ecylt9zuqL683tuiLYpTRil4H++eIhqCmx6ko6KAFem9dty8sOdnEiX7j4K1nRE628fQ==",
+      "dev": true,
       "engines": {
         "node": ">=10"
       },
@@ -19219,6 +19398,116 @@
           "requires": {
             "aggregate-error": "^3.0.0"
           }
+        }
+      }
+    },
+    "del-cli": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/del-cli/-/del-cli-4.0.0.tgz",
+      "integrity": "sha512-G6FD38YZ28nkI34J+oxiYGbJg/t2hCkUgg9di9311gHZWWe9hY4CphewtU5l3RO1LTYxNMxla2D/we4CbBMHcA==",
+      "dev": true,
+      "requires": {
+        "del": "^6.0.0",
+        "meow": "^10.0.1"
+      },
+      "dependencies": {
+        "decamelize": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-5.0.0.tgz",
+          "integrity": "sha512-U75DcT5hrio3KNtvdULAWnLiAPbFUC4191ldxMmj4FA/mRuBnmDwU0boNfPyFRhnan+Jm+haLeSn3P0afcBn4w==",
+          "dev": true
+        },
+        "indent-string": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-5.0.0.tgz",
+          "integrity": "sha512-m6FAo/spmsW2Ab2fU35JTYwtOKa2yAwXSwgjSv1TJzh4Mh7mC3lzAOVLBprb72XsTrgkEIsl7YrFNAiDiRhIGg==",
+          "dev": true
+        },
+        "meow": {
+          "version": "10.0.1",
+          "resolved": "https://registry.npmjs.org/meow/-/meow-10.0.1.tgz",
+          "integrity": "sha512-65vCCdUI8wS5upK24fDFo25FcViNExdTGAR/vaWN4E6fXsWQ8fGdbkjCWp3nDTuJMlIYuEoAEMiB2/b81DBJjg==",
+          "dev": true,
+          "requires": {
+            "@types/minimist": "^1.2.1",
+            "camelcase-keys": "^6.2.2",
+            "decamelize": "^5.0.0",
+            "decamelize-keys": "^1.1.0",
+            "hard-rejection": "^2.1.0",
+            "minimist-options": "4.1.0",
+            "normalize-package-data": "^3.0.2",
+            "read-pkg-up": "^8.0.0",
+            "redent": "^4.0.0",
+            "trim-newlines": "^4.0.1",
+            "type-fest": "^1.0.2",
+            "yargs-parser": "^20.2.7"
+          }
+        },
+        "parse-json": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
+          "integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
+          "dev": true,
+          "requires": {
+            "@babel/code-frame": "^7.0.0",
+            "error-ex": "^1.3.1",
+            "json-parse-even-better-errors": "^2.3.0",
+            "lines-and-columns": "^1.1.6"
+          }
+        },
+        "read-pkg": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-6.0.0.tgz",
+          "integrity": "sha512-X1Fu3dPuk/8ZLsMhEj5f4wFAF0DWoK7qhGJvgaijocXxBmSToKfbFtqbxMO7bVjNA1dmE5huAzjXj/ey86iw9Q==",
+          "dev": true,
+          "requires": {
+            "@types/normalize-package-data": "^2.4.0",
+            "normalize-package-data": "^3.0.2",
+            "parse-json": "^5.2.0",
+            "type-fest": "^1.0.1"
+          }
+        },
+        "read-pkg-up": {
+          "version": "8.0.0",
+          "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-8.0.0.tgz",
+          "integrity": "sha512-snVCqPczksT0HS2EC+SxUndvSzn6LRCwpfSvLrIfR5BKDQQZMaI6jPRC9dYvYFDRAuFEAnkwww8kBBNE/3VvzQ==",
+          "dev": true,
+          "requires": {
+            "find-up": "^5.0.0",
+            "read-pkg": "^6.0.0",
+            "type-fest": "^1.0.1"
+          }
+        },
+        "redent": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/redent/-/redent-4.0.0.tgz",
+          "integrity": "sha512-tYkDkVVtYkSVhuQ4zBgfvciymHaeuel+zFKXShfDnFP5SyVEP7qo70Rf1jTOTCx3vGNAbnEi/xFkcfQVMIBWag==",
+          "dev": true,
+          "requires": {
+            "indent-string": "^5.0.0",
+            "strip-indent": "^4.0.0"
+          }
+        },
+        "strip-indent": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-4.0.0.tgz",
+          "integrity": "sha512-mnVSV2l+Zv6BLpSD/8V87CW/y9EmmbYzGCIavsnsI6/nwn26DwffM/yztm30Z/I2DY9wdS3vXVCMnHDgZaVNoA==",
+          "dev": true,
+          "requires": {
+            "min-indent": "^1.0.1"
+          }
+        },
+        "trim-newlines": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-4.0.2.tgz",
+          "integrity": "sha512-GJtWyq9InR/2HRiLZgpIKv+ufIKrVrvjQWEj7PxAXNc5dwbNJkqhAUoAGgzRmULAnoOM5EIpveYd3J2VeSAIew==",
+          "dev": true
+        },
+        "type-fest": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-1.2.1.tgz",
+          "integrity": "sha512-SbmIRuXhJs8KTneu77Ecylt9zuqL683tuiLYpTRil4H++eIhqCmx6ko6KAFem9dty8sOdnEiX7j4K1nRE628fQ==",
+          "dev": true
         }
       }
     },

--- a/packages/client/package-lock.json
+++ b/packages/client/package-lock.json
@@ -17,8 +17,7 @@
         "carbites": "^1.0.6",
         "ipfs-car": "^0.4.1",
         "p-retry": "^4.5.0",
-        "streaming-iterables": "^6.0.0",
-        "web3-file": "^0.2.0"
+        "streaming-iterables": "^6.0.0"
       },
       "devDependencies": {
         "@rollup/plugin-commonjs": "^19.0.0",
@@ -28,7 +27,7 @@
         "del-cli": "^4.0.0",
         "hundreds": "0.0.9",
         "mocha": "8.3.2",
-        "multiformats": "^7.0.0",
+        "multiformats": "^9.1.1",
         "npm-run-all": "^4.1.5",
         "nyc": "15.1.0",
         "playwright-test": "^4.1.0",
@@ -2045,11 +2044,6 @@
         "varint": "^6.0.0"
       }
     },
-    "node_modules/@ipld/car/node_modules/multiformats": {
-      "version": "9.1.0",
-      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-9.1.0.tgz",
-      "integrity": "sha512-NhIM1NI9O2BSgWQWRsf8qEkRjKgNwEtwPb+gJKNMZW4xM/l1HbRktjXJvcG936QL/hrUh54T959JuLMF65Cbhw=="
-    },
     "node_modules/@ipld/dag-cbor": {
       "version": "6.0.4",
       "resolved": "https://registry.npmjs.org/@ipld/dag-cbor/-/dag-cbor-6.0.4.tgz",
@@ -2059,11 +2053,6 @@
         "multiformats": "^9.0.0"
       }
     },
-    "node_modules/@ipld/dag-cbor/node_modules/multiformats": {
-      "version": "9.1.0",
-      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-9.1.0.tgz",
-      "integrity": "sha512-NhIM1NI9O2BSgWQWRsf8qEkRjKgNwEtwPb+gJKNMZW4xM/l1HbRktjXJvcG936QL/hrUh54T959JuLMF65Cbhw=="
-    },
     "node_modules/@ipld/dag-pb": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/@ipld/dag-pb/-/dag-pb-2.1.1.tgz",
@@ -2071,11 +2060,6 @@
       "dependencies": {
         "multiformats": "^9.0.0"
       }
-    },
-    "node_modules/@ipld/dag-pb/node_modules/multiformats": {
-      "version": "9.1.0",
-      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-9.1.0.tgz",
-      "integrity": "sha512-NhIM1NI9O2BSgWQWRsf8qEkRjKgNwEtwPb+gJKNMZW4xM/l1HbRktjXJvcG936QL/hrUh54T959JuLMF65Cbhw=="
     },
     "node_modules/@istanbuljs/load-nyc-config": {
       "version": "1.1.0",
@@ -3311,11 +3295,6 @@
         "npm": ">=7.0.0"
       }
     },
-    "node_modules/@vascosantos/ipfs-unixfs-exporter/node_modules/multiformats": {
-      "version": "9.1.1",
-      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-9.1.1.tgz",
-      "integrity": "sha512-JkIoxg+QIZwkGxuPFEo5QlI5c8T4aEIgJ6pxiiOvSkjekc4JUGxb6oS1uHzjEQQdmDvBmJJF80Za5cSGtJl5Ng=="
-    },
     "node_modules/@vascosantos/ipfs-unixfs-importer": {
       "version": "10.0.0",
       "resolved": "https://registry.npmjs.org/@vascosantos/ipfs-unixfs-importer/-/ipfs-unixfs-importer-10.0.0.tgz",
@@ -3341,11 +3320,6 @@
         "node": ">=14.0.0",
         "npm": ">=7.0.0"
       }
-    },
-    "node_modules/@vascosantos/ipfs-unixfs-importer/node_modules/multiformats": {
-      "version": "9.1.1",
-      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-9.1.1.tgz",
-      "integrity": "sha512-JkIoxg+QIZwkGxuPFEo5QlI5c8T4aEIgJ6pxiiOvSkjekc4JUGxb6oS1uHzjEQQdmDvBmJJF80Za5cSGtJl5Ng=="
     },
     "node_modules/@web-std/blob": {
       "version": "2.1.1",
@@ -4427,11 +4401,6 @@
         "@ipld/dag-pb": "^2.0.2",
         "multiformats": "^9.0.4"
       }
-    },
-    "node_modules/carbites/node_modules/multiformats": {
-      "version": "9.1.1",
-      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-9.1.1.tgz",
-      "integrity": "sha512-JkIoxg+QIZwkGxuPFEo5QlI5c8T4aEIgJ6pxiiOvSkjekc4JUGxb6oS1uHzjEQQdmDvBmJJF80Za5cSGtJl5Ng=="
     },
     "node_modules/cborg": {
       "version": "1.3.4",
@@ -7310,11 +7279,6 @@
         "ipfs-car": "dist/cjs/cli/cli.js"
       }
     },
-    "node_modules/ipfs-car/node_modules/multiformats": {
-      "version": "9.1.0",
-      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-9.1.0.tgz",
-      "integrity": "sha512-NhIM1NI9O2BSgWQWRsf8qEkRjKgNwEtwPb+gJKNMZW4xM/l1HbRktjXJvcG936QL/hrUh54T959JuLMF65Cbhw=="
-    },
     "node_modules/ipfs-car/node_modules/streaming-iterables": {
       "version": "5.0.4",
       "resolved": "https://registry.npmjs.org/streaming-iterables/-/streaming-iterables-5.0.4.tgz",
@@ -10069,14 +10033,9 @@
       }
     },
     "node_modules/multiformats": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-7.0.0.tgz",
-      "integrity": "sha512-B39Rk603Ri8AKHCVhRGwZk+MfxqcxsDxgvja801cMoPJRk4BvS6kxDr5C0331JvnQDK4phJBfMQjcTlwfOAImw==",
-      "dev": true,
-      "dependencies": {
-        "buffer": "^6.0.3",
-        "cids": "^1.1.6"
-      }
+      "version": "9.1.1",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-9.1.1.tgz",
+      "integrity": "sha512-JkIoxg+QIZwkGxuPFEo5QlI5c8T4aEIgJ6pxiiOvSkjekc4JUGxb6oS1uHzjEQQdmDvBmJJF80Za5cSGtJl5Ng=="
     },
     "node_modules/multihashes": {
       "version": "4.0.2",
@@ -14955,15 +14914,6 @@
         "node": ">= 8"
       }
     },
-    "node_modules/web3-file": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/web3-file/-/web3-file-0.2.0.tgz",
-      "integrity": "sha512-O3t4B44dXZbL+9eGbkyn8k9upUCE7ICuzvjDSPuCYdec4r7Ds6IrzhMm72YbuOGYzHYsnfLIhAZzuXKCSdfk8w==",
-      "dependencies": {
-        "@web-std/blob": "2.1.1",
-        "browser-readablestream-to-it": "^1.0.2"
-      }
-    },
     "node_modules/whatwg-fetch": {
       "version": "3.6.2",
       "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.6.2.tgz",
@@ -16715,13 +16665,6 @@
         "@types/varint": "^6.0.0",
         "multiformats": "^9.0.0",
         "varint": "^6.0.0"
-      },
-      "dependencies": {
-        "multiformats": {
-          "version": "9.1.0",
-          "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-9.1.0.tgz",
-          "integrity": "sha512-NhIM1NI9O2BSgWQWRsf8qEkRjKgNwEtwPb+gJKNMZW4xM/l1HbRktjXJvcG936QL/hrUh54T959JuLMF65Cbhw=="
-        }
       }
     },
     "@ipld/dag-cbor": {
@@ -16731,13 +16674,6 @@
       "requires": {
         "cborg": "^1.2.1",
         "multiformats": "^9.0.0"
-      },
-      "dependencies": {
-        "multiformats": {
-          "version": "9.1.0",
-          "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-9.1.0.tgz",
-          "integrity": "sha512-NhIM1NI9O2BSgWQWRsf8qEkRjKgNwEtwPb+gJKNMZW4xM/l1HbRktjXJvcG936QL/hrUh54T959JuLMF65Cbhw=="
-        }
       }
     },
     "@ipld/dag-pb": {
@@ -16746,13 +16682,6 @@
       "integrity": "sha512-bB7HxHlyKtLRbZVJQxdi+CakXFfQKogINzUxvhfGURUpZLvwTq3x8jwHT1UvPWuO0SHgMBQN5mIBeOUnes3MHg==",
       "requires": {
         "multiformats": "^9.0.0"
-      },
-      "dependencies": {
-        "multiformats": {
-          "version": "9.1.0",
-          "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-9.1.0.tgz",
-          "integrity": "sha512-NhIM1NI9O2BSgWQWRsf8qEkRjKgNwEtwPb+gJKNMZW4xM/l1HbRktjXJvcG936QL/hrUh54T959JuLMF65Cbhw=="
-        }
       }
     },
     "@istanbuljs/load-nyc-config": {
@@ -17803,13 +17732,6 @@
         "multicodec": "^3.0.1",
         "multiformats": "^9.0.4",
         "multihashing-async": "^2.1.0"
-      },
-      "dependencies": {
-        "multiformats": {
-          "version": "9.1.1",
-          "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-9.1.1.tgz",
-          "integrity": "sha512-JkIoxg+QIZwkGxuPFEo5QlI5c8T4aEIgJ6pxiiOvSkjekc4JUGxb6oS1uHzjEQQdmDvBmJJF80Za5cSGtJl5Ng=="
-        }
       }
     },
     "@vascosantos/ipfs-unixfs-importer": {
@@ -17832,13 +17754,6 @@
         "multihashing-async": "^2.1.0",
         "rabin-wasm": "^0.1.4",
         "uint8arrays": "^2.1.5"
-      },
-      "dependencies": {
-        "multiformats": {
-          "version": "9.1.1",
-          "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-9.1.1.tgz",
-          "integrity": "sha512-JkIoxg+QIZwkGxuPFEo5QlI5c8T4aEIgJ6pxiiOvSkjekc4JUGxb6oS1uHzjEQQdmDvBmJJF80Za5cSGtJl5Ng=="
-        }
       }
     },
     "@web-std/blob": {
@@ -18704,13 +18619,6 @@
         "@ipld/dag-cbor": "^6.0.3",
         "@ipld/dag-pb": "^2.0.2",
         "multiformats": "^9.0.4"
-      },
-      "dependencies": {
-        "multiformats": {
-          "version": "9.1.1",
-          "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-9.1.1.tgz",
-          "integrity": "sha512-JkIoxg+QIZwkGxuPFEo5QlI5c8T4aEIgJ6pxiiOvSkjekc4JUGxb6oS1uHzjEQQdmDvBmJJF80Za5cSGtJl5Ng=="
-        }
       }
     },
     "cborg": {
@@ -20945,11 +20853,6 @@
         "uint8arrays": "^2.1.5"
       },
       "dependencies": {
-        "multiformats": {
-          "version": "9.1.0",
-          "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-9.1.0.tgz",
-          "integrity": "sha512-NhIM1NI9O2BSgWQWRsf8qEkRjKgNwEtwPb+gJKNMZW4xM/l1HbRktjXJvcG936QL/hrUh54T959JuLMF65Cbhw=="
-        },
         "streaming-iterables": {
           "version": "5.0.4",
           "resolved": "https://registry.npmjs.org/streaming-iterables/-/streaming-iterables-5.0.4.tgz",
@@ -23160,14 +23063,9 @@
       }
     },
     "multiformats": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-7.0.0.tgz",
-      "integrity": "sha512-B39Rk603Ri8AKHCVhRGwZk+MfxqcxsDxgvja801cMoPJRk4BvS6kxDr5C0331JvnQDK4phJBfMQjcTlwfOAImw==",
-      "dev": true,
-      "requires": {
-        "buffer": "^6.0.3",
-        "cids": "^1.1.6"
-      }
+      "version": "9.1.1",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-9.1.1.tgz",
+      "integrity": "sha512-JkIoxg+QIZwkGxuPFEo5QlI5c8T4aEIgJ6pxiiOvSkjekc4JUGxb6oS1uHzjEQQdmDvBmJJF80Za5cSGtJl5Ng=="
     },
     "multihashes": {
       "version": "4.0.2",
@@ -27019,15 +26917,6 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.0.3.tgz",
       "integrity": "sha512-d2H/t0eqRNM4w2WvmTdoeIvzAUSpK7JmATB8Nr2lb7nQ9BTIJVjbQ/TRFVEh2gUH1HwclPdoPtfMoFfetXaZnA=="
-    },
-    "web3-file": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/web3-file/-/web3-file-0.2.0.tgz",
-      "integrity": "sha512-O3t4B44dXZbL+9eGbkyn8k9upUCE7ICuzvjDSPuCYdec4r7Ds6IrzhMm72YbuOGYzHYsnfLIhAZzuXKCSdfk8w==",
-      "requires": {
-        "@web-std/blob": "2.1.1",
-        "browser-readablestream-to-it": "^1.0.2"
-      }
     },
     "whatwg-fetch": {
       "version": "3.6.2",

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -20,13 +20,14 @@
     "test:cjs": "API_PORT=1337 mocha dist/test/*.spec.cjs --exit",
     "test:esm": "API_PORT=1337 hundreds mocha test/*.spec.js --exit",
     "mock:api": "smoke -p 1337 --hooks test/mocks/hooks.js test/mocks/api",
-    "build": "run-p build:*",
+    "build": "run-s clean build:*",
     "build:cjs": "rollup --config --silent rollup.config.js",
     "build:esm": "rollup --config rollup.esm.config.js",
     "build:tsc": "tsc --build",
     "coverage": "nyc report --reporter=text-lcov > coverage.lcov && npx codecov",
     "typedoc": "typedoc --entryPoints src  --out ../../docs/client",
-    "prepare": "npm run build"
+    "prepare": "npm run build",
+    "clean": "del dist"
   },
   "dependencies": {
     "@ipld/car": "^3.1.2",
@@ -45,6 +46,7 @@
     "@rollup/plugin-node-resolve": "^13.0.0",
     "@types/mocha": "8.2.2",
     "bundlesize": "^0.18.1",
+    "del-cli": "^4.0.0",
     "hundreds": "0.0.9",
     "mocha": "8.3.2",
     "multiformats": "^7.0.0",

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -48,7 +48,7 @@
     "del-cli": "^4.0.0",
     "hundreds": "0.0.9",
     "mocha": "8.3.2",
-    "multiformats": "^7.0.0",
+    "multiformats": "^9.1.1",
     "npm-run-all": "^4.1.5",
     "nyc": "15.1.0",
     "playwright-test": "^4.1.0",

--- a/packages/client/src/lib.js
+++ b/packages/client/src/lib.js
@@ -214,7 +214,7 @@ class Web3Storage {
  * @param {import('./lib/interface.js').UnixFSEntry} entry
  * @returns {Promise<import('./lib/interface.js').Web3File>}
  */
- async function toWeb3File({content, path, cid}) {
+async function toWeb3File({content, path, cid}) {
   const chunks = []
   for await (const chunk of content()) {
     chunks.push(chunk)

--- a/packages/client/src/lib.js
+++ b/packages/client/src/lib.js
@@ -207,29 +207,6 @@ class Web3Storage {
 }
 
 /**
- * map a UnixFSEntry to a ~Blob~ File with benefits
- * @param {import('./lib/interface.js').UnixFSEntry} e
- * @returns {Promise<import('./lib/interface.js').IpfsFile>}
- */
-async function toIpfsFile(e) {
-  const chunks = []
-  for await (const chunk of e.content()) {
-    chunks.push(chunk)
-  }
-
-  // A Blob in File clothing
-  const file = Object.assign(new Blob(chunks), {
-    cid: e.cid.toString(),
-    name: e.name,
-    relativePath: e.path,
-    webkitRelativePath: e.path,
-    // TODO: mtime may be available on UnixFSEntry... need to investigate ts weirdness.
-    lastModified: Date.now(),
-  })
-  return file
-}
-
-/**
  * Add car unpacking smarts to the response object,
  * @param {Response} res
  * @returns {import('./lib/interface.js').CarResponse}
@@ -254,7 +231,9 @@ function toCarResponse(res) {
         if (entry.type === 'directory') {
           continue
         }
-        const file = await toIpfsFile(entry)
+        const file = new Web3File(entry.content(), entry.name, {
+          path: entry.path,
+        })
         files.push(file)
       }
       return files

--- a/packages/client/src/lib/interface.ts
+++ b/packages/client/src/lib/interface.ts
@@ -3,7 +3,6 @@ import type { CID } from 'multiformats'
 import type { Web3File } from 'web3-file'
 export type { CID, UnixFSEntry, Web3File }
 
-
 /**
  * Define nominal type of U based on type of T. Similar to Opaque types in Flow
  */
@@ -32,7 +31,7 @@ export interface API {
     files: Iterable<Web3File>,
     options?: PutOptions
   ): Promise<CIDString>
-    
+
   /**
    * Get files for a root CID packed as a CAR file
    */
@@ -45,10 +44,10 @@ export type PutOptions = {
 }
 
 export interface IpfsFile extends File {
-  cid: CIDString,  
+  cid: CIDString,
 }
 
 export interface CarResponse extends Response {
   unixFsIterator: () => AsyncIterable<UnixFSEntry>
-  files: () => Promise<Array<IpfsFile>>
+  files: () => Promise<Array<Web3File>>
 }

--- a/packages/client/src/lib/interface.ts
+++ b/packages/client/src/lib/interface.ts
@@ -47,8 +47,8 @@ export type PutOptions = {
   maxRetries?: number
 }
 
-export interface IpfsFile extends File {
-  cid: CIDString,
+export interface Web3File extends File {
+  cid: CID,
 }
 
 export interface CarResponse extends Response {

--- a/packages/client/test/get.spec.js
+++ b/packages/client/test/get.spec.js
@@ -26,16 +26,15 @@ describe('get', () => {
     assert.ok(res.ok)
     const files = await res.files()
     for (const file of files) {
-      // TODO: add support for cid on web3 file
-      // assert.is(
-      //   file.cid,
-      //   cid,
-      //   'in a CAR with 1 file, the file name should match the CAR root'
-      // )
       assert.is(
-        file.path,
+        file.cid.toString(),
         cid,
-        `webkitRelativePath (${file.webkitRelativePath}) should be (${cid})`
+        'in a CAR with 1 file, the file name should match the CAR root'
+      )
+      assert.is(
+        file.name,
+        cid,
+        `name (${file.name}) should be (${cid})`
       )
       assert.ok(file.lastModified)
       assert.is(await file.text(), 'hello world')

--- a/packages/client/test/get.spec.js
+++ b/packages/client/test/get.spec.js
@@ -26,13 +26,14 @@ describe('get', () => {
     assert.ok(res.ok)
     const files = await res.files()
     for (const file of files) {
+      // TODO: add support for cid on web3 file
+      // assert.is(
+      //   file.cid,
+      //   cid,
+      //   'in a CAR with 1 file, the file name should match the CAR root'
+      // )
       assert.is(
-        file.cid,
-        cid,
-        'in a CAR with 1 file, the file name should match the CAR root'
-      )
-      assert.is(
-        file.webkitRelativePath,
+        file.path,
         cid,
         `webkitRelativePath (${file.webkitRelativePath}) should be (${cid})`
       )

--- a/packages/client/test/get.spec.js
+++ b/packages/client/test/get.spec.js
@@ -49,6 +49,15 @@ describe('get', () => {
     assert.ok(res.ok)
     const files = await res.files()
     assert.is(files.length, 3, 'should contain 3 files')
+    assert.is(files[0].name, 'dr-is-tired.jpg')
+    assert.is(files[0].cid.toString(), 'bafkreiabltrd5zm73pvi7plq25pef3hm7jxhbi3kv4hapegrkfpkqtkbme')
+    assert.is(files[0].size, 94482)
+    assert.is(files[1].name, 'not-distributed.jpg')
+    assert.is(files[1].cid.toString(), 'bafybeicklkqcnlvtiscr2hzkubjwnwjinvskffn4xorqeduft3wq7vm5u4')
+    assert.is(files[1].size, 414201)
+    assert.is(files[2].name, 'youareanonsense.jpg')
+    assert.is(files[2].cid.toString(), 'bafkreiaqv66m5nd6mwgkk7h5lwqnjzj54s4f7knmnrjhb7ylzqfg2vdo54')
+    assert.is(files[2].size, 55415)
   })
 
   it('returns null on 404', async () => {


### PR DESCRIPTION
- Update client.get to use https://github.com/web3-storage/ipfs-car/pull/46
  - uses a blockstore during unpack so should be able to deal with cars larger than mem now.
  - ipfs-car adopts the ReadableStream vs AsyncIterator shim which is nice
- Adds `clean` target called before `build` to ensure we're fresh.

Needs https://github.com/web3-storage/web3-file/issues/7

Builds on #12 

License: (Apache-2.0 AND MIT)
Signed-off-by: Oli Evans <oli@tableflip.io>