### PR TITLE
chore: use node@16 & npm@7 when building workers

### DIFF
--- a/.github/workflows/api.yml
+++ b/.github/workflows/api.yml
@@ -36,7 +36,8 @@ jobs:
           node-version: 16
       - uses: bahmutov/npm-install@v1
       - name: Publish api worker
-        uses: cloudflare/wrangler-action@1.3.0
+        # workaround for https://github.com/cloudflare/wrangler-action/issues/59 to use node 16
+        uses: web3-storage/wrangler-action@78130c1d1e3ceb6ee3bb7613d7753431ce6bb479
         with:
           apiToken: ${{ secrets.CF_API_TOKEN }}
           workingDirectory: 'packages/api'

--- a/.github/workflows/api.yml
+++ b/.github/workflows/api.yml
@@ -37,7 +37,7 @@ jobs:
       - uses: bahmutov/npm-install@v1
       - name: Publish api worker
         # workaround for https://github.com/cloudflare/wrangler-action/issues/59 to use node 16
-        uses: web3-storage/wrangler-action@78130c1d1e3ceb6ee3bb7613d7753431ce6bb479
+        uses: web3-storage/wrangler-action@node16
         with:
           apiToken: ${{ secrets.CF_API_TOKEN }}
           workingDirectory: 'packages/api'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -116,7 +116,8 @@ jobs:
       # --- API deploy steps -------------------------------------------------
       - name: API - Deploy to Cloudflare
         if: ${{ steps.tag-release.outputs.release_created && matrix.package == 'api' }}
-        uses: cloudflare/wrangler-action@1.3.0
+        # workaround for https://github.com/cloudflare/wrangler-action/issues/59 to use node 16
+        uses: web3-storage/wrangler-action@node16
         with:
           apiToken: ${{ secrets.CF_API_TOKEN }}
           workingDirectory: 'packages/api'


### PR DESCRIPTION
see: https://github.com/cloudflare/wrangler-action/issues/59
see: https://github.com/web3-storage/wrangler-action/pull/1


License: (Apache-2.0 AND MIT)
Signed-off-by: Oli Evans <oli@tableflip.io>