### PR TITLE
fix!: cid prop on web3file is a string

### DIFF
--- a/packages/client/src/lib.js
+++ b/packages/client/src/lib.js
@@ -234,7 +234,7 @@ async function toWeb3File({content, path, cid}) {
     chunks.push(chunk)
   }
   const file = new File(chunks, toFilenameWithPath(path))
-  return Object.assign(file, { cid })
+  return Object.assign(file, { cid: cid.toString() })
 }
 
 /**

--- a/packages/client/src/lib/interface.ts
+++ b/packages/client/src/lib/interface.ts
@@ -55,7 +55,7 @@ export type PutOptions = {
 }
 
 export interface Web3File extends File {
-  cid: CID,
+  cid: CIDString,
 }
 
 export interface Web3Response extends Response {

--- a/packages/client/test/get.spec.js
+++ b/packages/client/test/get.spec.js
@@ -27,7 +27,7 @@ describe('get', () => {
     const files = await res.files()
     for (const file of files) {
       assert.is(
-        file.cid.toString(),
+        file.cid,
         cid,
         'in a CAR with 1 file, the file name should match the CAR root'
       )
@@ -50,13 +50,13 @@ describe('get', () => {
     const files = await res.files()
     assert.is(files.length, 3, 'should contain 3 files')
     assert.is(files[0].name, 'dr-is-tired.jpg')
-    assert.is(files[0].cid.toString(), 'bafkreiabltrd5zm73pvi7plq25pef3hm7jxhbi3kv4hapegrkfpkqtkbme')
+    assert.is(files[0].cid, 'bafkreiabltrd5zm73pvi7plq25pef3hm7jxhbi3kv4hapegrkfpkqtkbme')
     assert.is(files[0].size, 94482)
     assert.is(files[1].name, 'not-distributed.jpg')
-    assert.is(files[1].cid.toString(), 'bafybeicklkqcnlvtiscr2hzkubjwnwjinvskffn4xorqeduft3wq7vm5u4')
+    assert.is(files[1].cid, 'bafybeicklkqcnlvtiscr2hzkubjwnwjinvskffn4xorqeduft3wq7vm5u4')
     assert.is(files[1].size, 414201)
     assert.is(files[2].name, 'youareanonsense.jpg')
-    assert.is(files[2].cid.toString(), 'bafkreiaqv66m5nd6mwgkk7h5lwqnjzj54s4f7knmnrjhb7ylzqfg2vdo54')
+    assert.is(files[2].cid, 'bafkreiaqv66m5nd6mwgkk7h5lwqnjzj54s4f7knmnrjhb7ylzqfg2vdo54')
     assert.is(files[2].size, 55415)
   })
 


### PR DESCRIPTION
Previously calling `res.files()` on the response from `client.get` would return an array of Files with a `.cid` property that was a CID instance. This PR makes it a string, to be consistent with the our other usages of CID which are all strings. If folks need to upgrade their string CIDs to instances of CID then the `CID.parse(str)` method is the one to use.

A breaking change for the client API! 


License: (Apache-2.0 AND MIT)
Signed-off-by: Oli Evans <oli@tableflip.io>