### PR TITLE
refactor: allow chunked adding of batch entries

### DIFF
--- a/packages/db/fauna/resources/Function/addBatchEntries.js
+++ b/packages/db/fauna/resources/Function/addBatchEntries.js
@@ -1,0 +1,81 @@
+import fauna from 'faunadb'
+
+const {
+  Function,
+  CreateFunction,
+  Query,
+  Lambda,
+  Let,
+  Select,
+  Var,
+  If,
+  Create,
+  Update,
+  Exists,
+  Foreach,
+  Index,
+  IsEmpty,
+  Abort,
+  Match,
+  Do,
+  Get
+} = fauna
+
+const name = 'addBatchEntries'
+const body = Query(
+  Lambda(
+    ['batchCid', 'entries'],
+    Let(
+      {
+        batchMatch: Match(Index('unique_Batch_cid'), Var('batchCid')),
+        batch: If(
+          IsEmpty(Var('batchMatch')),
+          Abort('batch not found'),
+          Get(Var('batchMatch'))
+        ),
+        batchRef: Select('ref', Var('batch'))
+      },
+      Do(
+        Foreach(
+          Var('entries'),
+          Lambda(
+            'data',
+            Let(
+              {
+                contentMatch: Match(Index('unique_Content_cid'), Select('cid', Var('data'))),
+                content: If(
+                  IsEmpty(Var('contentMatch')),
+                  Abort('missing content CID'),
+                  Get(Var('contentMatch'))
+                ),
+                entryMatch: Match(
+                  Index('batchEntry_by_batch_and_content'),
+                  Var('batchRef'),
+                  Select('ref', Var('content'))
+                )
+              },
+              If(
+                IsEmpty(Var('entryMatch')),
+                Create('BatchEntry', {
+                  data: {
+                    content: Select('ref', Var('content')),
+                    batch: Var('batchRef'),
+                    dataModelSelector: Select('dataModelSelector', Var('data'), null)
+                  }
+                }),
+                null
+              )
+            )
+          )
+        ),
+        Var('batch')
+      )
+    )
+  )
+)
+
+export default If(
+  Exists(Function(name)),
+  Update(Function(name), { name, body }),
+  CreateFunction({ name, body })
+)

--- a/packages/db/fauna/resources/Function/createBatch.js
+++ b/packages/db/fauna/resources/Function/createBatch.js
@@ -5,20 +5,12 @@ const {
   CreateFunction,
   Query,
   Lambda,
-  Let,
   Select,
   Var,
   If,
   Create,
   Update,
   Exists,
-  Foreach,
-  Index,
-  IsEmpty,
-  Abort,
-  Match,
-  Do,
-  Get,
   Now
 } = fauna
 
@@ -26,46 +18,13 @@ const name = 'createBatch'
 const body = Query(
   Lambda(
     ['data'],
-    Let(
-      {
-        batchCid: Select('batchCid', Var('data')),
+    Create('Batch', {
+      data: {
+        cid: Select('batchCid', Var('data')),
         pieceCid: Select('pieceCid', Var('data')),
-        batch: Create('Batch', {
-          data: {
-            cid: Var('batchCid'),
-            pieceCid: Var('pieceCid'),
-            created: Now()
-          }
-        }),
-        batchRef: Select('ref', Var('batch')),
-        entries: Select('entries', Var('data'))
-      },
-      Do(
-        Foreach(
-          Var('entries'),
-          Lambda(
-            'data',
-            Let(
-              {
-                contentMatch: Match(Index('unique_Content_cid'), Select('cid', Var('data')))
-              },
-              If(
-                IsEmpty(Var('contentMatch')),
-                Abort('missing content CID'),
-                Create('BatchEntry', {
-                  data: {
-                    content: Select('ref', Get(Var('contentMatch'))),
-                    batch: Var('batchRef'),
-                    dataModelSelector: Select('dataModelSelector', Var('data'), null)
-                  }
-                })
-              )
-            )
-          )
-        ),
-        Get(Var('batchRef'))
-      )
-    )
+        created: Now()
+      }
+    })
   )
 )
 

--- a/packages/db/fauna/resources/Index/batchEntryByBatchAndContent.js
+++ b/packages/db/fauna/resources/Index/batchEntryByBatchAndContent.js
@@ -1,0 +1,35 @@
+import fauna from 'faunadb'
+
+const {
+  CreateIndex,
+  Collection,
+  If,
+  Index,
+  Exists,
+  Not
+} = fauna
+
+/**
+ * Usage:
+ *
+ * Match(
+ *   Index('batchEntry_by_batch_and_content'),
+ *   Ref(Collection('Batch'), Var('batchId')),
+ *   Ref(Collection('Content'), Var('contentId'))
+ * )
+ */
+const index = {
+  name: 'batchEntry_by_batch_and_content',
+  source: Collection('BatchEntry'),
+  terms: [
+    { field: ['data', 'batch'] },
+    { field: ['data', 'content'] }
+  ]
+}
+
+// indexes cannot be updated
+export default If(
+  Not(Exists(Index(index.name))),
+  CreateIndex(index),
+  Index(index.name)
+)

--- a/packages/db/fauna/schema.graphql
+++ b/packages/db/fauna/schema.graphql
@@ -322,13 +322,16 @@ type Mutation {
   deleteAuthToken(user: ID!, authToken: ID!): AuthToken! @resolver
   deleteUserUpload(user: ID!, cid: String!): Upload! @resolver
   createBatch(data: CreateBatchInput!): Batch! @resolver
+  """
+  Adds new entries to the batch, existing entries are ignored.
+  """
+  addBatchEntries(batchCid: String!, entries: [BatchEntryInput!]!): Batch! @resolver
   createOrUpdateDeal(data: CreateOrUpdateDealInput!): Deal! @resolver
 }
 
 input CreateBatchInput {
   batchCid: String!
   pieceCid: String!
-  entries: [BatchEntryInput!]!
 }
 
 input BatchEntryInput {


### PR DESCRIPTION
The max payload for Fauna is around 10MB, but even then the query backing this operation can only deal with around 10,000 entries before it throws "An internal server error occurred. Please contact Fauna support.".

This PR splits the `createBatch` call into two: 1) `createBatch` and 2) `addEntries`, so that a batch can be created and then entries can be added to the batch. The `createBatch` method no longer takes a list of entries.

You use it like this now:

```gql
# Create a new batch
mutation {
  createBatch(data: { batchCid: "bafybatch", pieceCid: "baga" }) {
    # returns a Batch object
    _id
  }
}

# Adds new entries to the batch, existing entries are ignored.
# Call it multiple times, call it with the same entries, nothing goes wrong.
mutation {
  addBatchEntries(
    batchCid: "bafybatch",
    entries: [{ cid: "QmFile", dataModelSelector: "Links/0/Hash" }]
  ) {
    # returns a Batch object also
    _id
  }
}
```