### PR TITLE
fix: switch dagSize type to Long

### DIFF
--- a/packages/api/src/car.js
+++ b/packages/api/src/car.js
@@ -24,7 +24,7 @@ const IMPORT_CAR = gql`
 `
 
 const UPDATE_DAG_SIZE = gql`
-  mutation UpdateContentDagSize($content: ID!, $dagSize: Int!) {
+  mutation UpdateContentDagSize($content: ID!, $dagSize: Long!) {
     updateContentDagSize(content: $content, dagSize: $dagSize) {
       _id
     }

--- a/packages/cron/src/jobs/pins.js
+++ b/packages/cron/src/jobs/pins.js
@@ -33,7 +33,7 @@ const CREATE_OR_UPDATE_PIN = gql`
 `
 
 const UPDATE_CONTENT_DAG_SIZE = gql`
-  mutation UpdateContentDagSize($content: ID!, $dagSize: Int!) {
+  mutation UpdateContentDagSize($content: ID!, $dagSize: Long!) {
     updateContentDagSize(content: $content, dagSize: $dagSize) {
       _id
     }

--- a/packages/db/fauna/schema.graphql
+++ b/packages/db/fauna/schema.graphql
@@ -87,7 +87,7 @@ type Content {
   Size of the DAG in bytes. Set if known on upload or for partials is set when
   content is fully pinned in at least one location.
   """
-  dagSize: Int
+  dagSize: Long
 
   """
   Creation date.
@@ -269,7 +269,7 @@ type Deal {
   """
   Identifier for the deal stored on chain.
   """
-  dealId: Int! @unique
+  dealId: Long! @unique
 
   """
   Time when deal will be active.
@@ -339,16 +339,16 @@ type Mutation {
   Creates a new pin object (and location) or updates an existing pin object.
   """
   createOrUpdatePin(data: CreateOrUpdatePinInput): Pin! @resolver
-  updateContentDagSize(content: ID!, dagSize: Int!): Content! @resolver
+  updateContentDagSize(content: ID!, dagSize: Long!): Content! @resolver
 }
 
 type Metrics {
   usersTotal: Int!
   uploadsTotal: Int!
   contentTotal: Int!
-  contentTotalBytes: Int!
+  contentTotalBytes: Long!
   pinsTotal: Int!
-  pinsTotalBytes: Int!
+  pinsTotalBytes: Long!
   pinsQueuedTotal: Int!
   pinsPinningTotal: Int!
   pinsPinnedTotal: Int!
@@ -371,7 +371,7 @@ input CreateOrUpdateDealInput {
   """
   dataCid: String
   miner: String
-  dealId: Int!
+  dealId: Long!
   activation: Time
   renewal: Time
   status: DealStatus!
@@ -403,7 +403,7 @@ input ImportCarInput {
   authToken: ID
   cid: String!
   name: String
-  dagSize: Int
+  dagSize: Long
   pins: [PinInput!]!
 }
 


### PR DESCRIPTION
Turns out `Int` is an 32bit integer not 64bit https://docs.fauna.com/fauna/current/api/graphql/#supported-scalar-types

This PR switches to using `Long`.