### PR TITLE
chore: set CLUSTER_API_URL for staging & prod

### DIFF
--- a/packages/api/wrangler.toml
+++ b/packages/api/wrangler.toml
@@ -11,14 +11,13 @@ command = "npm run build"
 watch_dir = "src"
 [build.upload]
 format = "service-worker"
-[vars]
-CLUSTER_API_URL = "https://web3.storage.ipfscluster.io/api/"
 
 # ---- Environment specific overrides below ! ----
 # NOTE: wrangler automatically assigns each env the root `name` with the env name suffixed on the end
 # NOTE: wrangler tries to find an account_id defined at the root if workers_dev = true is not provided on your env.
 # NOTE: set BOTH a `route` template and `zone_id` to deploy to a custom domain.
 # NOTE: set worker_dev to true to deploy to a ${name}.${zone}.workers.dev
+# NOTE: `vars` are not inherited by envs. You need to declare all of them in each env.
 
 # PROD!
 [env.production]
@@ -26,14 +25,14 @@ CLUSTER_API_URL = "https://web3.storage.ipfscluster.io/api/"
 account_id = "fffa4b4363a7e5250af8357087263b3a" # Protocol Labs CF account
 zone_id = "7eee3323c1b35b6650568604c65f441e"    # web3.storage zone
 route = "https://api.web3.storage/*"
+vars = { CLUSTER_API_URL = "https://filecoin.storage.ipfscluster.io/api/" }
 
 [env.staging]
 # name = "web3-storage-staging"
 account_id = "fffa4b4363a7e5250af8357087263b3a" # Protocol Labs CF account
 zone_id = "7eee3323c1b35b6650568604c65f441e"    # web3.storage zone
 route = "https://api-staging.web3.storage/*"
-
-# Add your env here. Override the the values you need to change.
+vars = { CLUSTER_API_URL = "https://filecoin.storage.ipfscluster.io/api/" }
 
 [env.alan]
 workers_dev = true
@@ -55,8 +54,11 @@ workers_dev = true
 account_id = "7ec0b7cf2ec201b2580374e53ba5f37b"
 vars = { CLUSTER_API_URL = "https://vsantos-cluster-api-web3-storage.loca.lt" }
 
+# Add your env here. Override the the values you need to change.
+
 # Create your env name as the value of `whoami` on your system, so you can run `npm start` to run in dev mode.
 # Copy this template and fill out the values
 # [env.${whoami}]
 # workers_dev = true
 # account_id = "<get me from `wrangler whoami`"
+# vars = { CLUSTER_API_URL = "https://<your ${whoami} here>-cluster-api-web3-storage.loca.lt" }


### PR DESCRIPTION
wrangler.toml environments do not inherit vars
see: https://developers.cloudflare.com/workers/cli-wrangler/configuration#keys

Cluster is not renamed yet, so is filecoin.storage for now
see: https://github.com/protocol/bifrost-infra/issues/1319

License: (Apache-2.0 AND MIT)
Signed-off-by: Oli Evans <oli@tableflip.io>