### PR TITLE
fix: throw on 404 from /get

### DIFF
--- a/packages/client/src/lib.js
+++ b/packages/client/src/lib.js
@@ -179,9 +179,6 @@ class Web3Storage {
       method: 'GET',
       headers: Web3Storage.headers(token)
     })
-    if (!res.ok) {
-      throw new Error(`${res.status} ${res.statusText}`)
-    }
     return toWeb3Response(res)
   }
 
@@ -297,6 +294,9 @@ function toFilenameWithPath (unixFsPath) {
 function toWeb3Response (res) {
   const response = Object.assign(res, {
     unixFsIterator: async function * () {
+      if (!res.ok) {
+        throw new Error(`Response was not ok: ${res.status} ${res.statusText} - Check for { "ok": false } on the Response object before calling .unixFsIterator`)
+      }
       /* c8 ignore next 3 */
       if (!res.body) {
         throw new Error('No body on response')
@@ -311,6 +311,9 @@ function toWeb3Response (res) {
       }
     },
     files: async () => {
+      if (!res.ok) {
+        throw new Error(`Response was not ok: ${res.status} ${res.statusText} - Check for { "ok": false } on the Response object before calling .files`)
+      }
       const files = []
       // @ts-ignore we're using the enriched response here
       for await (const entry of response.unixFsIterator()) {

--- a/packages/client/src/lib.js
+++ b/packages/client/src/lib.js
@@ -180,13 +180,7 @@ class Web3Storage {
       headers: Web3Storage.headers(token)
     })
     if (!res.ok) {
-      // TODO: I'm assuming that an error for "CID isn't there (yet)" would be unergonomic. Need to verify.
-      // I'm thinking null means, nope, not yet, no can has. Anything else is _AN ERROR_
-      if (res.status === 404) {
-        return null
-      } else {
-        throw new Error(`${res.status} ${res.statusText}`)
-      }
+      throw new Error(`${res.status} ${res.statusText}`)
     }
     return toWeb3Response(res)
   }

--- a/packages/client/test/get.spec.js
+++ b/packages/client/test/get.spec.js
@@ -61,11 +61,15 @@ describe('get', () => {
     assert.is(files[2].size, 55415)
   })
 
-  it('returns null on 404', async () => {
+  it('throws on 404', async () => {
     const client = new Web3Storage({ token, endpoint })
     const cid = 'bafkreieq5jui4j25lacwomsqgjeswwl3y5zcdrresptwgmfylxo2depppq'
-    const res = await client.get(cid)
-    assert.not.ok(res, 'res should be null')
+    try {
+      await client.get(cid)
+      assert.unreachable('sholud have thrown')
+    } catch (err) {
+      assert.match(err, /404/)
+    }
   })
 
   it('throws on invalid cid', async () => {

--- a/packages/client/test/get.spec.js
+++ b/packages/client/test/get.spec.js
@@ -61,23 +61,28 @@ describe('get', () => {
     assert.is(files[2].size, 55415)
   })
 
-  it('throws on 404', async () => {
+  it('res.files throws on 404', async () => {
     const client = new Web3Storage({ token, endpoint })
     const cid = 'bafkreieq5jui4j25lacwomsqgjeswwl3y5zcdrresptwgmfylxo2depppq'
     try {
-      await client.get(cid)
-      assert.unreachable('sholud have thrown')
+      const res = await client.get(cid)
+      assert.not.ok(res.ok)
+      await res.files()
+      assert.unreachable('res.files() should have thrown')
     } catch (err) {
       assert.match(err, /404/)
     }
   })
 
-  it('throws on invalid cid', async () => {
+  it('res.unixFsIteratory throws on invalid cid', async () => {
     const client = new Web3Storage({ token, endpoint })
     const cid = 'bafkreieq'
     try {
-      await client.get(cid)
-      assert.unreachable('sholud have thrown')
+      const res = await client.get(cid)
+      assert.not.ok(res.ok)
+      for await (const _ of res.unixFsIterator()) { // eslint-disable-line
+        assert.unreachable('res.unixFsIterator() should have thrown')
+      }
     } catch (err) {
       assert.match(err, /400/)
     }


### PR DESCRIPTION
- remove the spcial case to return undefined on a 404. We get from the gateway currently so any valid CID would either be returned succesfully or fail with a non 404 error code, so this 404 would not occur in the wild
- the plan is to have the api redirect to get from a dedicated gateway when we host the CID, and redirect to the public gateway where the user tries to get a CID we dont recognise.

License: (Apache-2.0 AND MIT)
Signed-off-by: Oli Evans <oli@tableflip.io>