### PR TITLE
refactor: rename miner to storage provider

### DIFF
--- a/packages/api/scripts/add-mock-deals.js
+++ b/packages/api/scripts/add-mock-deals.js
@@ -87,7 +87,7 @@ function mockAggregateEntry (cid) {
  */
 function mockDeal (dataCid) {
   const status = ['Queued', 'Published', 'Active'][randomInt(0, 3)]
-  const miner = `f0${randomInt(1000, 100000)}`
+  const storageProvider = `f0${randomInt(1000, 100000)}`
   const dealId = randomInt(1000, 1000000)
 
   if (status === 'Queued') {
@@ -97,12 +97,12 @@ function mockDeal (dataCid) {
   if (status === 'Published') {
     const activation = new Date(Date.now() + randomInt(0, 5000000))
     const renewal = new Date(activation.getTime() + randomInt(0, 5000000))
-    return { dataCid, miner, dealId, activation: activation.toISOString(), renewal: renewal.toISOString(), status }
+    return { dataCid, storageProvider, dealId, activation: activation.toISOString(), renewal: renewal.toISOString(), status }
   }
 
   const activation = new Date(Date.now() - randomInt(0, 5000000))
   const renewal = new Date(Date.now() + randomInt(0, 5000000))
-  return { dataCid, miner, dealId, activation: activation.toISOString(), renewal: renewal.toISOString(), status }
+  return { dataCid, storageProvider, dealId, activation: activation.toISOString(), renewal: renewal.toISOString(), status }
 }
 
 async function main () {

--- a/packages/api/src/status.js
+++ b/packages/api/src/status.js
@@ -36,7 +36,7 @@ export async function statusGet (request, env) {
               pieceCid
               deals {
                 data {
-                  miner
+                  storageProvider
                   dealId
                   status
                   activation
@@ -84,9 +84,9 @@ export async function statusGet (request, env) {
     }
     return deals.data
       .filter(({ status }) => DEAL_STATUS.has(status))
-      .map(({ dealId, miner, status, activation, created, updated }) => ({
+      .map(({ dealId, storageProvider, status, activation, created, updated }) => ({
         dealId,
-        miner,
+        storageProvider,
         status,
         pieceCid,
         dataCid,

--- a/packages/api/test/fixtures/find-content-by-cid.json
+++ b/packages/api/test/fixtures/find-content-by-cid.json
@@ -11,7 +11,7 @@
             "pieceCid": "baga",
             "deals": {
               "data" : [ {
-                "miner": "f99",
+                "storageProvider": "f99",
                 "dealId": 12345,
                 "status": "Active",
                 "activation": "<iso timestamp>",

--- a/packages/api/test/fixtures/status.json
+++ b/packages/api/test/fixtures/status.json
@@ -10,7 +10,7 @@
   }],
   "deals": [{
     "dealId": 12345,
-    "miner": "f99",
+    "storageProvider": "f99",
     "status": "Active",
     "pieceCid": "baga",
     "dataCid": "bafy",

--- a/packages/api/test/status.spec.js
+++ b/packages/api/test/status.spec.js
@@ -21,7 +21,7 @@ describe('GET /status/:cid', () => {
       }],
       deals: [{
         dealId: 12345,
-        miner: 'f99',
+        storageProvider: 'f99',
         status: 'Active',
         pieceCid: 'baga',
         dataCid: 'bafy',

--- a/packages/client/src/lib/interface.ts
+++ b/packages/client/src/lib/interface.ts
@@ -122,9 +122,9 @@ export interface Deal {
    */
   dealId: number
   /**
-   * Address of the miner storing this data.
+   * Address of the provider storing this data.
    */
-  miner: string
+  storageProvider: string
   /**
    * Current deal status.
    */

--- a/packages/client/test/fixtures/status.json
+++ b/packages/client/test/fixtures/status.json
@@ -10,7 +10,7 @@
   }],
   "deals": [{
     "dealId": 12345,
-    "miner": "f99",
+    "storageProvider": "f99",
     "status": "Active",
     "pieceCid": "baga",
     "dataCid": "bafy",

--- a/packages/db/fauna/resources/Function/createOrUpdateDeal.js
+++ b/packages/db/fauna/resources/Function/createOrUpdateDeal.js
@@ -48,7 +48,7 @@ const body = Query(
           Create('Deal', {
             data: {
               aggregate: Var('aggregateRef'),
-              miner: Select('miner', Var('data')),
+              storageProvider: Select('storageProvider', Var('data')),
               dealId: Select('dealId', Var('data')),
               activation: Select('activation', Var('data'), null),
               renewal: Select('renewal', Var('data'), null),
@@ -62,14 +62,14 @@ const body = Query(
         Let(
           {
             deal: Get(Var('dealMatch')),
-            currMiner: Select(['data', 'miner'], Var('deal')),
+            currStorageProvider: Select(['data', 'storageProvider'], Var('deal')),
             currActivation: Select(['data', 'activation'], Var('deal'), null),
             currRenewal: Select(['data', 'renewal'], Var('deal'), null),
             currStatusReason: Select(['data', 'statusReason'], Var('deal'), null)
           },
           Update(Select('ref', Var('deal')), {
             data: {
-              miner: Select('miner', Var('data'), Var('currMiner')),
+              storageProvider: Select('storageProvider', Var('data'), Var('currStorageProvider')),
               activation: Select('activation', Var('data'), Var('currActivation')),
               renewal: Select('renewal', Var('data'), Var('currRenewal')),
               status: Select('status', Var('data')),

--- a/packages/db/fauna/schema.graphql
+++ b/packages/db/fauna/schema.graphql
@@ -262,9 +262,9 @@ type Deal {
   aggregate: Aggregate! @relation
 
   """
-  ID of miner this deal was made with.
+  ID of storage provider this deal was made with.
   """
-  miner: String!
+  storageProvider: String!
 
   """
   Identifier for the deal stored on chain.
@@ -363,6 +363,7 @@ input CreateAggregateInput {
 input AggregateEntryInput {
   cid: String!
   dataModelSelector: String
+  dagSize: Long
 }
 
 input CreateOrUpdateDealInput {
@@ -370,7 +371,7 @@ input CreateOrUpdateDealInput {
   CID of the aggregate included in this deal. Required for create, ignored for update.
   """
   dataCid: String
-  miner: String
+  storageProvider: String
   dealId: Long!
   activation: Time
   renewal: Time

--- a/packages/website/content/about.md
+++ b/packages/website/content/about.md
@@ -4,9 +4,9 @@ Web3.Storage aims to make leveraging the power of decentralized storage for web3
 
 ### Methodology
 
-Content uploaded to [Web3.Storage](http://web3.storage) is pinned redundantly in an [IPFS Cluster](https://cluster.ipfs.io/) of 3 geographically distributed nodes. When 32GiB of content is made available, a request is made to pin a new batch of content into a separate IPFS cluster - where a 32GiB [CAR file](https://ipld.io/specs/transport/car/carv2/#summary) is generated to store the data. Once this 32GiB CAR file is ready, a queue of geographically distributed miners - selected for performance and availability - bid for the right to store these deals, with the Web3.Storage client making a minimum of 5 deals with the various miners. Please see the [documentation](/) for how one can use the Status API to query for information regarding pin status and deal status for your uploaded content.
+Content uploaded to [Web3.Storage](http://web3.storage) is pinned redundantly in an [IPFS Cluster](https://cluster.ipfs.io/) of 3 geographically distributed nodes. When 32GiB of content is made available, a request is made to pin a new batch of content into a separate IPFS cluster - where a 32GiB [CAR file](https://ipld.io/specs/transport/car/carv2/#summary) is generated to store the data. Once this 32GiB CAR file is ready, a queue of geographically distributed storage providers - selected for performance and availability - bid for the right to store these deals, with the Web3.Storage client making a minimum of 5 deals with the various storage providers. Please see the [documentation](/) for how one can use the Status API to query for information regarding pin status and deal status for your uploaded content.
 
-Once the deals are active, the [Web3.Storage](http://web3.storage) client polls to ensure that the relevant sectors are still available. In the event of an early termination (or a miner going offline), the [Web3.Storage](http://web3.storage) client will automatically add the relevant deals into the queue of upcoming deals to ensure at all times there are always a minimum of 5 copies of data being stored with Filecoin Miners.
+Once the deals are active, the [Web3.Storage](http://web3.storage) client polls to ensure that the relevant sectors are still available. In the event of an early termination (or a storage provider going offline), the [Web3.Storage](http://web3.storage) client will automatically add the relevant deals into the queue of upcoming deals to ensure at all times there are always a minimum of 5 copies of data being stored with Filecoin Storage Providers.
 
 In the future, we hope to expand this service to offer a variety of options for storing data - including purely protocol based approaches (e.g. via smart contracts) as well as other hosted options (e.g. HTTP end points). We also aim to provide more native tooling for automated deal management via tools like Data DAOs - which may augment the offerings of this service in the future. Our aim today is to provide a user friendly experience that massively reduces the burden for onboarding new use cases into the web3 ecosystem today - while providing an upgrade path for further decentralization.
 
@@ -24,9 +24,9 @@ Data stored in [Web3.Storage](http://web3.storage) is guaranteed to be available
 
 For reference, the following parameters and strategies are used to ensure highly redundant storage on the Filecoin network:
 
-- Deals with miners are set to last 18 months with deal renewals being automatically managed by [Web3.Storage](http://web3.storage).
-- Each piece of content is stored with a minimum of 5 miners, typically exceeding this minimum (the specific list of miners being provided via the [Status API](/)).
-- In the event of a miner going offline, [Web3.Storage](http://web3.storage) will automatically store an additional copy to meet the minimum of 5 copies being stored on the Filecoin network.
+- Deals with Storage Providers are set to last 18 months with deal renewals being automatically managed by [Web3.Storage](http://web3.storage).
+- Each piece of content is stored with a minimum of 5 storage providers, typically exceeding this minimum (the specific list of storage providers being provided via the [Status API](/)).
+- In the event of a storage provider going offline, [Web3.Storage](http://web3.storage) will automatically store an additional copy to meet the minimum of 5 copies being stored on the Filecoin network.
 
 It is recommended that you do not rely on Filecoin deals directly for performant retrieval, and instead you allow [Web3.Storage](http://web3.storage) to make the data available in IPFS. Retrieving data over the IPFS network is the recommended means of accessing [Web3.Storage](http://web3.storage) data.
 


### PR DESCRIPTION
As per https://www.notion.so/protocollabs/FIP-Operational-renaming-proposal-for-miner-ecosystem-d1e286a2a4254510b98681ceb9c8ed85 this PR renames "miner" to "storageProvider".

This also adds an optional `dagSize: Long` to `AggregateEntryInput` which we can use to populate `dagSize` on `Content` for really big DAGs.