### PR TITLE
feat: subcommands for w3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,8 +15,7 @@
         "packages/website"
       ],
       "devDependencies": {
-        "prettier": "^2.3.1",
-        "standard": "^16.0.3"
+        "prettier": "^2.3.1"
       }
     },
     "node_modules/@arr/every": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,8 @@
         "packages/website"
       ],
       "devDependencies": {
-        "prettier": "^2.3.1"
+        "prettier": "^2.3.1",
+        "standard": "^16.0.3"
       }
     },
     "node_modules/@arr/every": {
@@ -6144,6 +6145,7 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-5.0.0.tgz",
       "integrity": "sha512-U75DcT5hrio3KNtvdULAWnLiAPbFUC4191ldxMmj4FA/mRuBnmDwU0boNfPyFRhnan+Jm+haLeSn3P0afcBn4w==",
+      "dev": true,
       "engines": {
         "node": ">=10"
       },
@@ -12062,6 +12064,7 @@
       "version": "10.0.1",
       "resolved": "https://registry.npmjs.org/meow/-/meow-10.0.1.tgz",
       "integrity": "sha512-65vCCdUI8wS5upK24fDFo25FcViNExdTGAR/vaWN4E6fXsWQ8fGdbkjCWp3nDTuJMlIYuEoAEMiB2/b81DBJjg==",
+      "dev": true,
       "dependencies": {
         "@types/minimist": "^1.2.1",
         "camelcase-keys": "^6.2.2",
@@ -12087,6 +12090,7 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
       "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+      "dev": true,
       "dependencies": {
         "locate-path": "^6.0.0",
         "path-exists": "^4.0.0"
@@ -12102,6 +12106,7 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
       "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+      "dev": true,
       "dependencies": {
         "p-locate": "^5.0.0"
       },
@@ -12116,6 +12121,7 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
       "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+      "dev": true,
       "dependencies": {
         "p-limit": "^3.0.2"
       },
@@ -12130,6 +12136,7 @@
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
       "integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
+      "dev": true,
       "dependencies": {
         "@babel/code-frame": "^7.0.0",
         "error-ex": "^1.3.1",
@@ -12147,6 +12154,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
       "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -12155,6 +12163,7 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-6.0.0.tgz",
       "integrity": "sha512-X1Fu3dPuk/8ZLsMhEj5f4wFAF0DWoK7qhGJvgaijocXxBmSToKfbFtqbxMO7bVjNA1dmE5huAzjXj/ey86iw9Q==",
+      "dev": true,
       "dependencies": {
         "@types/normalize-package-data": "^2.4.0",
         "normalize-package-data": "^3.0.2",
@@ -12172,6 +12181,7 @@
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-8.0.0.tgz",
       "integrity": "sha512-snVCqPczksT0HS2EC+SxUndvSzn6LRCwpfSvLrIfR5BKDQQZMaI6jPRC9dYvYFDRAuFEAnkwww8kBBNE/3VvzQ==",
+      "dev": true,
       "dependencies": {
         "find-up": "^5.0.0",
         "read-pkg": "^6.0.0",
@@ -12188,6 +12198,7 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-1.2.1.tgz",
       "integrity": "sha512-SbmIRuXhJs8KTneu77Ecylt9zuqL683tuiLYpTRil4H++eIhqCmx6ko6KAFem9dty8sOdnEiX7j4K1nRE628fQ==",
+      "dev": true,
       "engines": {
         "node": ">=10"
       },
@@ -13429,7 +13440,6 @@
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/mri/-/mri-1.1.6.tgz",
       "integrity": "sha512-oi1b3MfbyGa7FJMP9GmLTttni5JoICpYBRlq+x5V16fZbLsnL9N3wFqqIm/nIG43FjUFkFh9Epzp/kzUGUnJxQ==",
-      "dev": true,
       "engines": {
         "node": ">=4"
       }
@@ -16422,6 +16432,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/redent/-/redent-4.0.0.tgz",
       "integrity": "sha512-tYkDkVVtYkSVhuQ4zBgfvciymHaeuel+zFKXShfDnFP5SyVEP7qo70Rf1jTOTCx3vGNAbnEi/xFkcfQVMIBWag==",
+      "dev": true,
       "dependencies": {
         "indent-string": "^5.0.0",
         "strip-indent": "^4.0.0"
@@ -16437,6 +16448,7 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-5.0.0.tgz",
       "integrity": "sha512-m6FAo/spmsW2Ab2fU35JTYwtOKa2yAwXSwgjSv1TJzh4Mh7mC3lzAOVLBprb72XsTrgkEIsl7YrFNAiDiRhIGg==",
+      "dev": true,
       "engines": {
         "node": ">=12"
       },
@@ -16860,7 +16872,6 @@
       "version": "1.7.4",
       "resolved": "https://registry.npmjs.org/sade/-/sade-1.7.4.tgz",
       "integrity": "sha512-y5yauMD93rX840MwUJr7C1ysLFBgMspsdTo4UVrDg3fXDvtwOyIqykhVAAm6fk/3au77773itJStObgK+LKaiA==",
-      "dev": true,
       "dependencies": {
         "mri": "^1.1.0"
       },
@@ -18928,6 +18939,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-4.0.0.tgz",
       "integrity": "sha512-mnVSV2l+Zv6BLpSD/8V87CW/y9EmmbYzGCIavsnsI6/nwn26DwffM/yztm30Z/I2DY9wdS3vXVCMnHDgZaVNoA==",
+      "dev": true,
       "dependencies": {
         "min-indent": "^1.0.1"
       },
@@ -19551,6 +19563,7 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-4.0.2.tgz",
       "integrity": "sha512-GJtWyq9InR/2HRiLZgpIKv+ufIKrVrvjQWEj7PxAXNc5dwbNJkqhAUoAGgzRmULAnoOM5EIpveYd3J2VeSAIew==",
+      "dev": true,
       "engines": {
         "node": ">=12"
       },
@@ -20868,7 +20881,7 @@
     },
     "packages/client": {
       "name": "web3.storage",
-      "version": "0.0.0",
+      "version": "1.0.0",
       "license": "(Apache-2.0 AND MIT)",
       "dependencies": {
         "@ipld/car": "^3.1.4",
@@ -20995,13 +21008,10 @@
         "err-code": "^3.0.1",
         "ipfs-car": "^0.4.2",
         "it-glob": "^0.0.13",
-        "meow": "^10.0.1"
+        "sade": "^1.7.4"
       },
       "bin": {
         "w3": "bin.js"
-      },
-      "devDependencies": {
-        "standard": "^16.0.3"
       }
     },
     "packages/website": {
@@ -25911,7 +25921,8 @@
     "decamelize": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-5.0.0.tgz",
-      "integrity": "sha512-U75DcT5hrio3KNtvdULAWnLiAPbFUC4191ldxMmj4FA/mRuBnmDwU0boNfPyFRhnan+Jm+haLeSn3P0afcBn4w=="
+      "integrity": "sha512-U75DcT5hrio3KNtvdULAWnLiAPbFUC4191ldxMmj4FA/mRuBnmDwU0boNfPyFRhnan+Jm+haLeSn3P0afcBn4w==",
+      "dev": true
     },
     "decamelize-keys": {
       "version": "1.1.0",
@@ -30513,6 +30524,7 @@
       "version": "10.0.1",
       "resolved": "https://registry.npmjs.org/meow/-/meow-10.0.1.tgz",
       "integrity": "sha512-65vCCdUI8wS5upK24fDFo25FcViNExdTGAR/vaWN4E6fXsWQ8fGdbkjCWp3nDTuJMlIYuEoAEMiB2/b81DBJjg==",
+      "dev": true,
       "requires": {
         "@types/minimist": "^1.2.1",
         "camelcase-keys": "^6.2.2",
@@ -30532,6 +30544,7 @@
           "version": "5.0.0",
           "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
           "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+          "dev": true,
           "requires": {
             "locate-path": "^6.0.0",
             "path-exists": "^4.0.0"
@@ -30541,6 +30554,7 @@
           "version": "6.0.0",
           "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
           "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+          "dev": true,
           "requires": {
             "p-locate": "^5.0.0"
           }
@@ -30549,6 +30563,7 @@
           "version": "5.0.0",
           "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
           "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+          "dev": true,
           "requires": {
             "p-limit": "^3.0.2"
           }
@@ -30557,6 +30572,7 @@
           "version": "5.2.0",
           "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
           "integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
+          "dev": true,
           "requires": {
             "@babel/code-frame": "^7.0.0",
             "error-ex": "^1.3.1",
@@ -30567,12 +30583,14 @@
         "path-exists": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
-          "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w=="
+          "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+          "dev": true
         },
         "read-pkg": {
           "version": "6.0.0",
           "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-6.0.0.tgz",
           "integrity": "sha512-X1Fu3dPuk/8ZLsMhEj5f4wFAF0DWoK7qhGJvgaijocXxBmSToKfbFtqbxMO7bVjNA1dmE5huAzjXj/ey86iw9Q==",
+          "dev": true,
           "requires": {
             "@types/normalize-package-data": "^2.4.0",
             "normalize-package-data": "^3.0.2",
@@ -30584,6 +30602,7 @@
           "version": "8.0.0",
           "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-8.0.0.tgz",
           "integrity": "sha512-snVCqPczksT0HS2EC+SxUndvSzn6LRCwpfSvLrIfR5BKDQQZMaI6jPRC9dYvYFDRAuFEAnkwww8kBBNE/3VvzQ==",
+          "dev": true,
           "requires": {
             "find-up": "^5.0.0",
             "read-pkg": "^6.0.0",
@@ -30593,7 +30612,8 @@
         "type-fest": {
           "version": "1.2.1",
           "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-1.2.1.tgz",
-          "integrity": "sha512-SbmIRuXhJs8KTneu77Ecylt9zuqL683tuiLYpTRil4H++eIhqCmx6ko6KAFem9dty8sOdnEiX7j4K1nRE628fQ=="
+          "integrity": "sha512-SbmIRuXhJs8KTneu77Ecylt9zuqL683tuiLYpTRil4H++eIhqCmx6ko6KAFem9dty8sOdnEiX7j4K1nRE628fQ==",
+          "dev": true
         }
       }
     },
@@ -31608,8 +31628,7 @@
     "mri": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/mri/-/mri-1.1.6.tgz",
-      "integrity": "sha512-oi1b3MfbyGa7FJMP9GmLTttni5JoICpYBRlq+x5V16fZbLsnL9N3wFqqIm/nIG43FjUFkFh9Epzp/kzUGUnJxQ==",
-      "dev": true
+      "integrity": "sha512-oi1b3MfbyGa7FJMP9GmLTttni5JoICpYBRlq+x5V16fZbLsnL9N3wFqqIm/nIG43FjUFkFh9Epzp/kzUGUnJxQ=="
     },
     "ms": {
       "version": "2.1.2",
@@ -33947,6 +33966,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/redent/-/redent-4.0.0.tgz",
       "integrity": "sha512-tYkDkVVtYkSVhuQ4zBgfvciymHaeuel+zFKXShfDnFP5SyVEP7qo70Rf1jTOTCx3vGNAbnEi/xFkcfQVMIBWag==",
+      "dev": true,
       "requires": {
         "indent-string": "^5.0.0",
         "strip-indent": "^4.0.0"
@@ -33955,7 +33975,8 @@
         "indent-string": {
           "version": "5.0.0",
           "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-5.0.0.tgz",
-          "integrity": "sha512-m6FAo/spmsW2Ab2fU35JTYwtOKa2yAwXSwgjSv1TJzh4Mh7mC3lzAOVLBprb72XsTrgkEIsl7YrFNAiDiRhIGg=="
+          "integrity": "sha512-m6FAo/spmsW2Ab2fU35JTYwtOKa2yAwXSwgjSv1TJzh4Mh7mC3lzAOVLBprb72XsTrgkEIsl7YrFNAiDiRhIGg==",
+          "dev": true
         }
       }
     },
@@ -34275,7 +34296,6 @@
       "version": "1.7.4",
       "resolved": "https://registry.npmjs.org/sade/-/sade-1.7.4.tgz",
       "integrity": "sha512-y5yauMD93rX840MwUJr7C1ysLFBgMspsdTo4UVrDg3fXDvtwOyIqykhVAAm6fk/3au77773itJStObgK+LKaiA==",
-      "dev": true,
       "requires": {
         "mri": "^1.1.0"
       }
@@ -35901,6 +35921,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-4.0.0.tgz",
       "integrity": "sha512-mnVSV2l+Zv6BLpSD/8V87CW/y9EmmbYzGCIavsnsI6/nwn26DwffM/yztm30Z/I2DY9wdS3vXVCMnHDgZaVNoA==",
+      "dev": true,
       "requires": {
         "min-indent": "^1.0.1"
       }
@@ -36407,7 +36428,8 @@
     "trim-newlines": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-4.0.2.tgz",
-      "integrity": "sha512-GJtWyq9InR/2HRiLZgpIKv+ufIKrVrvjQWEj7PxAXNc5dwbNJkqhAUoAGgzRmULAnoOM5EIpveYd3J2VeSAIew=="
+      "integrity": "sha512-GJtWyq9InR/2HRiLZgpIKv+ufIKrVrvjQWEj7PxAXNc5dwbNJkqhAUoAGgzRmULAnoOM5EIpveYd3J2VeSAIew==",
+      "dev": true
     },
     "trouter": {
       "version": "2.0.1",
@@ -37060,8 +37082,7 @@
         "err-code": "^3.0.1",
         "ipfs-car": "^0.4.2",
         "it-glob": "^0.0.13",
-        "meow": "^10.0.1",
-        "standard": "*"
+        "sade": "^1.7.4"
       }
     },
     "webidl-conversions": {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "format": "prettier --write '**/*.{js,jsx,ts,tsx}'"
   },
   "devDependencies": {
-    "prettier": "^2.3.1"
+    "prettier": "^2.3.1",
+    "standard": "^16.0.3"
   },
   "prettier": {
     "trailingComma": "es5",

--- a/package.json
+++ b/package.json
@@ -15,8 +15,7 @@
     "format": "prettier --write '**/*.{js,jsx,ts,tsx}'"
   },
   "devDependencies": {
-    "prettier": "^2.3.1",
-    "standard": "^16.0.3"
+    "prettier": "^2.3.1"
   },
   "prettier": {
     "trailingComma": "es5",

--- a/packages/w3/bin.js
+++ b/packages/w3/bin.js
@@ -12,13 +12,13 @@ cli
   .example('get bafkreigh2akiscaildcqabsyg3dfr6chu3fgpregiymsck7e7aqa4s52zy -o room-guardian.jpg')
 
 cli.command('get <cid>')
-  .describe('Get and verify files from web3.storage')
+  .describe('Fetch and verify files from web3.storage')
   .option('-o, --output', 'Write to the output file name')
   .example('get bafkreigh2akiscaildcqabsyg3dfr6chu3fgpregiymsck7e7aqa4s52zy -o room-guardian.jpg')
   .action(get)
 
-cli.command('put <path...>')
-  .describe('Upload files to web3.storage')
+cli.command('put <path>')
+  .describe('Upload a file or directory to web3.storage')
   .action(put)
 
 cli.parse(process.argv)

--- a/packages/w3/bin.js
+++ b/packages/w3/bin.js
@@ -17,7 +17,7 @@ cli.command('get <cid>')
   .example('get bafkreigh2akiscaildcqabsyg3dfr6chu3fgpregiymsck7e7aqa4s52zy -o room-guardian.jpg')
   .action(get)
 
-cli.command('put <path>')
+cli.command('put <path...>')
   .describe('Upload files to web3.storage')
   .action(put)
 

--- a/packages/w3/bin.js
+++ b/packages/w3/bin.js
@@ -1,41 +1,24 @@
 #!/usr/bin/env node
-import meow from 'meow'
-import w3 from './index.js'
 
-const cli = meow(
-  `Usage
-    --get bafybeidd2gyhagleh47qeg77xqndy2qy3yzn4vkxmk775bg2t5lpuy7pcu --output pics --api http://127.0.0.1:8787
-    --put /path/to/files
-  `,
-  {
-    importMeta: import.meta,
-    flags: {
-      api: {
-        type: 'string',
-        default: 'https://api.web3.storage'
-      },
-      token: {
-        type: 'string',
-      },
-      get: {
-        type: 'string',
-      },
-      put: {
-        type: 'string',
-      },
-      output: {
-        type: 'string',
-        alias: 'o',
-      }
-    },
-  }
-)
+import sade from 'sade'
+import { get, put } from './index.js'
 
-if (!cli.flags.get && !cli.flags.put) {
-  cli.showHelp()
-}
-if (cli.flags.get && cli.flags.put) {
-  cli.showHelp()
-}
+const cli = sade('w3')
 
-w3(cli)
+cli
+  .option('--api', 'URL for API to use')
+  .option('--token', 'API token to use')
+  .example('put path/to/files')
+  .example('get bafkreigh2akiscaildcqabsyg3dfr6chu3fgpregiymsck7e7aqa4s52zy -o room-guardian.jpg')
+
+cli.command('get <cid>')
+  .describe('Get and verify files from web3.storage')
+  .option('-o, --output', 'Write to the output file name')
+  .example('get bafkreigh2akiscaildcqabsyg3dfr6chu3fgpregiymsck7e7aqa4s52zy -o room-guardian.jpg')
+  .action(get)
+
+cli.command('put <path>')
+  .describe('Upload files to web3.storage')
+  .action(put)
+
+cli.parse(process.argv)

--- a/packages/w3/index.js
+++ b/packages/w3/index.js
@@ -2,22 +2,20 @@ import { globSource } from './utils/glob-source.js'
 import { writeFiles } from 'ipfs-car/unpack/fs'
 import { Web3Storage } from 'web3.storage'
 
-export default async function ({ input, flags }) {
-  const client = new Web3Storage({ token: flags.token, endpoint: flags.api })
-  if (flags.get) {
-    const res = await client.get(flags.get)
-    await writeFiles(res.unixFsIterator(), flags.output)
-    return
+export async function get (cid, opts) {
+  const client = new Web3Storage({ token: opts.token, endpoint: opts.api })
+  const res = await client.get(cid)
+  await writeFiles(res.unixFsIterator(), opts.output)
+}
+
+export async function put (path, opts) {
+  const client = new Web3Storage({ token: opts.token, endpoint: opts.api })
+  const files = []
+  console.log('')
+  for await (const file of globSource(path)) {
+    console.log(`+ ${file.name}`)
+    files.push(file)
   }
-  if (flags.put) {
-    const files = []
-    console.log('')
-    for await (const file of globSource(flags.put)) {
-      console.log(`+ ${file.name}`)
-      files.push(file)
-    }
-    const root = await client.put(files)
-    console.log(`⁂ https://dweb.link/ipfs/${root}`)
-    return
-  }
+  const root = await client.put(files)
+  console.log(`⁂ https://dweb.link/ipfs/${root}`)
 }

--- a/packages/w3/index.js
+++ b/packages/w3/index.js
@@ -28,7 +28,6 @@ export async function get (cid, opts) {
  * @param {string[]} opts._ additonal paths to add
  */
 export async function put (path, opts) {
-  console.log(opts)
   const client = new Web3Storage({ token: opts.token, endpoint: new URL(opts.api) })
   const spinner = ora('Packing files').start()
   const paths = [path, ...opts._]

--- a/packages/w3/index.js
+++ b/packages/w3/index.js
@@ -1,21 +1,60 @@
 import { globSource } from './utils/glob-source.js'
 import { writeFiles } from 'ipfs-car/unpack/fs'
 import { Web3Storage } from 'web3.storage'
+import ora from 'ora'
 
+/**
+ * Download and verify a file/directory by CID and write it to disk.
+ *
+ * @param {string} cid the root CID to fetch
+ * @param {object} opts
+ * @param {string} [opts.api]
+ * @param {string} [opts.token]
+ * @param {string} [opts.output] the path to write the files to
+ */
 export async function get (cid, opts) {
-  const client = new Web3Storage({ token: opts.token, endpoint: opts.api })
+  const client = new Web3Storage({ token: opts.token, endpoint: new URL(opts.api) })
   const res = await client.get(cid)
   await writeFiles(res.unixFsIterator(), opts.output)
 }
 
+/**
+ * Add 1 or more files/directories to web3.storage
+ *
+ * @param {string} path the first file path to store
+ * @param {object} opts
+ * @param {string} [opts.api]
+ * @param {string} [opts.token]
+ * @param {string[]} opts._ additonal paths to add
+ */
 export async function put (path, opts) {
-  const client = new Web3Storage({ token: opts.token, endpoint: opts.api })
+  console.log(opts)
+  const client = new Web3Storage({ token: opts.token, endpoint: new URL(opts.api) })
+  const spinner = ora('Packing files').start()
+  const paths = [path, ...opts._]
   const files = []
-  console.log('')
-  for await (const file of globSource(path)) {
-    console.log(`+ ${file.name}`)
-    files.push(file)
+  let totalSize = 0
+  let totalSent = 0
+  for (const p of paths) {
+    for await (const file of globSource(p)) {
+      totalSize += file.size
+      files.push(file)
+      spinner.text = `Packing ${files.length} file${files.length === 1 ? '' : 's'}`
+    }
   }
-  const root = await client.put(files)
+  let rootCid = ''
+  const root = await client.put(files, {
+    onRootCidReady: (cid) => {
+      rootCid = cid
+      spinner.stopAndPersist({ symbol: '#', text: `Packed ${files.length} file${files.length === 1 ? '' : 's'}` })
+      console.log(`# ${rootCid}`)
+      spinner.start('Storing')
+    },
+    onStoredChunk: (size) => {
+      totalSent += size
+      spinner.text = `Storing ${Math.round((totalSent / totalSize) * 100)}%`
+    }
+  })
+  spinner.stopAndPersist({ symbol: '⁂', text: `Stored ${files.length} file${files.length === 1 ? '' : 's'}` })
   console.log(`⁂ https://dweb.link/ipfs/${root}`)
 }

--- a/packages/w3/package.json
+++ b/packages/w3/package.json
@@ -23,10 +23,7 @@
     "err-code": "^3.0.1",
     "ipfs-car": "^0.4.2",
     "it-glob": "^0.0.13",
-    "meow": "^10.0.1"
-  },
-  "devDependencies": {
-    "standard": "^16.0.3"
+    "sade": "^1.7.4"
   },
   "main": "index.js"
 }

--- a/packages/w3/utils/glob-source.js
+++ b/packages/w3/utils/glob-source.js
@@ -1,6 +1,6 @@
 import Path from 'path'
-import { promises as fsp } from 'fs'
-import fs from 'fs'
+import fs, { promises as fsp } from 'fs'
+
 import glob from 'it-glob'
 import errCode from 'err-code'
 
@@ -71,6 +71,7 @@ export async function * globSource (paths, options) {
       prefix,
       mode,
       mtime,
+      size: stat.size,
       preserveMode: options.preserveMode,
       preserveMtime: options.preserveMtime
     }, globSourceOptions)
@@ -78,17 +79,18 @@ export async function * globSource (paths, options) {
 }
 
 // @ts-ignore
-async function * toGlobSource ({ path, type, prefix, mode, mtime, preserveMode, preserveMtime }, options) {
+async function * toGlobSource ({ path, type, prefix, mode, mtime, size, preserveMode, preserveMtime }, options) {
   options = options || {}
 
   const baseName = Path.basename(path)
 
   if (type === 'file') {
     yield {
-      name: `${baseName.replace(prefix, '')}`,
+      name: `/${baseName.replace(prefix, '')}`,
       stream: () => fs.createReadStream(Path.isAbsolute(path) ? path : Path.join(process.cwd(), path)),
       mode,
-      mtime
+      mtime,
+      size
     }
 
     return
@@ -123,7 +125,8 @@ async function * toGlobSource ({ path, type, prefix, mode, mtime, preserveMode, 
       name: toPosix(p.replace(prefix, '')),
       stream: () => fs.createReadStream(p),
       mode,
-      mtime
+      mtime,
+      size: stat.size
     }
   }
 }


### PR DESCRIPTION
- `w3 get <cid>` fetch files by cid and verify them
- `w3 put <path>` upload files to web3.storage
- switches `meow` for `sade` for the subcommand support.

**upload in progress**

```console
$ w3 put ~/Desktop/output/week-in-web3-2021-07-02.mov
# Packed 1 file (181.4MB)
# bafybeigzwx5ychvapyslpmgy7hwdwh6nabyapxkjmpmtwwqevv4zpwfauy
⠧ Storing 48%
```

**success ✨**

```console
$ w3 put ~/Desktop/output/week-in-web3-2021-07-02.mov
# Packed 1 file (181.4MB)
# bafybeigzwx5ychvapyslpmgy7hwdwh6nabyapxkjmpmtwwqevv4zpwfauy
⁂ Stored 1 file
⁂ https://dweb.link/ipfs/bafybeigzwx5ychvapyslpmgy7hwdwh6nabyapxkjmpmtwwqevv4zpwfauy
```


License: (Apache-2.0 AND MIT)
Signed-off-by: Oli Evans <oli@tableflip.io>