### PR TITLE
fix: split CAR uploads

### DIFF
--- a/packages/api/src/car.js
+++ b/packages/api/src/car.js
@@ -63,7 +63,7 @@ export async function carGet(request, env, ctx) {
  * @param {import('./env').Env} env
  */
 export async function carPost(request, env) {
-  const { _id } = request.auth.authToken
+  const { user, authToken } = request.auth
   const { headers } = request
 
   let name = headers.get('x-name')
@@ -92,8 +92,9 @@ export async function carPost(request, env) {
       }
     }
   `, {
-    data: { 
-      authToken: _id,
+    data: {
+      user: user._id,
+      authToken: authToken?._id,
       cid,
       name
       // dagSize: undefined // TODO: should we default to chunk car behavior?

--- a/packages/api/src/env.js
+++ b/packages/api/src/env.js
@@ -20,6 +20,6 @@ export function envAll (_, env) {
   env.SALT = env.SALT || SALT
 
   const clusterAuthToken = env.CLUSTER_BASIC_AUTH_TOKEN || (typeof CLUSTER_BASIC_AUTH_TOKEN === 'undefined' ? undefined : CLUSTER_BASIC_AUTH_TOKEN)
-  const headers = clusterAuthToken ? { Authorization: `Basic ${clusterAuthToken}` } : null
+  const headers = clusterAuthToken ? { Authorization: `Basic ${clusterAuthToken}` } : {}
   env.cluster = new Cluster(env.CLUSTER_API_URL || CLUSTER_API_URL, { headers })
 }

--- a/packages/db/fauna/resources/Function/findUploads.js
+++ b/packages/db/fauna/resources/Function/findUploads.js
@@ -31,7 +31,7 @@ const body = Query(
       {
         match: Filter(
           Match(
-            Index('upload_sort_by_created_desc'),
+            Index('upload_by_user_sort_by_created_desc'),
             Ref(Collection('User'), Select('user', Var('where'))),
             true
           ),

--- a/packages/db/fauna/resources/Function/importCar.js
+++ b/packages/db/fauna/resources/Function/importCar.js
@@ -20,7 +20,8 @@ const {
   IsNonEmpty,
   Abort,
   Collection,
-  IsNull
+  IsNull,
+  Not
 } = fauna
 
 const name = 'importCar'
@@ -37,7 +38,8 @@ const body = Query(
         )
       },
       If(
-        Exists(Var('userRef')),
+        Not(Exists(Var('userRef'))),
+        Abort('user not found'),
         Let(
           {
             cid: Select('cid', Var('data')),
@@ -92,8 +94,7 @@ const body = Query(
               })
             )
           )
-        ),
-        Abort('user not found')
+        )
       )
     )
   )

--- a/packages/db/fauna/resources/Function/importCar.js
+++ b/packages/db/fauna/resources/Function/importCar.js
@@ -19,7 +19,8 @@ const {
   Ref,
   IsNonEmpty,
   Abort,
-  Collection
+  Collection,
+  IsNull
 } = fauna
 
 const name = 'importCar'
@@ -28,15 +29,19 @@ const body = Query(
     ['data'],
     Let(
       {
-        authTokenRef: Ref(Collection('AuthToken'), Select('authToken', Var('data')))
+        userRef: Ref(Collection('User'), Select('user', Var('data'))),
+        authTokenRef: If(
+          IsNull(Select('authToken', Var('data'), null)),
+          null,
+          Ref(Collection('AuthToken'), Select('authToken', Var('data')))
+        )
       },
       If(
-        Exists(Var('authTokenRef')),
+        Exists(Var('userRef')),
         Let(
           {
             cid: Select('cid', Var('data')),
-            contentMatch: Match(Index('unique_Content_cid'), Var('cid')),
-            userRef: Select(['data', 'user'], Get(Var('authTokenRef')))
+            contentMatch: Match(Index('unique_Content_cid'), Var('cid'))
           },
           If(
             IsNonEmpty(Var('contentMatch')),

--- a/packages/db/fauna/resources/Function/importCar.js
+++ b/packages/db/fauna/resources/Function/importCar.js
@@ -93,7 +93,7 @@ const body = Query(
             )
           )
         ),
-        Abort('auth token not found')
+        Abort('user not found')
       )
     )
   )

--- a/packages/db/fauna/resources/Index/uploadByUserAndContent.js
+++ b/packages/db/fauna/resources/Index/uploadByUserAndContent.js
@@ -1,0 +1,52 @@
+import fauna from 'faunadb'
+
+const {
+  CreateIndex,
+  Collection,
+  If,
+  Index,
+  Exists,
+  Not,
+  Query,
+  Lambda,
+  Equals,
+  Select,
+  Var
+} = fauna
+
+/**
+ * Usage:
+ *
+ * Match(
+ *   Index('upload_by_user_and_content'),
+ *   Ref(Collection('user'), Var('id')),
+ *   Ref(Collection('content'), Var('id')),
+ *   true // not_deleted
+ * )
+ */
+const index = {
+  name: 'upload_by_user_and_content',
+  source: [{
+    collection: Collection('Upload'),
+    fields: {
+      not_deleted: Query(
+        Lambda(
+          'upload',
+          Equals(Select(['data', 'deleted'], Var('upload'), null), null)
+        )
+      )
+    }
+  }],
+  terms: [
+    { field: ['data', 'user'] },
+    { field: ['data', 'content'] },
+    { binding: 'not_deleted' }
+  ]
+}
+
+// indexes cannot be updated
+export default If(
+  Not(Exists(Index(index.name))),
+  CreateIndex(index),
+  Index(index.name)
+)

--- a/packages/db/fauna/resources/Index/uploadByUserSortByCreatedDesc.js
+++ b/packages/db/fauna/resources/Index/uploadByUserSortByCreatedDesc.js
@@ -18,13 +18,13 @@ const {
  * Usage:
  *
  * Match(
- *   Index('upload_sort_by_created_desc'),
+ *   Index('upload_by_user_sort_by_created_desc'),
  *   Ref(Collection('user'), Var('id')),
  *   true // not_deleted
  * )
  */
 const index = {
-  name: 'upload_sort_by_created_desc',
+  name: 'upload_by_user_sort_by_created_desc',
   source: [{
     collection: Collection('Upload'),
     fields: {

--- a/packages/db/fauna/schema.graphql
+++ b/packages/db/fauna/schema.graphql
@@ -169,8 +169,9 @@ type Upload {
 
   """
   User authentication token that was used to upload this content.
+  Note: nullable, because the user may have used a Magic.link token.
   """
-  authToken: AuthToken! @relation
+  authToken: AuthToken @relation
 
   """
   User provided name for this upload.
@@ -307,7 +308,8 @@ input CreateAuthTokenInput {
 }
 
 input ImportCarInput {
-  authToken: ID!
+  user: ID!
+  authToken: ID
   cid: String!
   name: String
   dagSize: Int

--- a/packages/db/fauna/schema.graphql
+++ b/packages/db/fauna/schema.graphql
@@ -45,12 +45,12 @@ type AuthToken {
   """
   Uploads made using this token.
   """
-  uploads: [Upload!]! @relation @index
+  uploads: [Upload!]! @relation
 
   """
   User this token belongs to.
   """
-  user: User! @relation @index
+  user: User! @relation
 
   """
   Creation date.
@@ -165,7 +165,7 @@ type Upload {
   """
   User that uploaded this content.
   """
-  user: User! @relation @index
+  user: User! @relation
 
   """
   User authentication token that was used to upload this content.
@@ -200,7 +200,7 @@ type Deal {
   """
   CIDs in this deal.
   """
-  contents: [Content!]! @relation @index
+  contents: [Content!]! @relation
 
   """
   ID of miner this deal was made with.

--- a/packages/website/pages/new-file.js
+++ b/packages/website/pages/new-file.js
@@ -1,15 +1,14 @@
 import { getToken, API } from '../lib/api'
 import { useRouter } from 'next/router'
-import { NFTStorage } from 'nft.storage'
+import { Web3Storage } from 'web3.storage'
 import { useQueryClient } from 'react-query'
 import { useState } from 'react'
-import Box from '../components/box.js'
 import Button from '../components/button.js'
 
 export function getStaticProps() {
   return {
     props: {
-      title: 'New NFT - NFT Storage',
+      title: 'New File - Web3 Storage',
       navBgColor: 'nsyellow',
       redirectTo: '/',
       needsUser: true,
@@ -21,19 +20,7 @@ export default function NewFile() {
   const router = useRouter()
   const queryClient = useQueryClient()
   const [uploading, setUploading] = useState(false)
-  const [isCar, setIsCar] = useState(false)
-
-  /**
-   * @param {import('react').ChangeEvent<HTMLInputElement>} e
-   */
-  function checkCar(e) {
-    const file = e.target.files && e.target.files[0]
-    if (file && file.name.endsWith('.car')) {
-      setIsCar(true)
-    } else {
-      setIsCar(false)
-    }
-  }
+  const [percentComplete, setPercentComplete] = useState(0)
 
   /**
    * @param {import('react').ChangeEvent<HTMLFormElement>} e
@@ -43,17 +30,20 @@ export default function NewFile() {
     const data = new FormData(e.target)
     const file = data.get('file')
     if (file && file instanceof File) {
-      const client = new NFTStorage({
+      const client = new Web3Storage({
         token: await getToken(),
         endpoint: new URL(API),
       })
       setUploading(true)
       try {
-        if (isCar) {
-          await client.storeCar(file)
-        } else {
-          await client.storeBlob(file)
-        }
+        let totalBytesSent = 0
+        await client.put([file], {
+          name: file.name,
+          onStoredChunk: size => {
+            totalBytesSent += size
+            setPercentComplete(Math.round((totalBytesSent / file.size) * 100))
+          }
+        })
       } finally {
         await queryClient.invalidateQueries('get-uploads')
         setUploading(false)
@@ -65,11 +55,7 @@ export default function NewFile() {
   return (
     <main className="bg-nsyellow">
       <div className="mw9 center pv3 ph3 ph5-ns min-vh-100">
-        <Box
-          bgColor="nsgray"
-          borderColor="nspink"
-          wrapperClassName="center mv4 mw6"
-        >
+        <div className="center mv4 mw6">
           <h1 className="chicagoflf f4 fw4">Upload File</h1>
           <form onSubmit={handleUploadSubmit}>
             <div className="mv3">
@@ -82,52 +68,8 @@ export default function NewFile() {
                 type="file"
                 className="db ba b--black w5 pa2"
                 required
-                onChange={checkCar}
               />
             </div>
-            <label>
-              <input
-                id="is-car"
-                name="is-car"
-                type="checkbox"
-                checked={isCar}
-                readOnly
-              />
-              <span className="ml2">is CAR?</span>
-            </label>
-            <details className="db mt3 mb4">
-              <summary className="i">
-                CAR files supported! What is a CAR?
-              </summary>
-              <p className="pl3 mt3 lh-copy">
-                A CAR is a Content Addressed Archive that allows you to
-                pre-compute the root CID for your assets. You can pack your
-                assets into a CAR with the{' '}
-                <a
-                  className="black"
-                  href="https://github.com/vasco-santos/ipfs-car"
-                  target="_blank"
-                  rel="noreferrer"
-                >
-                  <code>ipfs-car</code>
-                </a>{' '}
-                cli or via{' '}
-                <a
-                  className="black"
-                  href="https://car.ipfs.io"
-                  target="_blank"
-                  rel="noreferrer"
-                >
-                  https://car.ipfs.io
-                </a>
-                .
-              </p>
-              <p className="pl3 mt2 lh-copy">
-                Give your CAR filename the <code>.car</code> extention, and when
-                it&apos;s uploaded to nft.storge your asset will be stored with
-                the exact same root CID as defined in the CAR file.
-              </p>
-            </details>
             <div className="mv3">
               <Button
                 className="bg-nslime"
@@ -135,32 +77,25 @@ export default function NewFile() {
                 disabled={uploading}
                 id="upload-file"
               >
-                {uploading ? 'Uploading...' : 'Upload'}
+                {uploading
+                  ? `Uploading...${percentComplete ? `(${percentComplete}%)` : ''}`
+                  : 'Upload'}
               </Button>
             </div>
             <div>
-              <p className="lh-copy f7">100MB upload limit per file.</p>
               <p className="lh-copy f7">
                 You can also upload files using the{' '}
                 <a href="/#js-client" className="black">
                   JS Client Library
                 </a>
-                ,{' '}
+                {' '}or using{' '}
                 <a href="/#raw-http-request" className="black">
                   Raw HTTP Requests
-                </a>{' '}
-                or via the{' '}
-                <a
-                  href="/#configure-as-a-remote-pinning-service"
-                  className="black"
-                >
-                  Remote Pinning Service API
-                </a>
-                .
+                </a>.
               </p>
             </div>
           </form>
-        </Box>
+        </div>
       </div>
     </main>
   )


### PR DESCRIPTION
* Creates an index of `Upload`s by `user` and `content`
* Fixes `importCar` to check for an existing `Upload` from the user for the given CID and returns that if found
    * This effectively allows split CAR uploads by not creating a new `Upload` object for every chunk of CAR that is uploaded