### PR TITLE
fix: set npm publish access to public

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17306,7 +17306,7 @@
     },
     "packages/client": {
       "name": "web3.storage",
-      "version": "2.0.0",
+      "version": "2.0.1",
       "license": "(Apache-2.0 AND MIT)",
       "dependencies": {
         "@ipld/car": "^3.1.4",
@@ -17435,7 +17435,7 @@
     },
     "packages/w3": {
       "name": "@web3-storage/w3",
-      "version": "0.0.0",
+      "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
         "conf": "^10.0.1",
@@ -20416,7 +20416,7 @@
         "err-code": "^3.0.1",
         "ipfs-car": "^0.5.1",
         "sade": "^1.7.4",
-        "web3.storage": "*"
+        "web3.storage": "^2.0.0"
       }
     },
     "@web3-storage/website": {

--- a/packages/w3/package.json
+++ b/packages/w3/package.json
@@ -28,5 +28,8 @@
     "sade": "^1.7.4",
     "web3.storage": "^2.0.0"
   },
-  "main": "index.js"
+  "main": "index.js",
+  "publishConfig": {
+    "access": "public"
+  }
 }


### PR DESCRIPTION
✨🎷🐩

sets the access flag in the package.json so I can trigger another release-please PR for the `w3` package.

License: (Apache-2.0 AND MIT)
Signed-off-by: Oli Evans <oli@tableflip.io>