### PR TITLE
chore: use filelike in put

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15318,15 +15318,6 @@
         "node": ">= 8"
       }
     },
-    "node_modules/web3-file": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/web3-file/-/web3-file-0.2.0.tgz",
-      "integrity": "sha512-O3t4B44dXZbL+9eGbkyn8k9upUCE7ICuzvjDSPuCYdec4r7Ds6IrzhMm72YbuOGYzHYsnfLIhAZzuXKCSdfk8w==",
-      "dependencies": {
-        "@web-std/blob": "2.1.1",
-        "browser-readablestream-to-it": "^1.0.2"
-      }
-    },
     "node_modules/web3.storage": {
       "resolved": "packages/client",
       "link": true
@@ -15962,8 +15953,7 @@
         "carbites": "^1.0.6",
         "ipfs-car": "^0.4.1",
         "p-retry": "^4.5.0",
-        "streaming-iterables": "^6.0.0",
-        "web3-file": "^0.2.0"
+        "streaming-iterables": "^6.0.0"
       },
       "devDependencies": {
         "@rollup/plugin-commonjs": "^19.0.0",
@@ -16039,6 +16029,17 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "packages/client/node_modules/strip-ansi": {
+      "version": "6.0.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "packages/client/node_modules/v8-to-istanbul": {
@@ -28091,15 +28092,6 @@
       "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.0.3.tgz",
       "integrity": "sha512-d2H/t0eqRNM4w2WvmTdoeIvzAUSpK7JmATB8Nr2lb7nQ9BTIJVjbQ/TRFVEh2gUH1HwclPdoPtfMoFfetXaZnA=="
     },
-    "web3-file": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/web3-file/-/web3-file-0.2.0.tgz",
-      "integrity": "sha512-O3t4B44dXZbL+9eGbkyn8k9upUCE7ICuzvjDSPuCYdec4r7Ds6IrzhMm72YbuOGYzHYsnfLIhAZzuXKCSdfk8w==",
-      "requires": {
-        "@web-std/blob": "2.1.1",
-        "browser-readablestream-to-it": "^1.0.2"
-      }
-    },
     "web3.storage": {
       "version": "file:packages/client",
       "requires": {
@@ -28127,8 +28119,7 @@
         "smoke": "^3.1.1",
         "streaming-iterables": "^6.0.0",
         "typedoc": "0.20.36",
-        "uvu": "0.5.1",
-        "web3-file": "^0.2.0"
+        "uvu": "0.5.1"
       },
       "dependencies": {
         "camelcase": {
@@ -28168,6 +28159,13 @@
         "source-map": {
           "version": "0.6.1",
           "dev": true
+        },
+        "strip-ansi": {
+          "version": "6.0.0",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^5.0.0"
+          }
         },
         "v8-to-istanbul": {
           "version": "7.1.2",

--- a/packages/client/examples/browser/main.js
+++ b/packages/client/examples/browser/main.js
@@ -1,4 +1,4 @@
-import { Web3Storage, Web3File } from 'web3.storage'
+import { Web3Storage } from 'web3.storage'
 
 const endpoint = 'https://api.web3.storage' // the default
 const token =
@@ -24,25 +24,21 @@ function prepareFiles () {
   const data2 = 'Hello web3.storage!!'
 
   return [
-    Web3File.fromText(
-      data,
-      'data.txt',
-      { path: '/dir/data.txt' }
+    new File(
+      [data],
+      '/dir/data.txt'
     ),
-    Web3File.fromText(
-      data2,
-      'data2.txt',
-      { path: '/dir/data2.txt' }
+    new File(
+      [data2],
+      '/dir/data2.txt'
     ),
-    Web3File.fromText(
-      data,
-      'data.txt',
-      { path: '/dir/otherdir/data.txt' }
+    new File(
+      [data],
+      '/dir/otherdir/data.txt'
     ),
-    Web3File.fromText(
-      data2,
-      'data2.txt',
-      { path: '/dir/otherdir/data2.txt' }
+    new File(
+      [data2],
+      '/dir/otherdir/data2.txt'
     )
   ]
 }

--- a/packages/client/examples/node.js/files.js
+++ b/packages/client/examples/node.js/files.js
@@ -1,4 +1,4 @@
-import { Web3Storage, Web3File } from '../../src/lib.js'
+import { Web3Storage } from '../../src/lib.js'
 
 // TODO
 const endpoint = 'https://api.web3.storage' // the default
@@ -19,25 +19,21 @@ function prepareFiles () {
   const data2 = 'Hello web3.storage!!'
 
   return [
-    Web3File.fromText(
-      data,
-      'data.txt',
-      { path: '/dir/data.txt' }
+    new File(
+      [data],
+      '/dir/data.txt'
     ),
-    Web3File.fromText(
-      data2,
-      'data2.txt',
-      { path: '/dir/data2.txt' }
+    new File(
+      [data2],
+      '/dir/data2.txt'
     ),
-    Web3File.fromText(
-      data,
-      'data.txt',
-      { path: '/dir/otherdir/data.txt' }
+    new File(
+      [data],
+      '/dir/otherdir/data.txt'
     ),
-    Web3File.fromText(
-      data2,
-      'data2.txt',
-      { path: '/dir/otherdir/data2.txt' }
+    new File(
+      [data2],
+      '/dir/otherdir/data2.txt'
     )
   ]
 }

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -37,8 +37,7 @@
     "carbites": "^1.0.6",
     "ipfs-car": "^0.4.1",
     "p-retry": "^4.5.0",
-    "streaming-iterables": "^6.0.0",
-    "web3-file": "^0.2.0"
+    "streaming-iterables": "^6.0.0"
   },
   "devDependencies": {
     "@rollup/plugin-commonjs": "^19.0.0",

--- a/packages/client/src/lib.js
+++ b/packages/client/src/lib.js
@@ -17,7 +17,6 @@ import { transform } from 'streaming-iterables'
 import pRetry from 'p-retry'
 import { pack } from 'ipfs-car/pack'
 import { TreewalkCarSplitter } from 'carbites/treewalk'
-import { Web3File } from 'web3-file'
 import * as API from './lib/interface.js'
 import {
   fetch,
@@ -88,7 +87,7 @@ class Web3Storage {
 
   /**
    * @param {API.Service} service
-   * @param {Iterable<API.Web3File>} files
+   * @param {Iterable<API.Filelike>} files
    * @param {API.PutOptions} [options]
    * @returns {Promise<API.CIDString>}
    */
@@ -102,7 +101,10 @@ class Web3Storage {
 
     try {
       const { out } = await pack({
-        input: files,
+        input: Array.from(files).map((f) => ({
+          path: f.name,
+          content: f.stream()
+        })),
         blockstore
       })
       const splitter = await TreewalkCarSplitter.fromIterable(out, targetSize)
@@ -192,7 +194,7 @@ class Web3Storage {
    * const cid = await client.store(car)
    * console.assert(cid === root)
    * ```
-   * @param {Iterable<API.Web3File>} files
+   * @param {Iterable<API.Filelike>} files
    * @param {API.PutOptions} [options]
    */
   put(files, options) {
@@ -281,7 +283,7 @@ function toCarResponse(res) {
   return response
 }
 
-export { Web3Storage, Blob, Web3File }
+export { Web3Storage, Blob }
 
 /**
  * Just to verify API compatibility.

--- a/packages/client/src/lib/interface.ts
+++ b/packages/client/src/lib/interface.ts
@@ -1,8 +1,6 @@
 import type { UnixFSEntry } from 'ipfs-car/unpack'
 import type { CID } from 'multiformats'
-import type { Web3File } from 'web3-file'
-export type { CID, UnixFSEntry, Web3File }
-
+export type { CID, UnixFSEntry }
 
 /**
  * Define nominal type of U based on type of T. Similar to Opaque types in Flow
@@ -29,7 +27,7 @@ export interface API {
    */
   put(
     service: Service,
-    files: Iterable<Web3File>,
+    files: Iterable<Filelike>,
     options?: PutOptions
   ): Promise<CIDString>
     
@@ -37,6 +35,11 @@ export interface API {
    * Get files for a root CID packed as a CAR file
    */
   get(service: Service, cid: CIDString): Promise<CarResponse | null>
+}
+
+export interface Filelike {
+  name: string,
+  stream: () => ReadableStream
 }
 
 export type PutOptions = {

--- a/packages/client/test/put.spec.js
+++ b/packages/client/test/put.spec.js
@@ -1,6 +1,7 @@
 import * as assert from 'uvu/assert'
 import randomBytes from 'randombytes'
-import { Web3Storage, Web3File } from 'web3.storage'
+import { Web3Storage } from 'web3.storage'
+import { File } from '../src/platform.js'
 
 describe('put', () => {
   const { AUTH_TOKEN, API_PORT } = process.env
@@ -32,9 +33,10 @@ describe('put', () => {
   it('erros with a File that will not be parsed by the Cluster', async function () {
     const client = new Web3Storage({ token, endpoint })
     try {
-      await client.put([Web3File.fromText('test-put-fail', 'file.txt')], { maxRetries: 1 })
+      await client.put([new File(['test-put-fail'], 'file.txt')], { maxRetries: 1 })
       assert.unreachable('should have thrown')
     } catch (err) {
+      console.log('err', err.message)
       assert.match(err.message, /Request body not a valid CAR file/)
     }
   })
@@ -52,7 +54,7 @@ describe('put', () => {
     let uploadedChunks = 0
 
     const files =[
-      Web3File.fromBytes(randomBytes(1024e6))
+      new File([randomBytes(1024e6)], '102mb.txt')
     ]
 
     await client.put(files, {
@@ -69,25 +71,21 @@ function prepareFiles () {
   const data2 = 'Hello web3.storage!!'
 
   return [
-    Web3File.fromText(
-      data,
-      'data.txt',
-      { path: '/dir/data.txt' }
+    new File(
+      [data],
+      '/dir/data.txt'
     ),
-    Web3File.fromText(
-      data2,
-      'data2.txt',
-      { path: '/dir/data2.txt' }
+    new File(
+      [data2],
+      '/dir/data2.txt'
     ),
-    Web3File.fromText(
-      data,
-      'data.txt',
-      { path: '/dir/otherdir/data.txt' }
+    new File(
+      [data],
+      '/dir/otherdir/data.txt'
     ),
-    Web3File.fromText(
-      data2,
-      'data2.txt',
-      { path: '/dir/otherdir/data2.txt' }
+    new File(
+      [data2],
+      '/dir/otherdir/data2.txt'
     )
   ]
 }


### PR DESCRIPTION
Uses filelike interface in put instead of Web3File, given we do not have cid reliability on it