### PR TITLE
chore: deploy staging db from ci

### DIFF
--- a/.github/workflows/db.yml
+++ b/.github/workflows/db.yml
@@ -17,7 +17,6 @@ jobs:
     name: Deploy Staging DB
     # if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
-    needs: test
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2

--- a/.github/workflows/db.yml
+++ b/.github/workflows/db.yml
@@ -24,7 +24,7 @@ jobs:
         with:
           node-version: 16
       - uses: bahmutov/npm-install@v1
-      - name: Update FuanaDB resources
+      - name: Update FaunaDB resources
         run: npm run import -w packages/db
         env:
           FAUNA_KEY: ${{ secrets.STAGING_FAUNA_KEY }}

--- a/.github/workflows/db.yml
+++ b/.github/workflows/db.yml
@@ -15,7 +15,7 @@ on:
 jobs:
   deploy-staging:
     name: Deploy Staging DB
-    # if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/db.yml
+++ b/.github/workflows/db.yml
@@ -15,7 +15,7 @@ on:
 jobs:
   deploy-staging:
     name: Deploy Staging DB
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    # if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     needs: test
     steps:

--- a/.github/workflows/db.yml
+++ b/.github/workflows/db.yml
@@ -1,0 +1,30 @@
+name: DB
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'packages/db/**'
+      - '.github/workflows/db.yml'
+  pull_request:
+    branches:
+      - main
+    paths:
+      - 'packages/db/**'
+      - '.github/workflows/db.yml'
+jobs:
+  deploy-staging:
+    name: Deploy Staging DB
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    needs: test
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: 16
+      - uses: bahmutov/npm-install@v1
+      - name: Update FuanaDB resources
+        run: npm run import -w packages/db
+        env:
+          FAUNA_KEY: ${{ secrets.STAGING_FAUNA_KEY }}

--- a/.github/workflows/db.yml
+++ b/.github/workflows/db.yml
@@ -6,6 +6,9 @@ on:
     paths:
       - 'packages/db/**'
       - '.github/workflows/db.yml'
+
+  # Nothing to do on PR yet, but having the check appear on the PR serves as a reminder 
+  # that we don't have proper tests for db changes yet, and that merging it will deploy.
   pull_request:
     branches:
       - main


### PR DESCRIPTION
- add db workflow that runs the fauna resource import script when a change is merged to main
- `STAGING_FAUNA_KEY` is added to repo.

License: (Apache-2.0 AND MIT)
Signed-off-by: Oli Evans <oli@tableflip.io>