### PR TITLE
fix: import gql schema before fql indexes

### DIFF
--- a/packages/db/README.md
+++ b/packages/db/README.md
@@ -13,6 +13,8 @@
     npm run import
     ```
 
+Note: the `import` task imports both the GraphQL schema and the FaunaQL functions and Indexes for you. If you run them separately you need to run `import:gql` first to create the Collections **before** running `import:fql` which include references to those Collections.
+
 ## Schema
 
 [![web3.storage schema](https://user-images.githubusercontent.com/152863/124463647-16f0bb00-dd8b-11eb-9a71-d710f5d77078.jpg)](https://user-images.githubusercontent.com/152863/124463647-16f0bb00-dd8b-11eb-9a71-d710f5d77078.jpg)

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -6,9 +6,9 @@
   "main": "index.js",
   "type": "module",
   "scripts": {
-    "import": "npm run import:fql && npm run import:gql",
-    "import:fql": "node tools/import-fql-resources.js",
+    "import": "npm run import:gql && npm run import:fql",
     "import:gql": "node tools/import-graphql-schema.js",
+    "import:fql": "node tools/import-fql-resources.js",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "keywords": [


### PR DESCRIPTION
The FQL refernces Collections that the GQL import step creates, so do `import:gql` first

Fixes #49

License: (Apache-2.0 AND MIT)
Signed-off-by: Oli Evans <oli@tableflip.io>