### PR TITLE
feat: user token delete

### DIFF
--- a/packages/api/src/index.js
+++ b/packages/api/src/index.js
@@ -2,7 +2,7 @@ import { Router } from 'itty-router'
 import { withCorsHeaders, corsOptions } from './cors.js'
 import { envAll } from './env.js'
 import { carHead, carGet, carPut, carPost } from './car.js'
-import { userLoginPost, userTokensPost, userTokensGet, withAuth } from './user.js'
+import { userLoginPost, userTokensPost, userTokensGet, userTokensDelete, withAuth } from './user.js'
 import { JSONResponse } from './utils/json-response.js'
 
 const router = Router()
@@ -16,6 +16,7 @@ router.post('/car', withCorsHeaders(withAuth(carPost)))
 router.post('/user/login', withCorsHeaders(userLoginPost))
 router.get('/user/tokens', withCorsHeaders(withAuth(userTokensGet)))
 router.post('/user/tokens', withCorsHeaders(withAuth(userTokensPost)))
+router.delete('/user/tokens/:id', withCorsHeaders(withAuth(userTokensDelete)))
 
 router.get('/', () => {
   return new Response(

--- a/packages/api/src/user.js
+++ b/packages/api/src/user.js
@@ -219,5 +219,5 @@ export async function userTokensDelete (request, env) {
     }
   `, { user: request.auth.user._id, authToken: request.params.id })
 
-  return new JSONResponse(res.deleteAuthToken, { status: 410 })
+  return new JSONResponse(res.deleteAuthToken)
 }

--- a/packages/api/test/mocks/db/post_graphql.js
+++ b/packages/api/test/mocks/db/post_graphql.js
@@ -35,7 +35,11 @@ module.exports = ({ body }) => {
   }
 
   if (body.query.includes('createAuthToken')) {
-    return gqlOkResponse({ createAuthToken: {} })
+    return gqlOkResponse({ createAuthToken: { _id: 'test-auth-token' } })
+  }
+
+  if (body.query.includes('deleteAuthToken')) {
+    return gqlOkResponse({ deleteAuthToken: { _id: 'test-auth-token' } })
   }
 
   return gqlResponse(400, {

--- a/packages/api/test/user.spec.js
+++ b/packages/api/test/user.spec.js
@@ -36,7 +36,9 @@ describe('POST /user/tokens', () => {
       body: JSON.stringify({ name: 'test' })
     })
     assert(res.ok)
-    // no response data expected
+    assert.strictEqual(res.status, 201)
+    const { _id } = await res.json()
+    assert(_id)
   })
 
   it('requires valid name', async () => {
@@ -49,5 +51,18 @@ describe('POST /user/tokens', () => {
     assert(!res.ok)
     const { message } = await res.json()
     assert.strictEqual(message, 'invalid name')
+  })
+})
+
+describe('DELETE /user/tokens/:id', () => {
+  it('removes a token', async () => {
+    const token = await getTestJWT()
+    const res = await fetch(new URL('user/tokens/xyz', endpoint).toString(), {
+      method: 'DELETE',
+      headers: { Authorization: `Bearer ${token}` }
+    })
+    assert.strictEqual(res.status, 410)
+    const { _id } = await res.json()
+    assert(_id)
   })
 })

--- a/packages/api/test/user.spec.js
+++ b/packages/api/test/user.spec.js
@@ -61,7 +61,7 @@ describe('DELETE /user/tokens/:id', () => {
       method: 'DELETE',
       headers: { Authorization: `Bearer ${token}` }
     })
-    assert.strictEqual(res.status, 410)
+    assert(res.ok)
     const { _id } = await res.json()
     assert(_id)
   })

--- a/packages/db/fauna/resources/Function/deleteAuthToken.js
+++ b/packages/db/fauna/resources/Function/deleteAuthToken.js
@@ -1,0 +1,50 @@
+import fauna from 'faunadb'
+
+const {
+  Function,
+  CreateFunction,
+  Query,
+  Lambda,
+  Let,
+  Var,
+  If,
+  Update,
+  Exists,
+  Now,
+  Ref,
+  Abort,
+  Collection,
+  Get,
+  Equals,
+  Select
+} = fauna
+
+const name = 'deleteAuthToken'
+const body = Query(
+  Lambda(
+    ['userId', 'authTokenId'],
+    Let(
+      { authTokenRef: Ref(Collection('AuthToken'), Var('authTokenId')) },
+      If(
+        // make sure the token exists
+        Exists(Var('authTokenRef')),
+        If(
+          // make sure the user owns this token
+          Equals(
+            Select(['data', 'user', 'id'], Get(Var('authTokenRef'))),
+            Var('userId')
+          ),
+          Update(Var('authTokenRef'), { data: { deleted: Now() } }),
+          Abort('unauthorized')
+        ),
+        Abort('not found')
+      )
+    )
+  )
+)
+
+export default If(
+  Exists(Function(name)),
+  Update(Function(name), { name, body }),
+  CreateFunction({ name, body })
+)

--- a/packages/db/fauna/schema.graphql
+++ b/packages/db/fauna/schema.graphql
@@ -283,6 +283,7 @@ type Mutation {
   createOrUpdateUser(data: CreateOrUpdateUserInput!): User! @resolver
   createAuthToken(data: CreateAuthTokenInput): AuthToken! @resolver
   importCar(data: ImportCarInput!): Upload! @resolver
+  deleteAuthToken(user: ID!, authToken: ID!): AuthToken! @resolver
 }
 
 input FindUploadsInput {


### PR DESCRIPTION
* Adds the endpoint `DELETE /user/tokens/:id`
* Adds a GQL function `deleteAuthToken(user: ID!, authToken: ID!)` which sets the `deleted` flag on the token provided the token owner is the passed `user`.
* Fixes for bad codings