### PR TITLE
feat: w3 --put /path/to/files

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20906,17 +20906,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "packages/client/node_modules/camelcase": {
-      "version": "6.2.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "packages/client/node_modules/playwright-test": {
       "version": "4.1.0",
       "dev": true,
@@ -20963,17 +20952,6 @@
         "node": ">=0.10.0"
       }
     },
-    "packages/client/node_modules/strip-ansi": {
-      "version": "6.0.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "packages/client/node_modules/v8-to-istanbul": {
       "version": "7.1.2",
       "dev": true,
@@ -21014,13 +20992,17 @@
       "version": "0.0.0",
       "license": "ISC",
       "dependencies": {
+        "err-code": "^3.0.1",
         "ipfs-car": "^0.4.2",
+        "it-glob": "^0.0.13",
         "meow": "^10.0.1"
       },
       "bin": {
         "w3": "bin.js"
       },
-      "devDependencies": {}
+      "devDependencies": {
+        "standard": "^16.0.3"
+      }
     },
     "packages/website": {
       "name": "@web3-storage/website",
@@ -36999,10 +36981,6 @@
           "version": "8.2.2",
           "dev": true
         },
-        "camelcase": {
-          "version": "6.2.0",
-          "dev": true
-        },
         "playwright-test": {
           "version": "4.1.0",
           "dev": true,
@@ -37036,13 +37014,6 @@
         "source-map": {
           "version": "0.6.1",
           "dev": true
-        },
-        "strip-ansi": {
-          "version": "6.0.0",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "^5.0.0"
-          }
         },
         "v8-to-istanbul": {
           "version": "7.1.2",
@@ -37086,8 +37057,11 @@
     "web3.storage-cli": {
       "version": "file:packages/w3",
       "requires": {
+        "err-code": "^3.0.1",
         "ipfs-car": "^0.4.2",
-        "meow": "^10.0.1"
+        "it-glob": "^0.0.13",
+        "meow": "^10.0.1",
+        "standard": "*"
       }
     },
     "webidl-conversions": {

--- a/packages/w3/bin.js
+++ b/packages/w3/bin.js
@@ -12,7 +12,7 @@ const cli = meow(
     flags: {
       api: {
         type: 'string',
-        default: 'https://api-staging.web3.storage'
+        default: 'https://api.web3.storage'
       },
       token: {
         type: 'string',

--- a/packages/w3/bin.js
+++ b/packages/w3/bin.js
@@ -5,15 +5,22 @@ import w3 from './index.js'
 const cli = meow(
   `Usage
     --get bafybeidd2gyhagleh47qeg77xqndy2qy3yzn4vkxmk775bg2t5lpuy7pcu --output pics --api http://127.0.0.1:8787
+    --put /path/to/files
   `,
   {
     importMeta: import.meta,
     flags: {
       api: {
         type: 'string',
-        default: 'https://api.web3.storage'
+        default: 'https://api-staging.web3.storage'
+      },
+      token: {
+        type: 'string',
       },
       get: {
+        type: 'string',
+      },
+      put: {
         type: 'string',
       },
       output: {
@@ -24,7 +31,10 @@ const cli = meow(
   }
 )
 
-if (!cli.flags.get) {
+if (!cli.flags.get && !cli.flags.put) {
+  cli.showHelp()
+}
+if (cli.flags.get && cli.flags.put) {
   cli.showHelp()
 }
 

--- a/packages/w3/index.js
+++ b/packages/w3/index.js
@@ -1,10 +1,23 @@
+import { globSource } from './utils/glob-source.js'
 import { writeFiles } from 'ipfs-car/unpack/fs'
 import { Web3Storage } from 'web3.storage'
 
 export default async function ({ input, flags }) {
-  const client = new Web3Storage({ token: 'test', endpoint: flags.api })
+  const client = new Web3Storage({ token: flags.token, endpoint: flags.api })
   if (flags.get) {
     const res = await client.get(flags.get)
-    writeFiles(res.unixFsIterator(), flags.output)
+    await writeFiles(res.unixFsIterator(), flags.output)
+    return
+  }
+  if (flags.put) {
+    const files = []
+    console.log('')
+    for await (const file of globSource(flags.put)) {
+      console.log(`+ ${file.name}`)
+      files.push(file)
+    }
+    const root = await client.put(files)
+    console.log(`⁂ https://dweb.link/ipfs/${root}`)
+    return
   }
 }

--- a/packages/w3/package.json
+++ b/packages/w3/package.json
@@ -1,7 +1,7 @@
 {
   "name": "web3.storage-cli",
   "version": "0.0.0",
-  "description": "Save your things in web3",
+  "description": "Save your things in web3 ⁂",
   "type": "module",
   "bin": {
     "w3": "bin.js"
@@ -20,9 +20,13 @@
   },
   "homepage": "https://github.com/web3-storage/web3.storage#readme",
   "dependencies": {
+    "err-code": "^3.0.1",
     "ipfs-car": "^0.4.2",
+    "it-glob": "^0.0.13",
     "meow": "^10.0.1"
   },
-  "devDependencies": {},
+  "devDependencies": {
+    "standard": "^16.0.3"
+  },
   "main": "index.js"
 }

--- a/packages/w3/utils/glob-source.js
+++ b/packages/w3/utils/glob-source.js
@@ -1,0 +1,134 @@
+import Path from 'path'
+import { promises as fsp } from 'fs'
+import fs from 'fs'
+import glob from 'it-glob'
+import errCode from 'err-code'
+
+// ported to esm from https://github.com/ipfs/js-ipfs-utils/blob/d7e7bde061ef928d72f34c17d4d6310a7215bd73/src/files/glob-source.js
+// converts path -> name and content -> stream to fit the web3.storage expectation
+
+/**
+ * Create an async iterator that yields paths that match requested file paths.
+ *
+ * @param {Iterable<string> | AsyncIterable<string> | string} paths - File system path(s) to glob from
+ * @param {Object} [options] - Optional options
+ * @param {boolean} [options.hidden] - Include .dot files in matched paths
+ * @param {Array<string>} [options.ignore] - Glob paths to ignore
+ * @param {boolean} [options.followSymlinks] - follow symlinks
+ * @param {boolean} [options.preserveMode] - preserve mode
+ * @param {boolean} [options.preserveMtime] - preserve mtime
+ * @param {number} [options.mode] - mode to use - if preserveMode is true this will be ignored
+ * @param {import('ipfs-unixfs').MtimeLike} [options.mtime] - mtime to use - if preserveMtime is true this will be ignored
+ * @yields {Object} File objects in the form `{ name: String, stream: AsyncIterator<Buffer> }`
+ */
+export async function * globSource (paths, options) {
+  options = options || {}
+
+  if (typeof paths === 'string') {
+    paths = [paths]
+  }
+
+  const globSourceOptions = {
+    recursive: true,
+    glob: {
+      dot: Boolean(options.hidden),
+      ignore: Array.isArray(options.ignore) ? options.ignore : [],
+      follow: options.followSymlinks != null ? options.followSymlinks : true
+    }
+  }
+
+  // Check the input paths comply with options.recursive and convert to glob sources
+  for await (const path of paths) {
+    if (typeof path !== 'string') {
+      throw errCode(
+        new Error('Path must be a string'),
+        'ERR_INVALID_PATH',
+        { path }
+      )
+    }
+
+    const absolutePath = Path.resolve(process.cwd(), path)
+    const stat = await fsp.stat(absolutePath)
+    const prefix = Path.dirname(absolutePath)
+
+    let mode = options.mode
+
+    if (options.preserveMode) {
+      // @ts-ignore
+      mode = stat.mode
+    }
+
+    let mtime = options.mtime
+
+    if (options.preserveMtime) {
+      // @ts-ignore
+      mtime = stat.mtime
+    }
+
+    yield * toGlobSource({
+      path,
+      type: stat.isDirectory() ? 'dir' : 'file',
+      prefix,
+      mode,
+      mtime,
+      preserveMode: options.preserveMode,
+      preserveMtime: options.preserveMtime
+    }, globSourceOptions)
+  }
+}
+
+// @ts-ignore
+async function * toGlobSource ({ path, type, prefix, mode, mtime, preserveMode, preserveMtime }, options) {
+  options = options || {}
+
+  const baseName = Path.basename(path)
+
+  if (type === 'file') {
+    yield {
+      name: `${baseName.replace(prefix, '')}`,
+      stream: () => fs.createReadStream(Path.isAbsolute(path) ? path : Path.join(process.cwd(), path)),
+      mode,
+      mtime
+    }
+
+    return
+  }
+
+  const globOptions = Object.assign({}, options.glob, {
+    cwd: path,
+    nodir: false,
+    realpath: false,
+    absolute: true
+  })
+
+  for await (const p of glob(path, '**/*', globOptions)) {
+    const stat = await fsp.stat(p)
+
+    if (!stat.isFile()) {
+      // skip dirs.
+      continue
+    }
+
+    if (preserveMode || preserveMtime) {
+      if (preserveMode) {
+        mode = stat.mode
+      }
+
+      if (preserveMtime) {
+        mtime = stat.mtime
+      }
+    }
+
+    yield {
+      name: toPosix(p.replace(prefix, '')),
+      stream: () => fs.createReadStream(p),
+      mode,
+      mtime
+    }
+  }
+}
+
+/**
+ * @param {string} path
+ */
+const toPosix = path => path.replace(/\\/g, '/')


### PR DESCRIPTION
adds a `--put` command to `w3`.

```console
$ w3 --put pics --token <your token here... this is temporary>

+ /pics/dr-is-tired.jpg
+ /pics/not-distributed.jpg
+ /pics/youareanonsense.jpg
⁂ https://dweb.link/ipfs/bafybeidd2gyhagleh47qeg77xqndy2qy3yzn4vkxmk775bg2t5lpuy7pcu
```

glob-source is ported from ipfs-utils to be esm and make files in the shape that client.put expects them.

License: (Apache-2.0 AND MIT)
Signed-off-by: Oli Evans <oli@tableflip.io>