### PR TITLE
feat: add timestamps to /status/:cid response

### DIFF
--- a/packages/api/README.md
+++ b/packages/api/README.md
@@ -82,6 +82,16 @@ date: Mon, 14 Jun 2021 08:30:56 GMT
 content-length: 564692
 ```
 
-### `GET /root/:cid/deals`
+### `GET /status/:cid`
 
-Get filecoin deals info. (_TBD_) We need to define what info we want here to find the right status.
+Get pinning status and filecoin deals info for a CID.
+
+```console
+$ curl 'http://127.0.0.1:8787/status/bafybeidwfngv7n5y7ydbzotrwl3gohgr2lv2g7vn6xggwcjzrf5emknrki' -s | jq
+{
+  "cid": "bafybeidwfngv7n5y7ydbzotrwl3gohgr2lv2g7vn6xggwcjzrf5emknrki",
+  "created": "2021-07-14T19:55:49.409306Z",
+  "dagSize": null,
+  "pins": [],
+  "deals": []
+}

--- a/packages/api/src/status.js
+++ b/packages/api/src/status.js
@@ -62,15 +62,15 @@ export async function statusGet (request, env) {
     }
   `, { cid })
 
-  if (!result.findContentByCid) {
+  const { findContentByCid: raw } = result
+
+  if (!raw) {
     return notFound()
   }
 
-  const { findContentByCid: raw } = result
-
   const pins = raw.pins.data
     .filter(({ status }) => PIN_STATUS.has(status))
-    .map(({ status, location }) => ({ status, ...location }))
+    .map(({ status, updated, location }) => ({ status, updated, ...location }))
 
   const deals = raw.batchEntries.data.map(({ dataModelSelector, batch }) => {
     const { pieceCid, cid: dataCid, deals } = batch
@@ -84,14 +84,16 @@ export async function statusGet (request, env) {
     }
     return deals.data
       .filter(({ status }) => DEAL_STATUS.has(status))
-      .map(({ chainDealId: dealId, miner, activation, status }) => ({
+      .map(({ chainDealId: dealId, miner, status, activation, created, updated }) => ({
         dealId,
         miner,
         status,
-        activation,
         pieceCid,
         dataCid,
-        dataModelSelector
+        dataModelSelector,
+        activation,
+        created,
+        updated
       }))
   }).reduce((a, b) => a.concat(b), []) // flatten array of arrays.
 

--- a/packages/api/src/status.js
+++ b/packages/api/src/status.js
@@ -94,7 +94,7 @@ export async function statusGet (request, env) {
         dataModelSelector
       }))
   }).reduce((a, b) => a.concat(b), []) // flatten array of arrays.
-  
+
   const { dagSize, created } = raw
 
   const status = {

--- a/packages/api/test/fixtures/find-content-by-cid-no-batch.json
+++ b/packages/api/test/fixtures/find-content-by-cid-no-batch.json
@@ -1,6 +1,7 @@
 {
   "data": {
     "findContentByCid": {
+      "created": "2021-07-14T19:27:14.934572Z",
       "dagSize": 101,
       "batchEntries": {
         "data": []
@@ -8,13 +9,14 @@
       "pins": {
         "data": [{
           "status": "Pinned",
+          "updated": "2021-07-14T19:27:14.934572Z",
           "location": {
             "peerId": "12D3KooWR1Js",
             "peerName": "who?",
             "region": "where?"
           }
         }]
-      }
+      }  
     }
   }
 }

--- a/packages/api/test/fixtures/find-content-by-cid-no-deal.json
+++ b/packages/api/test/fixtures/find-content-by-cid-no-deal.json
@@ -1,6 +1,7 @@
 {
   "data": {
     "findContentByCid": {
+      "created": "2021-07-14T19:27:14.934572Z",
       "dagSize": 101,
       "batchEntries": {
         "data": [{
@@ -17,6 +18,7 @@
       "pins": {
         "data": [{
           "status": "Pinned",
+          "updated": "2021-07-14T19:27:14.934572Z",
           "location": {
             "peerId": "12D3KooWR1Js",
             "peerName": "who?",

--- a/packages/api/test/fixtures/find-content-by-cid-unknown.json
+++ b/packages/api/test/fixtures/find-content-by-cid-unknown.json
@@ -1,13 +1,5 @@
 {
   "data": {
-    "findContentByCid": {
-      "dagSize": null,
-      "batchEntries": {
-        "data": []
-      },
-      "pins": {
-        "data": []
-      }
-    }
+    "findContentByCid": null
   }
 }

--- a/packages/api/test/fixtures/find-content-by-cid.json
+++ b/packages/api/test/fixtures/find-content-by-cid.json
@@ -1,34 +1,36 @@
 {
-  "data": {
-    "findContentByCid": {
-      "dagSize": 101,
-      "batchEntries": {
-        "data": [{
-          "dataModelSelector": "Links/0/Links",
-          "batch": {
-            "cid": "bafy",
-            "pieceCid": "baga",
-            "deals": {
-              "data" : [ {
-                "miner": "f99",
-                "chainDealId": 12345,
-                "activation": "<iso timestamp>",
-                "status": "Active"
-              }]
-            }
+  "findContentByCid": {
+    "created": "2021-07-14T19:27:14.934572Z",
+    "dagSize": 101,
+    "batchEntries": {
+      "data": [{
+        "dataModelSelector": "Links/0/Links",
+        "batch": {
+          "cid": "bafy",
+          "pieceCid": "baga",
+          "deals": {
+            "data" : [ {
+              "miner": "f99",
+              "chainDealId": 12345,
+              "status": "Active",
+              "activation": "<iso timestamp>",
+              "created": "2021-07-14T19:27:14.934572Z",
+              "updated": "2021-07-14T19:27:14.934572Z"
+            }]
           }
-        }]
-      },
-      "pins": {
-        "data": [{
-          "status": "Pinned",
-          "location": {
-            "peerId": "12D3KooWR1Js",
-            "peerName": "who?",
-            "region": "where?"
-          }
-        }]
-      }
+        }
+      }]
+    },
+    "pins": {
+      "data": [{
+        "status": "Pinned",
+        "updated": "2021-07-14T19:27:14.934572Z",
+        "location": {
+          "peerId": "12D3KooWR1Js",
+          "peerName": "who?",
+          "region": "where?"
+        }
+      }]
     }
   }
 }

--- a/packages/api/test/fixtures/find-content-by-cid.json
+++ b/packages/api/test/fixtures/find-content-by-cid.json
@@ -1,36 +1,38 @@
 {
-  "findContentByCid": {
-    "created": "2021-07-14T19:27:14.934572Z",
-    "dagSize": 101,
-    "batchEntries": {
-      "data": [{
-        "dataModelSelector": "Links/0/Links",
-        "batch": {
-          "cid": "bafy",
-          "pieceCid": "baga",
-          "deals": {
-            "data" : [ {
-              "miner": "f99",
-              "chainDealId": 12345,
-              "status": "Active",
-              "activation": "<iso timestamp>",
-              "created": "2021-07-14T19:27:14.934572Z",
-              "updated": "2021-07-14T19:27:14.934572Z"
-            }]
+  "data": {
+    "findContentByCid": {
+      "created": "2021-07-14T19:27:14.934572Z",
+      "dagSize": 101,
+      "batchEntries": {
+        "data": [{
+          "dataModelSelector": "Links/0/Links",
+          "batch": {
+            "cid": "bafy",
+            "pieceCid": "baga",
+            "deals": {
+              "data" : [ {
+                "miner": "f99",
+                "chainDealId": 12345,
+                "status": "Active",
+                "activation": "<iso timestamp>",
+                "created": "2021-07-14T19:27:14.934572Z",
+                "updated": "2021-07-14T19:27:14.934572Z"
+              }]
+            }
           }
-        }
-      }]
-    },
-    "pins": {
-      "data": [{
-        "status": "Pinned",
-        "updated": "2021-07-14T19:27:14.934572Z",
-        "location": {
-          "peerId": "12D3KooWR1Js",
-          "peerName": "who?",
-          "region": "where?"
-        }
-      }]
+        }]
+      },
+      "pins": {
+        "data": [{
+          "status": "Pinned",
+          "updated": "2021-07-14T19:27:14.934572Z",
+          "location": {
+            "peerId": "12D3KooWR1Js",
+            "peerName": "who?",
+            "region": "where?"
+          }
+        }]
+      }
     }
   }
 }

--- a/packages/api/test/fixtures/status.json
+++ b/packages/api/test/fixtures/status.json
@@ -1,5 +1,6 @@
 {
   "cid": "testcid",
+  "created": "2021-07-14T19:27:14.934572Z",
   "dagSize": 101,
   "pins": [{
     "peerId": "12D3KooWR1Js",
@@ -11,9 +12,11 @@
     "dealId": 12345,
     "miner": "f99",
     "status": "Active",
-    "activation": "<iso timestamp>",
     "pieceCid": "baga",
     "dataCid": "bafy",
-    "dataModelSelector": "Links/0/Links"
+    "dataModelSelector": "Links/0/Links",
+    "activation": "<iso timestamp>",
+    "created": "2021-07-14T19:27:14.934572Z",
+    "updated": "2021-07-14T19:27:14.934572Z"
   }]
 }

--- a/packages/api/test/mocks/db/post_graphql.js
+++ b/packages/api/test/mocks/db/post_graphql.js
@@ -51,16 +51,18 @@ module.exports = ({ body }) => {
   }
 
   if (body.query.includes('findContentByCid')) {
+    console.log(body.query)
+    console.log(body.variables.cid)
     if (body.variables.cid === 'unknown') {
-      return gqlOkResponse(require('../../fixtures/find-content-by-cid-unknown.json'))
+      return gqlResponse(200, require('../../fixtures/find-content-by-cid-unknown.json'))
     }
     if (body.variables.cid === 'nobatch') {
-      return gqlOkResponse(require('../../fixtures/find-content-by-cid-no-batch.json'))
+      return gqlResponse(200, require('../../fixtures/find-content-by-cid-no-batch.json'))
     }
     if (body.variables.cid === 'nodeal') {
-      return gqlOkResponse(require('../../fixtures/find-content-by-cid-no-deal.json'))
+      return gqlResponse(200, require('../../fixtures/find-content-by-cid-no-deal.json'))
     }
-    return gqlOkResponse(require('../../fixtures/find-content-by-cid.json'))
+    return gqlResponse(200, (require('../../fixtures/find-content-by-cid.json'))
   }
 
   return gqlResponse(400, {

--- a/packages/api/test/mocks/db/post_graphql.js
+++ b/packages/api/test/mocks/db/post_graphql.js
@@ -51,8 +51,6 @@ module.exports = ({ body }) => {
   }
 
   if (body.query.includes('findContentByCid')) {
-    console.log(body.query)
-    console.log(body.variables.cid)
     if (body.variables.cid === 'unknown') {
       return gqlResponse(200, require('../../fixtures/find-content-by-cid-unknown.json'))
     }
@@ -62,7 +60,7 @@ module.exports = ({ body }) => {
     if (body.variables.cid === 'nodeal') {
       return gqlResponse(200, require('../../fixtures/find-content-by-cid-no-deal.json'))
     }
-    return gqlResponse(200, (require('../../fixtures/find-content-by-cid.json'))
+    return gqlResponse(200, require('../../fixtures/find-content-by-cid.json'))
   }
 
   return gqlResponse(400, {

--- a/packages/api/test/status.spec.js
+++ b/packages/api/test/status.spec.js
@@ -6,7 +6,8 @@ describe('GET /status/:cid', () => {
   it('get pin and deal status', async () => {
     const cid = 'testcid'
     const res = await fetch(new URL(`status/${cid}`, endpoint))
-    assert(res.ok, 'http response should be ok')
+    console.error(res)
+    assert(res.ok, `${JSON.stringify(res)}`)
     const json = await res.json()
     assert.deepStrictEqual(json, {
       cid: 'testcid',
@@ -46,7 +47,8 @@ describe('GET /status/:cid', () => {
         peerId: '12D3KooWR1Js',
         peerName: 'who?',
         region: 'where?',
-        status: 'Pinned'
+        status: 'Pinned',
+        updated: '2021-07-14T19:27:14.934572Z'
       }],
       deals: [{
         status: 'Queued',
@@ -70,7 +72,8 @@ describe('GET /status/:cid', () => {
         peerId: '12D3KooWR1Js',
         peerName: 'who?',
         region: 'where?',
-        status: 'Pinned'
+        status: 'Pinned',
+        updated: '2021-07-14T19:27:14.934572Z'
       }],
       deals: []
     })

--- a/packages/api/test/status.spec.js
+++ b/packages/api/test/status.spec.js
@@ -6,25 +6,29 @@ describe('GET /status/:cid', () => {
   it('get pin and deal status', async () => {
     const cid = 'testcid'
     const res = await fetch(new URL(`status/${cid}`, endpoint))
-    assert(res.ok)
+    assert(res.ok, 'http response should be ok')
     const json = await res.json()
     assert.deepStrictEqual(json, {
       cid: 'testcid',
+      created: "2021-07-14T19:27:14.934572Z",
       dagSize: 101,
       pins: [{
         peerId: '12D3KooWR1Js',
         peerName: 'who?',
         region: 'where?',
-        status: 'Pinned'
+        status: 'Pinned',
+        updated: "2021-07-14T19:27:14.934572Z"
       }],
       deals: [{
         dealId: 12345,
         miner: 'f99',
         status: 'Active',
-        activation: '<iso timestamp>',
         pieceCid: 'baga',
         dataCid: 'bafy',
-        dataModelSelector: 'Links/0/Links'
+        dataModelSelector: 'Links/0/Links',
+        activation: '<iso timestamp>',
+        created: "2021-07-14T19:27:14.934572Z",
+        updated: "2021-07-14T19:27:14.934572Z"
       }]
     })
   })
@@ -36,6 +40,7 @@ describe('GET /status/:cid', () => {
     const json = await res.json()
     assert.deepStrictEqual(json, {
       cid,
+      created: "2021-07-14T19:27:14.934572Z",
       dagSize: 101,
       pins: [{
         peerId: '12D3KooWR1Js',
@@ -59,6 +64,7 @@ describe('GET /status/:cid', () => {
     const json = await res.json()
     assert.deepStrictEqual(json, {
       cid,
+      created: "2021-07-14T19:27:14.934572Z",
       dagSize: 101,
       pins: [{
         peerId: '12D3KooWR1Js',

--- a/packages/api/test/status.spec.js
+++ b/packages/api/test/status.spec.js
@@ -10,14 +10,14 @@ describe('GET /status/:cid', () => {
     const json = await res.json()
     assert.deepStrictEqual(json, {
       cid: 'testcid',
-      created: "2021-07-14T19:27:14.934572Z",
+      created: '2021-07-14T19:27:14.934572Z',
       dagSize: 101,
       pins: [{
         peerId: '12D3KooWR1Js',
         peerName: 'who?',
         region: 'where?',
         status: 'Pinned',
-        updated: "2021-07-14T19:27:14.934572Z"
+        updated: '2021-07-14T19:27:14.934572Z'
       }],
       deals: [{
         dealId: 12345,
@@ -27,8 +27,8 @@ describe('GET /status/:cid', () => {
         dataCid: 'bafy',
         dataModelSelector: 'Links/0/Links',
         activation: '<iso timestamp>',
-        created: "2021-07-14T19:27:14.934572Z",
-        updated: "2021-07-14T19:27:14.934572Z"
+        created: '2021-07-14T19:27:14.934572Z',
+        updated: '2021-07-14T19:27:14.934572Z'
       }]
     })
   })
@@ -40,7 +40,7 @@ describe('GET /status/:cid', () => {
     const json = await res.json()
     assert.deepStrictEqual(json, {
       cid,
-      created: "2021-07-14T19:27:14.934572Z",
+      created: '2021-07-14T19:27:14.934572Z',
       dagSize: 101,
       pins: [{
         peerId: '12D3KooWR1Js',
@@ -64,7 +64,7 @@ describe('GET /status/:cid', () => {
     const json = await res.json()
     assert.deepStrictEqual(json, {
       cid,
-      created: "2021-07-14T19:27:14.934572Z",
+      created: '2021-07-14T19:27:14.934572Z',
       dagSize: 101,
       pins: [{
         peerId: '12D3KooWR1Js',

--- a/packages/api/test/status.spec.js
+++ b/packages/api/test/status.spec.js
@@ -6,7 +6,6 @@ describe('GET /status/:cid', () => {
   it('get pin and deal status', async () => {
     const cid = 'testcid'
     const res = await fetch(new URL(`status/${cid}`, endpoint))
-    console.error(res)
     assert(res.ok, `${JSON.stringify(res)}`)
     const json = await res.json()
     assert.deepStrictEqual(json, {


### PR DESCRIPTION
- add `created` denoting when we first saw this content
- add `pins.updated` for when the pin status last changed
- add `deals.created` and `deals.updated` to the filecoin deal status
- updated tests and docs
- fix 404 logic

fixes https://github.com/web3-storage/web3.storage/issues/78#issuecomment-880065131

**Example status response**

```json
{
  "cid": "testcid",
  "created": "2021-07-14T19:27:14.934572Z",
  "dagSize": 101,
  "pins": [{
    "peerId": "12D3KooWR1Js",
    "peerName": "who?",
    "region": "where?",
    "status": "Pinned",
    "created": "2021-07-14T19:27:14.934572Z",
  }],
  "deals": [{
    "dealId": 12345,
    "miner": "f99",
    "status": "Active",
    "pieceCid": "baga",
    "dataCid": "bafy",
    "dataModelSelector": "Links/0/Links",
    "activation": "<iso timestamp>",
    "created": "2021-07-14T19:27:14.934572Z",
    "updated": "2021-07-14T19:27:14.934572Z"
  }]
}
```

License: (Apache-2.0 AND MIT)
Signed-off-by: Oli Evans <oli@tableflip.io>