### PR TITLE
fix: webpack build process

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18031,7 +18031,7 @@
         "assert": "^2.0.0",
         "buffer": "^6.0.3",
         "npm-run-all": "^4.1.5",
-        "playwright-test": "^4.1.0",
+        "playwright-test": "^5.0.0",
         "process": "^0.11.10",
         "smoke": "^3.1.1",
         "stream-browserify": "^3.0.0",
@@ -33496,7 +33496,7 @@
         "buffer": "^6.0.3",
         "itty-router": "^2.3.10",
         "npm-run-all": "^4.1.5",
-        "playwright-test": "^4.1.0",
+        "playwright-test": "^5.0.0",
         "process": "^0.11.10",
         "smoke": "^3.1.1",
         "stream-browserify": "^3.0.0",
@@ -33511,8 +33511,7 @@
           "dev": true
         },
         "playwright-test": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/playwright-test/-/playwright-test-4.1.0.tgz",
+          "version": "https://registry.npmjs.org/playwright-test/-/playwright-test-4.1.0.tgz",
           "integrity": "sha512-cW+inSXe7wZc9vPnkLMYWs+8PnbAes2m1SL47Q8mqhby8oHJRiGXjyVJppE6FrvhtzIHtjPOPYkvmT/lk4E/dw==",
           "dev": true,
           "requires": {

--- a/packages/api/webpack.config.js
+++ b/packages/api/webpack.config.js
@@ -11,7 +11,7 @@ export default {
   devtool: 'cheap-module-source-map', // avoid "eval": Workers environment doesn't allow it
   plugins: [
     new webpack.ProvidePlugin({
-      process: 'process/browser',
+      process: 'process/browser.js',
       Buffer: ['buffer', 'Buffer']
     })
   ],


### PR DESCRIPTION
I was getting this error trying to run `npm run build` in the api package:

```bash
npm run build

> web3.storage-api@0.0.0 build
> webpack

1 asset
201 modules

ERROR in ./src/index.js 52:13-20
Module not found: Error: Can't resolve 'process/browser' in '/Users/yusef/work/repos/web3.storage/packages/api/src'
Did you mean 'browser.js'?
BREAKING CHANGE: The request 'process/browser' failed to resolve only because it was resolved as fully specified
(probably because the origin is a '*.mjs' file or a '*.js' file where the package.json contains '"type": "module"').
The extension in the request is mandatory for it to be fully specified.
Add the extension to the request.

webpack 5.42.0 compiled with 1 error in 466 ms
```

Using node v16.4.0, npm 7.18.1 on an M1 mac.

Changing the webpack config entry to `'process/browser.js'` instead of just `'process/browser'` fixes it up on my machine.