### PR TITLE
chore: max width for code sample box

### DIFF
--- a/packages/website/pages/index.js
+++ b/packages/website/pages/index.js
@@ -133,7 +133,7 @@ retrieveFiles()`
           </p>
         </div>
       </div>
-      <div className="layout-margins pt-24">
+      <div className="md:layout-margins pt-24">
         <div className="relative flex flex-col xl:flex-row justify-between py-20 md:py-12 mt-20 bg-w3storage-blue-dark" style={{ borderTopLeftRadius: '6rem' }}>
           <Squares className="absolute top-14 left-16 hidden md:block" />
           <div className="text-white pl-12 pr-12 md:pl-32 md:pr-0 w-full max-w-none xl:max-w-lg mb-16 mr-0 xl:mr-10 xl:mb-0">

--- a/packages/website/pages/index.js
+++ b/packages/website/pages/index.js
@@ -133,7 +133,7 @@ retrieveFiles()`
           </p>
         </div>
       </div>
-      <div className="md:px-12 pt-24">
+      <div className="layout-margins pt-24">
         <div className="relative flex flex-col xl:flex-row justify-between py-20 md:py-12 mt-20 bg-w3storage-blue-dark" style={{ borderTopLeftRadius: '6rem' }}>
           <Squares className="absolute top-14 left-16 hidden md:block" />
           <div className="text-white pl-12 pr-12 md:pl-32 md:pr-0 w-full max-w-none xl:max-w-lg mb-16 mr-0 xl:mr-10 xl:mb-0">

--- a/packages/website/styles/global.css
+++ b/packages/website/styles/global.css
@@ -157,7 +157,8 @@ body {
 
 /* 1440 max width + 58px left & right padding */
 @media only screen and (min-width: 1680px) {
-  .layout-margins {
+  .layout-margins,
+  .md\:layout-margins {
       @apply max-w-screen-2xl mx-auto;
   }
 }

--- a/packages/website/styles/global.css
+++ b/packages/website/styles/global.css
@@ -149,6 +149,10 @@ body {
   .layout-margins {
       margin: 0 4%;
   }
+
+  .md\:layout-margins {
+    @apply mx-8;
+  }
 }
 
 /* 1440 max width + 58px left & right padding */


### PR DESCRIPTION
Constrain the code-sample max width, to match the grid above it.

**after**
<img width="1230" alt="Screenshot 2021-07-26 at 09 37 13" src="https://user-images.githubusercontent.com/58871/126969548-7d8753a7-7498-4515-ad07-52056f04a300.png">


License: (Apache-2.0 AND MIT)
Signed-off-by: Oli Evans <oli@tableflip.io>