### PR TITLE
chore: install before staging deploy

### DIFF
--- a/.github/workflows/api.yml
+++ b/.github/workflows/api.yml
@@ -23,6 +23,7 @@ jobs:
           node-version: 16
       - uses: bahmutov/npm-install@v1
       - run: npm test --workspace packages/api
+
   deploy-staging:
     name: Deploy Staging API
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
@@ -30,6 +31,10 @@ jobs:
     needs: test
     steps:
       - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: 16
+      - uses: bahmutov/npm-install@v1
       - name: Publish api worker
         uses: cloudflare/wrangler-action@1.3.0
         with:


### PR DESCRIPTION
we no longer rely on wranglers built in webpack, so we must npm install before deploying


License: (Apache-2.0 AND MIT)
Signed-off-by: Oli Evans <oli@tableflip.io>