### PR TITLE
feat: mock deals script

### DIFF
--- a/packages/api/scripts/add-mock-deals.js
+++ b/packages/api/scripts/add-mock-deals.js
@@ -1,0 +1,141 @@
+/**
+ * Add some mock deals to your database for your existing content.
+ *
+ * Usage:
+ *     FAUNA_KEY=<SECRET> node add-mock-deals.js
+ */
+import { DBClient, gql } from '@web3-storage/db'
+import { CID } from 'multiformats/cid'
+import { sha256 } from 'multiformats/hashes/sha2'
+import * as pb from '@ipld/dag-pb'
+import crypto from 'crypto'
+
+const FIND_UPLOADS = gql`
+  query FindUploads($cursor: String, $size: Int) {
+    findUploadsCreatedAfter(since: "2021-06-01T00:00:00.000Z", _size: $size, _cursor: $cursor) {
+      data {
+        content {
+          cid
+        }
+      }
+      after
+    }
+  }
+`
+
+const CREATE_AGGREGATE = gql`
+  mutation CreateAggregate($data: CreateAggregateInput!) {
+    createAggregate(data: $data) {
+      _id
+    }
+  }
+`
+
+const ADD_AGGREGATE_ENTRIES = gql`
+  mutation AddAggregateEntries($dataCid: String!, $entries: [AggregateEntryInput!]!) {
+    addAggregateEntries(dataCid: $dataCid, entries: $entries) {
+      _id
+    }
+  }
+`
+
+const CREATE_DEAL = gql`
+  mutation CreateDeal($data: CreateOrUpdateDealInput!) {
+    createOrUpdateDeal(data: $data) {
+      _id
+    }
+  }
+`
+
+/**
+ * The maximum is exclusive and the minimum is inclusive.
+ * @param {number} min
+ * @param {number} max
+ * @returns {number}
+ */
+function randomInt (min, max) {
+  min = Math.ceil(min)
+  max = Math.floor(max)
+  return Math.floor(Math.random() * (max - min) + min)
+}
+
+/**
+ * @param {number} code
+ * @returns {Promise<string>}
+ */
+async function randomCid (code) {
+  const bytes = crypto.randomBytes(10)
+  const hash = await sha256.digest(bytes)
+  return CID.create(1, code, hash).toString()
+}
+
+async function mockAggregate () {
+  const dataCid = await randomCid(pb.code)
+  const pieceCid = await randomCid(0xf101)
+  return { dataCid, pieceCid }
+}
+
+/**
+ * @param {string} cid Content CID
+ */
+function mockAggregateEntry (cid) {
+  return { cid, dataModelSelector: `Links/${randomInt(0, 3)}/Links/${randomInt(0, 3)}` }
+}
+
+/**
+ * @param {string} dataCid
+ */
+function mockDeal (dataCid) {
+  const status = ['Queued', 'Published', 'Active'][randomInt(0, 3)]
+  const miner = `f0${randomInt(1000, 100000)}`
+  const dealId = randomInt(1000, 1000000)
+
+  if (status === 'Queued') {
+    return null
+  }
+
+  if (status === 'Published') {
+    const activation = new Date(Date.now() + randomInt(0, 5000000))
+    const renewal = new Date(activation.getTime() + randomInt(0, 5000000))
+    return { dataCid, miner, dealId, activation: activation.toISOString(), renewal: renewal.toISOString(), status }
+  }
+
+  const activation = new Date(Date.now() - randomInt(0, 5000000))
+  const renewal = new Date(Date.now() + randomInt(0, 5000000))
+  return { dataCid, miner, dealId, activation: activation.toISOString(), renewal: renewal.toISOString(), status }
+}
+
+async function main () {
+  const { FAUNA_KEY } = process.env
+  if (!FAUNA_KEY) throw new Error('missing FAUNA_KEY environment variable')
+
+  const db = new DBClient({ token: FAUNA_KEY })
+
+  let cursor = null
+  while (true) {
+    const size = randomInt(1, 5)
+    const { findUploadsCreatedAfter: page } = await db.query(FIND_UPLOADS, { cursor, size })
+    const aggregate = await mockAggregate()
+    console.log('🗃 Creating aggregate', aggregate)
+    await db.query(CREATE_AGGREGATE, { data: aggregate })
+
+    const entries = page.data.map(({ content }) => mockAggregateEntry(content.cid))
+    console.log('📜 Creating aggregate entries', { dataCid: aggregate.dataCid, entries })
+    await db.query(ADD_AGGREGATE_ENTRIES, { dataCid: aggregate.dataCid, entries })
+
+    const deal = mockDeal(aggregate.dataCid)
+    if (deal) {
+      console.log('🤝 Creating deal', deal)
+      await db.query(CREATE_DEAL, { data: deal })
+    } else {
+      console.log('⏩ Skipping creating deal')
+    }
+
+    if (!page.after) break
+    cursor = page.after
+  }
+
+  console.log('✅ Done')
+}
+
+main()


### PR DESCRIPTION
This adds a script for creating some mock deals in your local development database for content you've already added.

Make sure your database is up to date first by running `npm run import` in the `packages/db` directory.

It's safe to run multiple times to get more deals for your data.

Sample script output:

<img width="540" alt="Screenshot 2021-07-21 at 15 45 09" src="https://user-images.githubusercontent.com/152863/126511671-2b68d198-2dcc-4165-889d-4f7ab23b4022.png">

After the script has run you should be able to see deals for your CIDs e.g.

<img width="844" alt="Screenshot 2021-07-21 at 16 03 53" src="https://user-images.githubusercontent.com/152863/126511973-4a6f89b3-3d62-4e02-9d83-cee7c2ef74f3.png">

<img width="858" alt="Screenshot 2021-07-21 at 16 03 43" src="https://user-images.githubusercontent.com/152863/126511982-41ba3836-f673-4ba2-bb12-87d6f97dc345.png">

