### PR TITLE
chore: staging api config

### DIFF
--- a/.github/workflows/api.yml
+++ b/.github/workflows/api.yml
@@ -3,9 +3,15 @@ on:
   push:
     branches:
       - main
+    paths:
+      - 'packages/api/**'
+      - '.github/workflows/api.yml'
   pull_request:
     branches:
       - main
+    paths:
+      - 'packages/api/**'
+      - '.github/workflows/api.yml'
 jobs:
   test:
     runs-on: ubuntu-latest
@@ -17,3 +23,16 @@ jobs:
           node-version: 16
       - uses: bahmutov/npm-install@v1
       - run: npm test --workspace packages/api
+  deploy-staging:
+    name: Deploy Staging API
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    needs: test
+    steps:
+      - uses: actions/checkout@v2
+      - name: Publish api worker
+        uses: cloudflare/wrangler-action@1.3.0
+        with:
+          apiToken: ${{ secrets.CF_API_TOKEN }}
+          workingDirectory: 'packages/api'
+          environment: 'staging'

--- a/packages/api/wrangler.toml
+++ b/packages/api/wrangler.toml
@@ -13,11 +13,21 @@ watch_dir = "src"
 format = "service-worker"
 
 # ---- Environment specific overrides below ! ----
+# NOTE: wrangler automatically assigns each env the root `name` with the env name suffixed on the end
+# NOTE: wrangler tries to find an account_id defined at the root if workers_dev = true is not provided on your env.
 
 # PROD!
 [env.production]
 # name = "web3-storage-production"
-account_id = "?"
+workers_dev = true
+account_id = "fffa4b4363a7e5250af8357087263b3a" # Protocol Labs CF account
+route = "api.web3.storage/*"
+
+[env.staging]
+# name = "web3-storage-staging"
+workers_dev = true
+account_id = "fffa4b4363a7e5250af8357087263b3a" # Protocol Labs CF account
+route = "api-staging.web3.storage/*"
 
 # Add your env here. Override the the values you need to change.
 
@@ -26,9 +36,6 @@ workers_dev = true
 account_id = "4fe12d085474d33bdcfd8e9bed4d8f95"
 
 [env.oli]
-# NOTE: wrangler automatically assings each env the root `name` with the env name suffixed on the end
-# name = "web3-storage-oli"
-# NOTE: wrangler tries to find an account_id defined at the root if workers_dev = true is not provided on your env.
 workers_dev = true
 account_id = "6e5a2aed80cd37d77e8d0c797a75ebbd"
 


### PR DESCRIPTION
- update wrangler.toml with staging env
- update github action to publish staging api on merge to main

and out-of-band we have:
- web3.storage site created on Cloudflare
- nameservers updated to point web3.storage at Cloudflare
- DNSSEC enabled on web3.storage
- Scoped api token for editing workers on web3.storage added as `CF_API_TOKEN`


License: (Apache-2.0 AND MIT)
Signed-off-by: Oli Evans <oli@tableflip.io>