### PR TITLE
chore: remove test log

### DIFF
--- a/packages/api/test/user.spec.js
+++ b/packages/api/test/user.spec.js
@@ -76,7 +76,6 @@ describe('GET /user/uploads', () => {
     })
     assert(res.ok)
     const uploads = await res.json()
-    console.log(uploads)
     // TODO: import from fixture
     const expected = [
       {


### PR DESCRIPTION
Removes `console.log` in tests