### PR TITLE
fix: remove dev files from published client

### DIFF
--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -83,5 +83,11 @@
       "path": "./dist/bundle.esm.min.js",
       "maxSize": "200 kB"
     }
+  ],
+  "files": [
+    "src",
+    "!src/test",
+    "dist",
+    "!dist/test"
   ]
 }


### PR DESCRIPTION
trims out about 0.8MB and 46 files from the published build

**before**

```
npm notice package size:  898.9 kB
npm notice unpacked size: 2.0 MB
npm notice total files:   70
```

**after**

```
npm notice package size:  284.4 kB
npm notice unpacked size: 1.2 MB
npm notice total files:   24
```

License: (Apache-2.0 AND MIT)
Signed-off-by: Oli Evans <oli@tableflip.io>