### PR TITLE
chore: update playwright

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,7 +5,6 @@
   "requires": true,
   "packages": {
     "": {
-      "name": "web3.storage",
       "version": "1.0.0",
       "license": "(Apache-2.0 AND MIT)",
       "workspaces": [
@@ -15213,35 +15212,37 @@
       }
     },
     "node_modules/playwright-test": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/playwright-test/-/playwright-test-5.0.0.tgz",
-      "integrity": "sha512-S4OLOYwQFHTSHYcG6FRnDvUgeypFYdxgI/leGwuMqoJGBsatPa5jgw2dXhIbO28mgrqDoHO+r0Tijo+H3lo60g==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/playwright-test/-/playwright-test-6.0.0.tgz",
+      "integrity": "sha512-PPGTfpTMy29DtwwNnKlrYBB4T348VMQuVl9G1E1Zf9aTT96zbdgnh8BPfb7/C1qaiqAKjie1d+dhhL8gx31vRA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "buffer": "^6.0.3",
         "camelcase": "^6.2.0",
-        "esbuild": "0.11.20",
-        "globby": "^11.0.3",
+        "esbuild": "0.12.15",
+        "events": "^3.3.0",
+        "globby": "^11.0.4",
         "kleur": "^4.1.4",
-        "lilconfig": "^2.0.2",
+        "lilconfig": "^2.0.3",
         "lodash": "^4.17.21",
         "merge-options": "^3.0.4",
-        "ora": "^5.4.0",
-        "p-wait-for": "3.2.0",
+        "ora": "^5.4.1",
+        "p-wait-for": "4.0.0",
         "path-browserify": "^1.0.1",
-        "playwright-core": "1.11.0",
+        "playwright-core": "1.12.3",
         "polka": "^0.5.2",
         "premove": "^3.0.1",
         "process": "^0.11.10",
         "sade": "^1.7.4",
-        "sirv": "^1.0.11",
+        "sirv": "^1.0.12",
         "source-map": "0.6.1",
         "stream-browserify": "^3.0.0",
-        "strip-ansi": "^6.0.0",
+        "strip-ansi": "^7.0.0",
         "tape": "^5.2.2",
         "tempy": "^1.0.1",
         "test-exclude": "^6.0.0",
-        "v8-to-istanbul": "^7.1.2"
+        "v8-to-istanbul": "^8.0.0"
       },
       "bin": {
         "playwright-test": "cli.js",
@@ -15249,6 +15250,93 @@
       },
       "engines": {
         "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      }
+    },
+    "node_modules/playwright-test/node_modules/ansi-regex": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.0.0.tgz",
+      "integrity": "sha512-tAaOSrWCHF+1Ear1Z4wnJCXA9GGox4K6Ic85a5qalES2aeEwQGr7UC93mwef49536PkCYjzkp0zIxfFvexJ6zQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/playwright-test/node_modules/commander": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-6.2.1.tgz",
+      "integrity": "sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA==",
+      "dev": true,
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/playwright-test/node_modules/esbuild": {
+      "version": "0.12.15",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.12.15.tgz",
+      "integrity": "sha512-72V4JNd2+48eOVCXx49xoSWHgC3/cCy96e7mbXKY+WOWghN00cCmlGnwVLRhRHorvv0dgCyuMYBZlM2xDM5OQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "bin": {
+        "esbuild": "bin/esbuild"
+      }
+    },
+    "node_modules/playwright-test/node_modules/p-timeout": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-5.0.0.tgz",
+      "integrity": "sha512-z+bU/N7L1SABsqKnQzvAnINgPX7NHdzwUV+gHyJE7VGNDZSr03rhcPODCZSWiiT9k+gf74QPmzcZzqJRvxYZow==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/playwright-test/node_modules/p-wait-for": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/p-wait-for/-/p-wait-for-4.0.0.tgz",
+      "integrity": "sha512-nNTv4xr44ZCilARTe9Bbh0+Ou5D2O1y8CPUsgH7ok6r1F7pSHM7pkOjaySgrW+sq3l4NEMFtLu8u8rgHm6TK5w==",
+      "dev": true,
+      "dependencies": {
+        "p-timeout": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/playwright-test/node_modules/playwright-core": {
+      "version": "1.12.3",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.12.3.tgz",
+      "integrity": "sha512-7uCxloOH4JRVTdJa+PH0Lp+GqWHL7WjQwMT77TtGtBblgoVFuY7ZzVzXgAXtV0rfqq5xUvwaxFBS36fkgT2bNw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "dependencies": {
+        "commander": "^6.1.0",
+        "debug": "^4.1.1",
+        "extract-zip": "^2.0.1",
+        "https-proxy-agent": "^5.0.0",
+        "jpeg-js": "^0.4.2",
+        "mime": "^2.4.6",
+        "pngjs": "^5.0.0",
+        "progress": "^2.0.3",
+        "proper-lockfile": "^4.1.1",
+        "proxy-from-env": "^1.1.0",
+        "rimraf": "^3.0.2",
+        "stack-utils": "^2.0.3",
+        "ws": "^7.4.6",
+        "yazl": "^2.5.1"
+      },
+      "bin": {
+        "playwright": "lib/cli/cli.js"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/playwright-test/node_modules/source-map": {
@@ -15260,27 +15348,19 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/playwright-test/node_modules/v8-to-istanbul": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-7.1.2.tgz",
-      "integrity": "sha512-TxNb7YEUwkLXCQYeudi6lgQ/SZrzNO4kMdlqVxaZPUIUjCv6iSSypUQX70kNBSERpQ8fk48+d61FXk+tgqcWow==",
+    "node_modules/playwright-test/node_modules/strip-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.0.0.tgz",
+      "integrity": "sha512-UhDTSnGF1dc0DRbUqr1aXwNoY3RgVkSWG8BrpnuFIxhP57IqbS7IRta2Gfiavds4yCxc5+fEAVVOgBZWnYkvzg==",
       "dev": true,
       "dependencies": {
-        "@types/istanbul-lib-coverage": "^2.0.1",
-        "convert-source-map": "^1.6.0",
-        "source-map": "^0.7.3"
+        "ansi-regex": "^6.0.0"
       },
       "engines": {
-        "node": ">=10.10.0"
-      }
-    },
-    "node_modules/playwright-test/node_modules/v8-to-istanbul/node_modules/source-map": {
-      "version": "0.7.3",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.3.tgz",
-      "integrity": "sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==",
-      "dev": true,
-      "engines": {
-        "node": ">= 8"
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
       }
     },
     "node_modules/plist": {
@@ -20487,7 +20567,7 @@
         "buffer": "^6.0.3",
         "ipfs-car": "^0.4.3",
         "npm-run-all": "^4.1.5",
-        "playwright-test": "^5.0.0",
+        "playwright-test": "^6.0.0",
         "process": "^0.11.10",
         "smoke": "^3.1.1",
         "stream-browserify": "^3.0.0",
@@ -20534,62 +20614,6 @@
       "version": "8.2.2",
       "dev": true,
       "license": "MIT"
-    },
-    "packages/client/node_modules/@vascosantos/ipfs-unixfs-exporter": {
-      "version": "8.0.0",
-      "extraneous": true,
-      "license": "MIT",
-      "dependencies": {
-        "@ipld/dag-cbor": "^6.0.0",
-        "@ipld/dag-pb": "^2.0.2",
-        "err-code": "^3.0.1",
-        "hamt-sharding": "^2.0.0",
-        "ipfs-unixfs": "^4.0.3",
-        "it-last": "^1.0.5",
-        "multicodec": "^3.0.1",
-        "multiformats": "^9.0.4",
-        "multihashing-async": "^2.1.0"
-      },
-      "engines": {
-        "node": ">=14.0.0",
-        "npm": ">=7.0.0"
-      }
-    },
-    "packages/client/node_modules/@vascosantos/ipfs-unixfs-exporter/node_modules/multiformats": {
-      "version": "9.1.1",
-      "extraneous": true,
-      "license": "(Apache-2.0 AND MIT)"
-    },
-    "packages/client/node_modules/@vascosantos/ipfs-unixfs-importer": {
-      "version": "10.0.0",
-      "extraneous": true,
-      "license": "MIT",
-      "dependencies": {
-        "@ipld/dag-pb": "^2.1.1",
-        "bl": "^5.0.0",
-        "err-code": "^3.0.1",
-        "hamt-sharding": "^2.0.0",
-        "ipfs-unixfs": "^4.0.3",
-        "it-all": "^1.0.5",
-        "it-batch": "^1.0.8",
-        "it-first": "^1.0.6",
-        "it-parallel-batch": "^1.0.9",
-        "merge-options": "^3.0.4",
-        "multicodec": "^3.1.0",
-        "multiformats": "^9.0.4",
-        "multihashing-async": "^2.1.0",
-        "rabin-wasm": "^0.1.4",
-        "uint8arrays": "^2.1.5"
-      },
-      "engines": {
-        "node": ">=14.0.0",
-        "npm": ">=7.0.0"
-      }
-    },
-    "packages/client/node_modules/@vascosantos/ipfs-unixfs-importer/node_modules/multiformats": {
-      "version": "9.1.1",
-      "extraneous": true,
-      "license": "(Apache-2.0 AND MIT)"
     },
     "packages/client/node_modules/camelcase": {
       "version": "6.2.0",
@@ -20706,171 +20730,6 @@
         "w3": "bin.js"
       },
       "devDependencies": {}
-    },
-    "packages/w3/node_modules/@vascosantos/ipfs-unixfs-exporter": {
-      "version": "8.0.0",
-      "extraneous": true,
-      "license": "MIT",
-      "dependencies": {
-        "@ipld/dag-cbor": "^6.0.0",
-        "@ipld/dag-pb": "^2.0.2",
-        "err-code": "^3.0.1",
-        "hamt-sharding": "^2.0.0",
-        "ipfs-unixfs": "^4.0.3",
-        "it-last": "^1.0.5",
-        "multicodec": "^3.0.1",
-        "multiformats": "^9.0.4",
-        "multihashing-async": "^2.1.0"
-      },
-      "engines": {
-        "node": ">=14.0.0",
-        "npm": ">=7.0.0"
-      }
-    },
-    "packages/w3/node_modules/@vascosantos/ipfs-unixfs-importer": {
-      "version": "10.0.0",
-      "extraneous": true,
-      "license": "MIT",
-      "dependencies": {
-        "@ipld/dag-pb": "^2.1.1",
-        "bl": "^5.0.0",
-        "err-code": "^3.0.1",
-        "hamt-sharding": "^2.0.0",
-        "ipfs-unixfs": "^4.0.3",
-        "it-all": "^1.0.5",
-        "it-batch": "^1.0.8",
-        "it-first": "^1.0.6",
-        "it-parallel-batch": "^1.0.9",
-        "merge-options": "^3.0.4",
-        "multicodec": "^3.1.0",
-        "multiformats": "^9.0.4",
-        "multihashing-async": "^2.1.0",
-        "rabin-wasm": "^0.1.4",
-        "uint8arrays": "^2.1.5"
-      },
-      "engines": {
-        "node": ">=14.0.0",
-        "npm": ">=7.0.0"
-      }
-    },
-    "packages/w3/node_modules/decamelize": {
-      "version": "1.2.0",
-      "extraneous": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "packages/w3/node_modules/find-up": {
-      "version": "4.1.0",
-      "extraneous": true,
-      "license": "MIT",
-      "dependencies": {
-        "locate-path": "^5.0.0",
-        "path-exists": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "packages/w3/node_modules/hosted-git-info": {
-      "version": "2.8.9",
-      "extraneous": true,
-      "license": "ISC"
-    },
-    "packages/w3/node_modules/locate-path": {
-      "version": "5.0.0",
-      "extraneous": true,
-      "license": "MIT",
-      "dependencies": {
-        "p-locate": "^4.1.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "packages/w3/node_modules/p-limit": {
-      "version": "2.3.0",
-      "extraneous": true,
-      "license": "MIT",
-      "dependencies": {
-        "p-try": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "packages/w3/node_modules/p-locate": {
-      "version": "4.1.0",
-      "extraneous": true,
-      "license": "MIT",
-      "dependencies": {
-        "p-limit": "^2.2.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "packages/w3/node_modules/parse-json": {
-      "version": "5.2.0",
-      "extraneous": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/code-frame": "^7.0.0",
-        "error-ex": "^1.3.1",
-        "json-parse-even-better-errors": "^2.3.0",
-        "lines-and-columns": "^1.1.6"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "packages/w3/node_modules/read-pkg": {
-      "version": "5.2.0",
-      "extraneous": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/normalize-package-data": "^2.4.0",
-        "normalize-package-data": "^2.5.0",
-        "parse-json": "^5.0.0",
-        "type-fest": "^0.6.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "packages/w3/node_modules/read-pkg/node_modules/normalize-package-data": {
-      "version": "2.5.0",
-      "extraneous": true,
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "hosted-git-info": "^2.1.4",
-        "resolve": "^1.10.0",
-        "semver": "2 || 3 || 4 || 5",
-        "validate-npm-package-license": "^3.0.1"
-      }
-    },
-    "packages/w3/node_modules/read-pkg/node_modules/type-fest": {
-      "version": "0.6.0",
-      "extraneous": true,
-      "license": "(MIT OR CC0-1.0)",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "packages/w3/node_modules/semver": {
-      "version": "5.7.1",
-      "extraneous": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver"
-      }
     },
     "packages/website": {
       "name": "@web3-storage/website",
@@ -32907,60 +32766,106 @@
       }
     },
     "playwright-test": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/playwright-test/-/playwright-test-5.0.0.tgz",
-      "integrity": "sha512-S4OLOYwQFHTSHYcG6FRnDvUgeypFYdxgI/leGwuMqoJGBsatPa5jgw2dXhIbO28mgrqDoHO+r0Tijo+H3lo60g==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/playwright-test/-/playwright-test-6.0.0.tgz",
+      "integrity": "sha512-PPGTfpTMy29DtwwNnKlrYBB4T348VMQuVl9G1E1Zf9aTT96zbdgnh8BPfb7/C1qaiqAKjie1d+dhhL8gx31vRA==",
       "dev": true,
       "requires": {
         "buffer": "^6.0.3",
         "camelcase": "^6.2.0",
-        "esbuild": "0.11.20",
-        "globby": "^11.0.3",
+        "esbuild": "0.12.15",
+        "events": "^3.3.0",
+        "globby": "^11.0.4",
         "kleur": "^4.1.4",
-        "lilconfig": "^2.0.2",
+        "lilconfig": "^2.0.3",
         "lodash": "^4.17.21",
         "merge-options": "^3.0.4",
-        "ora": "^5.4.0",
-        "p-wait-for": "3.2.0",
+        "ora": "^5.4.1",
+        "p-wait-for": "4.0.0",
         "path-browserify": "^1.0.1",
-        "playwright-core": "1.11.0",
+        "playwright-core": "1.12.3",
         "polka": "^0.5.2",
         "premove": "^3.0.1",
         "process": "^0.11.10",
         "sade": "^1.7.4",
-        "sirv": "^1.0.11",
+        "sirv": "^1.0.12",
         "source-map": "0.6.1",
         "stream-browserify": "^3.0.0",
-        "strip-ansi": "^6.0.0",
+        "strip-ansi": "^7.0.0",
         "tape": "^5.2.2",
         "tempy": "^1.0.1",
         "test-exclude": "^6.0.0",
-        "v8-to-istanbul": "^7.1.2"
+        "v8-to-istanbul": "^8.0.0"
       },
       "dependencies": {
+        "ansi-regex": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.0.0.tgz",
+          "integrity": "sha512-tAaOSrWCHF+1Ear1Z4wnJCXA9GGox4K6Ic85a5qalES2aeEwQGr7UC93mwef49536PkCYjzkp0zIxfFvexJ6zQ==",
+          "dev": true
+        },
+        "commander": {
+          "version": "6.2.1",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-6.2.1.tgz",
+          "integrity": "sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA==",
+          "dev": true
+        },
+        "esbuild": {
+          "version": "0.12.15",
+          "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.12.15.tgz",
+          "integrity": "sha512-72V4JNd2+48eOVCXx49xoSWHgC3/cCy96e7mbXKY+WOWghN00cCmlGnwVLRhRHorvv0dgCyuMYBZlM2xDM5OQw==",
+          "dev": true
+        },
+        "p-timeout": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-5.0.0.tgz",
+          "integrity": "sha512-z+bU/N7L1SABsqKnQzvAnINgPX7NHdzwUV+gHyJE7VGNDZSr03rhcPODCZSWiiT9k+gf74QPmzcZzqJRvxYZow==",
+          "dev": true
+        },
+        "p-wait-for": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/p-wait-for/-/p-wait-for-4.0.0.tgz",
+          "integrity": "sha512-nNTv4xr44ZCilARTe9Bbh0+Ou5D2O1y8CPUsgH7ok6r1F7pSHM7pkOjaySgrW+sq3l4NEMFtLu8u8rgHm6TK5w==",
+          "dev": true,
+          "requires": {
+            "p-timeout": "^5.0.0"
+          }
+        },
+        "playwright-core": {
+          "version": "1.12.3",
+          "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.12.3.tgz",
+          "integrity": "sha512-7uCxloOH4JRVTdJa+PH0Lp+GqWHL7WjQwMT77TtGtBblgoVFuY7ZzVzXgAXtV0rfqq5xUvwaxFBS36fkgT2bNw==",
+          "dev": true,
+          "requires": {
+            "commander": "^6.1.0",
+            "debug": "^4.1.1",
+            "extract-zip": "^2.0.1",
+            "https-proxy-agent": "^5.0.0",
+            "jpeg-js": "^0.4.2",
+            "mime": "^2.4.6",
+            "pngjs": "^5.0.0",
+            "progress": "^2.0.3",
+            "proper-lockfile": "^4.1.1",
+            "proxy-from-env": "^1.1.0",
+            "rimraf": "^3.0.2",
+            "stack-utils": "^2.0.3",
+            "ws": "^7.4.6",
+            "yazl": "^2.5.1"
+          }
+        },
         "source-map": {
           "version": "0.6.1",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
           "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
           "dev": true
         },
-        "v8-to-istanbul": {
-          "version": "7.1.2",
-          "resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-7.1.2.tgz",
-          "integrity": "sha512-TxNb7YEUwkLXCQYeudi6lgQ/SZrzNO4kMdlqVxaZPUIUjCv6iSSypUQX70kNBSERpQ8fk48+d61FXk+tgqcWow==",
+        "strip-ansi": {
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.0.0.tgz",
+          "integrity": "sha512-UhDTSnGF1dc0DRbUqr1aXwNoY3RgVkSWG8BrpnuFIxhP57IqbS7IRta2Gfiavds4yCxc5+fEAVVOgBZWnYkvzg==",
           "dev": true,
           "requires": {
-            "@types/istanbul-lib-coverage": "^2.0.1",
-            "convert-source-map": "^1.6.0",
-            "source-map": "^0.7.3"
-          },
-          "dependencies": {
-            "source-map": {
-              "version": "0.7.3",
-              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.3.tgz",
-              "integrity": "sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==",
-              "dev": true
-            }
+            "ansi-regex": "^6.0.0"
           }
         }
       }
@@ -36599,54 +36504,6 @@
           "version": "8.2.2",
           "dev": true
         },
-        "@vascosantos/ipfs-unixfs-exporter": {
-          "version": "8.0.0",
-          "extraneous": true,
-          "requires": {
-            "@ipld/dag-cbor": "^6.0.0",
-            "@ipld/dag-pb": "^2.0.2",
-            "err-code": "^3.0.1",
-            "hamt-sharding": "^2.0.0",
-            "ipfs-unixfs": "^4.0.3",
-            "it-last": "^1.0.5",
-            "multicodec": "^3.0.1",
-            "multiformats": "^9.0.4",
-            "multihashing-async": "^2.1.0"
-          },
-          "dependencies": {
-            "multiformats": {
-              "version": "9.1.1",
-              "extraneous": true
-            }
-          }
-        },
-        "@vascosantos/ipfs-unixfs-importer": {
-          "version": "10.0.0",
-          "extraneous": true,
-          "requires": {
-            "@ipld/dag-pb": "^2.1.1",
-            "bl": "^5.0.0",
-            "err-code": "^3.0.1",
-            "hamt-sharding": "^2.0.0",
-            "ipfs-unixfs": "^4.0.3",
-            "it-all": "^1.0.5",
-            "it-batch": "^1.0.8",
-            "it-first": "^1.0.6",
-            "it-parallel-batch": "^1.0.9",
-            "merge-options": "^3.0.4",
-            "multicodec": "^3.1.0",
-            "multiformats": "^9.0.4",
-            "multihashing-async": "^2.1.0",
-            "rabin-wasm": "^0.1.4",
-            "uint8arrays": "^2.1.5"
-          },
-          "dependencies": {
-            "multiformats": {
-              "version": "9.1.1",
-              "extraneous": true
-            }
-          }
-        },
         "camelcase": {
           "version": "6.2.0",
           "dev": true
@@ -36723,7 +36580,7 @@
         "ipfs-car": "^0.4.3",
         "itty-router": "^2.3.10",
         "npm-run-all": "^4.1.5",
-        "playwright-test": "^5.0.0",
+        "playwright-test": "^6.0.0",
         "process": "^0.11.10",
         "smoke": "^3.1.1",
         "stream-browserify": "^3.0.0",
@@ -36736,121 +36593,6 @@
       "requires": {
         "ipfs-car": "^0.4.2",
         "meow": "^10.0.1"
-      },
-      "dependencies": {
-        "@vascosantos/ipfs-unixfs-exporter": {
-          "version": "8.0.0",
-          "extraneous": true,
-          "requires": {
-            "@ipld/dag-cbor": "^6.0.0",
-            "@ipld/dag-pb": "^2.0.2",
-            "err-code": "^3.0.1",
-            "hamt-sharding": "^2.0.0",
-            "ipfs-unixfs": "^4.0.3",
-            "it-last": "^1.0.5",
-            "multicodec": "^3.0.1",
-            "multiformats": "^9.0.4",
-            "multihashing-async": "^2.1.0"
-          }
-        },
-        "@vascosantos/ipfs-unixfs-importer": {
-          "version": "10.0.0",
-          "extraneous": true,
-          "requires": {
-            "@ipld/dag-pb": "^2.1.1",
-            "bl": "^5.0.0",
-            "err-code": "^3.0.1",
-            "hamt-sharding": "^2.0.0",
-            "ipfs-unixfs": "^4.0.3",
-            "it-all": "^1.0.5",
-            "it-batch": "^1.0.8",
-            "it-first": "^1.0.6",
-            "it-parallel-batch": "^1.0.9",
-            "merge-options": "^3.0.4",
-            "multicodec": "^3.1.0",
-            "multiformats": "^9.0.4",
-            "multihashing-async": "^2.1.0",
-            "rabin-wasm": "^0.1.4",
-            "uint8arrays": "^2.1.5"
-          }
-        },
-        "decamelize": {
-          "version": "1.2.0",
-          "extraneous": true
-        },
-        "find-up": {
-          "version": "4.1.0",
-          "extraneous": true,
-          "requires": {
-            "locate-path": "^5.0.0",
-            "path-exists": "^4.0.0"
-          }
-        },
-        "hosted-git-info": {
-          "version": "2.8.9",
-          "extraneous": true
-        },
-        "locate-path": {
-          "version": "5.0.0",
-          "extraneous": true,
-          "requires": {
-            "p-locate": "^4.1.0"
-          }
-        },
-        "p-limit": {
-          "version": "2.3.0",
-          "extraneous": true,
-          "requires": {
-            "p-try": "^2.0.0"
-          }
-        },
-        "p-locate": {
-          "version": "4.1.0",
-          "extraneous": true,
-          "requires": {
-            "p-limit": "^2.2.0"
-          }
-        },
-        "parse-json": {
-          "version": "5.2.0",
-          "extraneous": true,
-          "requires": {
-            "@babel/code-frame": "^7.0.0",
-            "error-ex": "^1.3.1",
-            "json-parse-even-better-errors": "^2.3.0",
-            "lines-and-columns": "^1.1.6"
-          }
-        },
-        "read-pkg": {
-          "version": "5.2.0",
-          "extraneous": true,
-          "requires": {
-            "@types/normalize-package-data": "^2.4.0",
-            "normalize-package-data": "^2.5.0",
-            "parse-json": "^5.0.0",
-            "type-fest": "^0.6.0"
-          },
-          "dependencies": {
-            "normalize-package-data": {
-              "version": "2.5.0",
-              "extraneous": true,
-              "requires": {
-                "hosted-git-info": "^2.1.4",
-                "resolve": "^1.10.0",
-                "semver": "2 || 3 || 4 || 5",
-                "validate-npm-package-license": "^3.0.1"
-              }
-            },
-            "type-fest": {
-              "version": "0.6.0",
-              "extraneous": true
-            }
-          }
-        },
-        "semver": {
-          "version": "5.7.1",
-          "extraneous": true
-        }
       }
     },
     "webidl-conversions": {

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -26,7 +26,7 @@
     "buffer": "^6.0.3",
     "ipfs-car": "^0.4.3",
     "npm-run-all": "^4.1.5",
-    "playwright-test": "^5.0.0",
+    "playwright-test": "^6.0.0",
     "process": "^0.11.10",
     "smoke": "^3.1.1",
     "stream-browserify": "^3.0.0",

--- a/packages/api/src/index.js
+++ b/packages/api/src/index.js
@@ -48,14 +48,5 @@ function serverError (error) {
 }
 
 addEventListener('fetch', (event) => {
-  const respond = () => event.respondWith(router.handle(event.request, {}, event).catch(serverError))
-  // when testing just respond to the fake testing domain
-  if (typeof process !== 'undefined' && process.env.PW_TEST) {
-    const url = new URL(event.request.url)
-    if (url.hostname === 'testing.web3.storage') {
-      respond()
-    }
-  } else {
-    respond()
-  }
+  event.respondWith(router.handle(event.request, {}, event).catch(serverError))
 })


### PR DESCRIPTION
This PR updates the `playwright-test` dependency.

The new version ensures the service worker is registered after the tests bundle is requested. This prevents the service worker responding to a fetch request for the bundle that contains the tests.

The worker no longer has to distinguish between requests for the worker and requests for other resources as everything should be for the worker (as it would be in production).