### PR TITLE
chore: fix release yaml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -84,7 +84,7 @@ jobs:
         package: ${{fromJson(needs.changeFinder.outputs.nodePaths)}}
     steps:
       - name: Handle Release PR Merge
-      - uses: GoogleCloudPlatform/release-please-action@v2
+        uses: GoogleCloudPlatform/release-please-action@v2
         id: tag-release
         with:
           path: packages/${{ matrix.package }}


### PR DESCRIPTION
too many hyphens spoils the yaml

License: (Apache-2.0 AND MIT)
Signed-off-by: Oli Evans <oli@tableflip.io>