### PR TITLE
fix: set cors headers on errors

### DIFF
--- a/packages/api/src/cors.js
+++ b/packages/api/src/cors.js
@@ -47,13 +47,22 @@ export function withCorsHeaders (handler) {
    */
   return async (request, ...rest) => {
     const response = await handler(request, ...rest)
-    const origin = request.headers.get('origin')
-    if (origin) {
-      response.headers.set('Access-Control-Allow-Origin', origin)
-      response.headers.set('Vary', 'Origin')
-    } else {
-      response.headers.set('Access-Control-Allow-Origin', '*')
-    }
-    return response
+    return addCorsHeaders(request, response)
   }
+}
+
+/**
+ * @param {Request} request
+ * @param {Response} response
+ * @returns {Response}
+ */
+export function addCorsHeaders (request, response) {
+  const origin = request.headers.get('origin')
+  if (origin) {
+    response.headers.set('Access-Control-Allow-Origin', origin)
+    response.headers.set('Vary', 'Origin')
+  } else {
+    response.headers.set('Access-Control-Allow-Origin', '*')
+  }
+  return response
 }

--- a/packages/api/src/index.js
+++ b/packages/api/src/index.js
@@ -1,6 +1,6 @@
 /* eslint-env serviceworker */
 import { Router } from 'itty-router'
-import { withCorsHeaders, corsOptions } from './cors.js'
+import { addCorsHeaders, withCorsHeaders, corsOptions } from './cors.js'
 import { envAll } from './env.js'
 import { carHead, carGet, carPut, carPost } from './car.js'
 import { userLoginPost, userTokensPost, userTokensGet, userTokensDelete, userUploadsGet, userUploadsDelete, withAuth } from './user.js'
@@ -41,15 +41,19 @@ router.get('/', () => {
   )
 })
 
-router.all('*', () => new JSONResponse({ message: 'Not Found' }, { status: 404 }))
+router.get('/error', () => { throw new Error('A deliberate error!') })
+router.all('*', withCorsHeaders(() => new JSONResponse({ message: 'Not Found' }, { status: 404 })))
 
-function serverError (error) {
+function serverError (request, error) {
   console.error(error.stack)
   const message = error.message || 'Server Error'
   const status = error.status || 500
-  return new JSONResponse({ message }, { status })
+  return addCorsHeaders(request, new JSONResponse({ message }, { status }))
 }
 
 addEventListener('fetch', (event) => {
-  event.respondWith(router.handle(event.request, {}, event).catch(serverError))
+  event.respondWith(router
+    .handle(event.request, {}, event)
+    .catch((e) => serverError(event.request, e))
+  )
 })

--- a/packages/api/test/cors.spec.js
+++ b/packages/api/test/cors.spec.js
@@ -6,8 +6,22 @@ const cid = 'bafkqaaa'
 
 describe('CORS', () => {
   it('sets CORS headers', async () => {
-    const res = await fetch(new URL(`car/${cid}`, endpoint).toString())
+    const res = await fetch(new URL(`car/${cid}`, endpoint))
     assert(res.ok)
+    assert.strictEqual(res.headers.get('Access-Control-Allow-Origin'), '*')
+  })
+
+  it('sets CORS headers on 404', async () => {
+    const res = await fetch(new URL('nope', endpoint))
+    assert(!res.ok)
+    assert.strictEqual(res.status, 404, 'Expected 404 on /nope')
+    assert.strictEqual(res.headers.get('Access-Control-Allow-Origin'), '*')
+  })
+
+  it('sets CORS headers on server error', async () => {
+    const res = await fetch(new URL('error', endpoint))
+    assert(!res.ok)
+    assert.strictEqual(res.status, 500, 'Expected 500 on /error')
     assert.strictEqual(res.headers.get('Access-Control-Allow-Origin'), '*')
   })
 })


### PR DESCRIPTION
Making debugging failures less awkward.

fixes #73

License: (Apache-2.0 AND MIT)
Signed-off-by: Oli Evans <oli@tableflip.io>