### PR TITLE
fix: make unixfs importer on ipfs-car use same defaults as lotus

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2185,9 +2185,9 @@
       "integrity": "sha1-p3c2C1s5oaLlEG+OhY8v0tBgxXA="
     },
     "node_modules/@rollup/plugin-commonjs": {
-      "version": "19.0.1",
-      "resolved": "https://registry.npmjs.org/@rollup/plugin-commonjs/-/plugin-commonjs-19.0.1.tgz",
-      "integrity": "sha512-bRrPTIAsWw2LmEspEMvV9f+7N7CEQgZCj2Zi1F0e0P3+/tbjQaSNNVVRSRWVhuDagp8yjK5kbIut8KTPsseRhg==",
+      "version": "19.0.2",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-commonjs/-/plugin-commonjs-19.0.2.tgz",
+      "integrity": "sha512-gBjarfqlC7qs0AutpRW/hrFNm+cd2/QKxhwyFa+srbg1oX7rDsEU3l+W7LAUhsAp9mPJMAkXDhLbQaVwEaE8bA==",
       "dev": true,
       "dependencies": {
         "@rollup/pluginutils": "^3.1.0",
@@ -8328,9 +8328,9 @@
       }
     },
     "node_modules/ipfs-car": {
-      "version": "0.5.2",
-      "resolved": "git+ssh://git@github.com/web3-storage/ipfs-car.git#f3d5f7c6ea7939548c79ffbbc6b2245d51c11c60",
-      "license": "(Apache-2.0 AND MIT)",
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/ipfs-car/-/ipfs-car-0.5.3.tgz",
+      "integrity": "sha512-jQVdKeiBCGyV5J5COpBabXgTkNxLCzii/oQOeB2qfLx679e9TZ0g1egb0fEcnrbHCkS4lh1/GqeP/UTMS5MINg==",
       "dependencies": {
         "@ipld/car": "^3.1.4",
         "@web-std/blob": "^2.1.1",
@@ -17388,7 +17388,7 @@
         "@web-std/form-data": "^2.1.0",
         "assert": "^2.0.0",
         "buffer": "^6.0.3",
-        "ipfs-car": "web3-storage/ipfs-car#feat/support-custom-max-children-per-node",
+        "ipfs-car": "^0.5.3",
         "ipfs-unixfs-importer": "^8.0.0",
         "npm-run-all": "^4.1.5",
         "playwright-test": "^7.0.1",
@@ -17435,7 +17435,7 @@
         "browser-readablestream-to-it": "^1.0.2",
         "carbites": "^1.0.6",
         "files-from-path": "^0.2.0",
-        "ipfs-car": "web3-storage/ipfs-car#feat/support-custom-max-children-per-node",
+        "ipfs-car": "^0.5.3",
         "p-retry": "^4.5.0",
         "streaming-iterables": "^6.0.0"
       },
@@ -17573,7 +17573,7 @@
       "dependencies": {
         "conf": "^10.0.1",
         "enquirer": "^2.3.6",
-        "ipfs-car": "web3-storage/ipfs-car#feat/support-custom-max-children-per-node",
+        "ipfs-car": "^0.5.3",
         "ora": "^5.4.1",
         "sade": "^1.7.4",
         "web3.storage": "^2.0.0"
@@ -19523,9 +19523,9 @@
       "integrity": "sha1-p3c2C1s5oaLlEG+OhY8v0tBgxXA="
     },
     "@rollup/plugin-commonjs": {
-      "version": "19.0.1",
-      "resolved": "https://registry.npmjs.org/@rollup/plugin-commonjs/-/plugin-commonjs-19.0.1.tgz",
-      "integrity": "sha512-bRrPTIAsWw2LmEspEMvV9f+7N7CEQgZCj2Zi1F0e0P3+/tbjQaSNNVVRSRWVhuDagp8yjK5kbIut8KTPsseRhg==",
+      "version": "19.0.2",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-commonjs/-/plugin-commonjs-19.0.2.tgz",
+      "integrity": "sha512-gBjarfqlC7qs0AutpRW/hrFNm+cd2/QKxhwyFa+srbg1oX7rDsEU3l+W7LAUhsAp9mPJMAkXDhLbQaVwEaE8bA==",
       "dev": true,
       "requires": {
         "@rollup/pluginutils": "^3.1.0",
@@ -20051,7 +20051,7 @@
         "@web3-storage/db": "^1.0.0",
         "assert": "^2.0.0",
         "buffer": "^6.0.3",
-        "ipfs-car": "web3-storage/ipfs-car#feat/support-custom-max-children-per-node",
+        "ipfs-car": "^0.5.3",
         "ipfs-unixfs-importer": "^8.0.0",
         "itty-router": "^2.3.10",
         "multiformats": "^9.0.4",
@@ -20117,7 +20117,7 @@
         "conf": "^10.0.1",
         "enquirer": "^2.3.6",
         "execa": "^5.1.1",
-        "ipfs-car": "web3-storage/ipfs-car#feat/support-custom-max-children-per-node",
+        "ipfs-car": "^0.5.3",
         "mocha": "^8.3.2",
         "ora": "^5.4.1",
         "sade": "^1.7.4",
@@ -24698,8 +24698,9 @@
       "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g=="
     },
     "ipfs-car": {
-      "version": "git+ssh://git@github.com/web3-storage/ipfs-car.git#f3d5f7c6ea7939548c79ffbbc6b2245d51c11c60",
-      "from": "ipfs-car@web3-storage/ipfs-car#feat/support-custom-max-children-per-node",
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/ipfs-car/-/ipfs-car-0.5.3.tgz",
+      "integrity": "sha512-jQVdKeiBCGyV5J5COpBabXgTkNxLCzii/oQOeB2qfLx679e9TZ0g1egb0fEcnrbHCkS4lh1/GqeP/UTMS5MINg==",
       "requires": {
         "@ipld/car": "^3.1.4",
         "@web-std/blob": "^2.1.1",
@@ -31155,7 +31156,7 @@
         "del-cli": "^4.0.0",
         "files-from-path": "^0.2.0",
         "hundreds": "0.0.9",
-        "ipfs-car": "web3-storage/ipfs-car#feat/support-custom-max-children-per-node",
+        "ipfs-car": "^0.5.3",
         "mocha": "8.3.2",
         "multiformats": "^9.1.2",
         "npm-run-all": "^4.1.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "web3.storage",
       "version": "1.0.0",
       "license": "(Apache-2.0 AND MIT)",
       "workspaces": [
@@ -1814,9 +1815,9 @@
       "integrity": "sha512-sqKVVVOe5ivCaXDWivIJYVSaEgdQK9ul7a4Kity5Iw7u9+wBAPbX1RMSnLLmp7O4Vzj0WOWwMAJsTL00xwaNug=="
     },
     "node_modules/@ipld/car": {
-      "version": "3.1.7",
-      "resolved": "https://registry.npmjs.org/@ipld/car/-/car-3.1.7.tgz",
-      "integrity": "sha512-+rCR5rxPBpU9V9aVmCUujrli3V0t9qb4pLozhrHeUjJJS1PaF/D5zgIfTpzRsuQWp2O0ZriYzuwyppuPCqhAWw==",
+      "version": "3.1.8",
+      "resolved": "https://registry.npmjs.org/@ipld/car/-/car-3.1.8.tgz",
+      "integrity": "sha512-6GbVnsgjlhia3glezx1Rbc4FPU9ZKS94GQwjab1J3auxIYXHrxQ3SV1WUUCjX5lO9qGCB10KiyiKEIY2Mj8/jA==",
       "dependencies": {
         "@ipld/dag-cbor": "^6.0.0",
         "@types/varint": "^6.0.0",
@@ -1834,9 +1835,9 @@
       }
     },
     "node_modules/@ipld/dag-pb": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/@ipld/dag-pb/-/dag-pb-2.1.4.tgz",
-      "integrity": "sha512-aRGX6NVUuv18/lrD1vPpthIbwUMb4TAuwLG15IZrvWNVrZasRLJhnU18jT+eans6OZe5fWzo0wb0UgORFx8iXg==",
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@ipld/dag-pb/-/dag-pb-2.1.5.tgz",
+      "integrity": "sha512-mdUiUZa+QFT0aPwjeU4mltrtCjl4ugxWgK5JluBV3F+mds7HANoWSuCvmK9f4qJYWEwN5xOHgZyFp3sQqSEmzw==",
       "dependencies": {
         "multiformats": "^9.0.0"
       }
@@ -2205,9 +2206,9 @@
       }
     },
     "node_modules/@rollup/plugin-node-resolve": {
-      "version": "13.0.2",
-      "resolved": "https://registry.npmjs.org/@rollup/plugin-node-resolve/-/plugin-node-resolve-13.0.2.tgz",
-      "integrity": "sha512-hv+eAMcA2hQ7qvPVcXbtIyc0dtue4jMyA2sCW4IMkrmh+SeDDEHg1MXTv65VPpKdtjvWzN3+4mHAEl4rT+zgzQ==",
+      "version": "13.0.4",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-node-resolve/-/plugin-node-resolve-13.0.4.tgz",
+      "integrity": "sha512-eYq4TFy40O8hjeDs+sIxEH/jc9lyuI2k9DM557WN6rO5OpnC2qXMBNj4IKH1oHrnAazL49C5p0tgP0/VpqJ+/w==",
       "dev": true,
       "dependencies": {
         "@rollup/pluginutils": "^3.1.0",
@@ -2662,9 +2663,9 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "16.4.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.4.1.tgz",
-      "integrity": "sha512-UW7cbLqf/Wu5XH2RKKY1cHwUNLicIDRLMraYKz+HHAerJ0ZffUEk+fMnd8qU2JaS6cAy0r8tsaf7yqHASf/Y0Q=="
+      "version": "16.4.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.4.3.tgz",
+      "integrity": "sha512-GKM4FLMkWDc0sfx7tXqPWkM6NBow1kge0fgQh0bOnlqo4iT1kvTvMEKE0c1RtUGnbLlGRXiAA8SumE//90uKAg=="
     },
     "node_modules/@types/normalize-package-data": {
       "version": "2.4.1",
@@ -2696,9 +2697,9 @@
       "dev": true
     },
     "node_modules/@types/react": {
-      "version": "17.0.14",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.14.tgz",
-      "integrity": "sha512-0WwKHUbWuQWOce61UexYuWTGuGY/8JvtUe/dtQ6lR4sZ3UiylHotJeWpf3ArP9+DSGUoLY3wbU59VyMrJps5VQ==",
+      "version": "17.0.15",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.15.tgz",
+      "integrity": "sha512-uTKHDK9STXFHLaKv6IMnwp52fm0hwU+N89w/p9grdUqcFA6WuqDyPhaWopbNyE1k/VhgzmHl8pu1L4wITtmlLw==",
       "dependencies": {
         "@types/prop-types": "*",
         "@types/scheduler": "*",
@@ -2808,9 +2809,9 @@
       }
     },
     "node_modules/@web-std/file": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@web-std/file/-/file-1.1.1.tgz",
-      "integrity": "sha512-ZrmLDdCGsmj1MRBLhAa7lEbd2edi6os7A9VGfkOAum5EqdK6nPCWIeZPsk8KaSsLDkw0P2rbnITiT/mdkB8fEA==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@web-std/file/-/file-1.1.2.tgz",
+      "integrity": "sha512-ecmKSJswuBJTxcrAQ1CYwVud9Ax/8F3gOD5fgHDjxbf8dW92twiQD+A9tHvoZ2E5pkOvLHYDyQhO4tQeBD0MYA==",
       "dependencies": {
         "@web-std/blob": "^2.1.0"
       }
@@ -4438,9 +4439,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001246",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001246.tgz",
-      "integrity": "sha512-Tc+ff0Co/nFNbLOrziBXmMVtpt9S2c2Y+Z9Nk9Khj09J+0zR9ejvIW5qkZAErCbOrVODCx/MN+GpB5FNBs5GFA==",
+      "version": "1.0.30001247",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001247.tgz",
+      "integrity": "sha512-4rS7co+7+AoOSPRPOPUt5/GdaqZc0EsUpWk66ofE3HJTAajUK2Ss2VwoNzVN69ghg8lYYlh0an0Iy4LIHHo9UQ==",
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/browserslist"
@@ -5886,9 +5887,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.3.785",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.785.tgz",
-      "integrity": "sha512-WmCgAeURsMFiyoJ646eUaJQ7GNfvMRLXo+GamUyKVNEM4MqTAsXyC0f38JEB4N3BtbD0tlAKozGP5E2T9K3YGg=="
+      "version": "1.3.786",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.786.tgz",
+      "integrity": "sha512-AmvbLBj3hepRk8v/DHrFF8gINxOFfDbrn6Ts3PcK46/FBdQb5OMmpamSpZQXSkfi77FfBzYtQtAk+00LCLYMVw=="
     },
     "node_modules/elliptic": {
       "version": "6.5.4",
@@ -6791,18 +6792,6 @@
         "url": "https://github.com/sindresorhus/execa?sponsor=1"
       }
     },
-    "node_modules/execa/node_modules/get-stream": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
-      "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
-      "dev": true,
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/expand-template": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
@@ -6938,6 +6927,21 @@
       },
       "optionalDependencies": {
         "@types/yauzl": "^2.9.1"
+      }
+    },
+    "node_modules/extract-zip/node_modules/get-stream": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
+      "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
+      "dev": true,
+      "dependencies": {
+        "pump": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/fast-deep-equal": {
@@ -7547,15 +7551,12 @@
       }
     },
     "node_modules/get-stream": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
-      "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
+      "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
       "dev": true,
-      "dependencies": {
-        "pump": "^3.0.0"
-      },
       "engines": {
-        "node": ">=8"
+        "node": ">=10"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -7575,6 +7576,19 @@
       "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
       "integrity": "sha1-l/tdlr/eiXMxPyDoKI75oWf6ZM4=",
       "dev": true
+    },
+    "node_modules/github-slugger": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/github-slugger/-/github-slugger-1.3.0.tgz",
+      "integrity": "sha512-gwJScWVNhFYSRDvURk/8yhcFBee6aFjye2a7Lhb2bUyRulpIoek9p0I9Kt7PT67d/nUlZbFu8L9RLiA0woQN8Q==",
+      "dependencies": {
+        "emoji-regex": ">=6.0.0 <=6.1.1"
+      }
+    },
+    "node_modules/github-slugger/node_modules/emoji-regex": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-6.1.1.tgz",
+      "integrity": "sha1-xs0OwbBkLio8Z6ETfvxeeW2k+I4="
     },
     "node_modules/glob": {
       "version": "7.1.7",
@@ -8315,8 +8329,8 @@
     },
     "node_modules/ipfs-car": {
       "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/ipfs-car/-/ipfs-car-0.5.2.tgz",
-      "integrity": "sha512-f86WKOgqm4l1YvA6EsjVY0dqePFe0IaNaxBQqd7qfXRorvDy5sa8E6gZVyknRpsFLisYxw10ueowR8KwAmv87g==",
+      "resolved": "git+ssh://git@github.com/web3-storage/ipfs-car.git#f3d5f7c6ea7939548c79ffbbc6b2245d51c11c60",
+      "license": "(Apache-2.0 AND MIT)",
       "dependencies": {
         "@ipld/car": "^3.1.4",
         "@web-std/blob": "^2.1.1",
@@ -9182,12 +9196,15 @@
       }
     },
     "node_modules/is-stream": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.0.tgz",
-      "integrity": "sha512-XCoy+WlUr7d1+Z8GgSuXmpuUFC9fOhRXglJMx+dwLKTkL44Cjd4W1Z5P+BQZpr+cR93aGP4S/s7Ftw6Nd/kiEw==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
       "dev": true,
       "engines": {
         "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/is-string": {
@@ -10127,6 +10144,23 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/mdast-util-from-markdown/node_modules/parse-entities": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-2.0.0.tgz",
+      "integrity": "sha512-kkywGpCcRYhqQIchaWqZ875wzpS/bMKhz5HnN3p7wveJTkTtyAB/AlnS0f8DFSqYW1T82t6yEAkEcB+A1I3MbQ==",
+      "dependencies": {
+        "character-entities": "^1.0.0",
+        "character-entities-legacy": "^1.0.0",
+        "character-reference-invalid": "^1.0.0",
+        "is-alphanumerical": "^1.0.0",
+        "is-decimal": "^1.0.0",
+        "is-hexadecimal": "^1.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/mdast-util-to-hast": {
       "version": "10.2.0",
       "resolved": "https://registry.npmjs.org/mdast-util-to-hast/-/mdast-util-to-hast-10.2.0.tgz",
@@ -10425,6 +10459,23 @@
       "dependencies": {
         "debug": "^4.0.0",
         "parse-entities": "^2.0.0"
+      }
+    },
+    "node_modules/micromark/node_modules/parse-entities": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-2.0.0.tgz",
+      "integrity": "sha512-kkywGpCcRYhqQIchaWqZ875wzpS/bMKhz5HnN3p7wveJTkTtyAB/AlnS0f8DFSqYW1T82t6yEAkEcB+A1I3MbQ==",
+      "dependencies": {
+        "character-entities": "^1.0.0",
+        "character-entities-legacy": "^1.0.0",
+        "character-reference-invalid": "^1.0.0",
+        "is-alphanumerical": "^1.0.0",
+        "is-decimal": "^1.0.0",
+        "is-hexadecimal": "^1.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/micromatch": {
@@ -12545,9 +12596,9 @@
       "integrity": "sha512-X4kUkCTHU1N/kEbwK9FpUJ0UZQa90VzeczfS704frR30gljxDG0pSziws06XlK+CGRSo/1wtG1mFIdBFQTMQNw=="
     },
     "node_modules/parse-entities": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-2.0.0.tgz",
-      "integrity": "sha512-kkywGpCcRYhqQIchaWqZ875wzpS/bMKhz5HnN3p7wveJTkTtyAB/AlnS0f8DFSqYW1T82t6yEAkEcB+A1I3MbQ==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-1.2.2.tgz",
+      "integrity": "sha512-NzfpbxW/NPrzZ/yYSoQxyqUZMZXIdCfE0OIN4ESsnptHJECoUk3FZktxNuzQf4tjt5UEopnxpYJbvYuxIFDdsg==",
       "dependencies": {
         "character-entities": "^1.0.0",
         "character-entities-legacy": "^1.0.0",
@@ -12555,10 +12606,6 @@
         "is-alphanumerical": "^1.0.0",
         "is-decimal": "^1.0.0",
         "is-hexadecimal": "^1.0.0"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/parse-json": {
@@ -13770,9 +13817,9 @@
       }
     },
     "node_modules/react-query": {
-      "version": "3.19.0",
-      "resolved": "https://registry.npmjs.org/react-query/-/react-query-3.19.0.tgz",
-      "integrity": "sha512-AaerSVsmBG2iIciwX2x8cWZS4Htw/4u2GFTYK8oiicpX3PY5mvat/8/Y3wZhM47KlllAzvC+P9MW81oHuEt2wg==",
+      "version": "3.19.1",
+      "resolved": "https://registry.npmjs.org/react-query/-/react-query-3.19.1.tgz",
+      "integrity": "sha512-tMBVKlmWevPHYWgI8ZBEgsTulJXSuXsxDbxqANODRnPI+3hd5GRVcc7nNIYSUx3aaULt08rN3EhTMHyTcFUNJw==",
       "dependencies": {
         "@babel/runtime": "^7.5.5",
         "broadcast-channel": "^3.4.1",
@@ -13944,19 +13991,6 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
-    "node_modules/refractor/node_modules/parse-entities": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-1.2.2.tgz",
-      "integrity": "sha512-NzfpbxW/NPrzZ/yYSoQxyqUZMZXIdCfE0OIN4ESsnptHJECoUk3FZktxNuzQf4tjt5UEopnxpYJbvYuxIFDdsg==",
-      "dependencies": {
-        "character-entities": "^1.0.0",
-        "character-entities-legacy": "^1.0.0",
-        "character-reference-invalid": "^1.0.0",
-        "is-alphanumerical": "^1.0.0",
-        "is-decimal": "^1.0.0",
-        "is-hexadecimal": "^1.0.0"
-      }
-    },
     "node_modules/refractor/node_modules/prismjs": {
       "version": "1.17.1",
       "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.17.1.tgz",
@@ -14100,6 +14134,29 @@
       "dependencies": {
         "mdast-util-to-hast": "^10.2.0"
       },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-slug": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/remark-slug/-/remark-slug-6.1.0.tgz",
+      "integrity": "sha512-oGCxDF9deA8phWvxFuyr3oSJsdyUAxMFbA0mZ7Y1Sas+emILtO+e5WutF9564gDsEN4IXaQXm5pFo6MLH+YmwQ==",
+      "dependencies": {
+        "github-slugger": "^1.0.0",
+        "mdast-util-to-string": "^1.0.0",
+        "unist-util-visit": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-slug/node_modules/mdast-util-to-string": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-1.1.0.tgz",
+      "integrity": "sha512-jVU0Nr2B9X3MU4tSK7JP1CMkSvOj7X5l/GboG1tKRw52lLF1x2Ju92Ms9tNetCcbfX3hzlM73zYo2NKkWSfF/A==",
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
@@ -15587,9 +15644,9 @@
       }
     },
     "node_modules/tailwindcss": {
-      "version": "2.2.6",
-      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-2.2.6.tgz",
-      "integrity": "sha512-hyYAltGfxf7zPpB9lImj7uUCoa0gdUKhG91J1JXdlLq2bTAgessoA0doJ1FhKc1KwSUfx0hiohPQbMfNFgQO1A==",
+      "version": "2.2.7",
+      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-2.2.7.tgz",
+      "integrity": "sha512-jv35rugP5j8PpzbXnsria7ZAry7Evh0KtQ4MZqNd+PhF+oIKPwJTVwe/rmfRx9cZw3W7iPZyzBmeoAoNwfJ1yg==",
       "dependencies": {
         "arg": "^5.0.0",
         "bytes": "^3.0.0",
@@ -17331,7 +17388,7 @@
         "@web-std/form-data": "^2.1.0",
         "assert": "^2.0.0",
         "buffer": "^6.0.3",
-        "ipfs-car": "^0.5.1",
+        "ipfs-car": "web3-storage/ipfs-car#feat/support-custom-max-children-per-node",
         "ipfs-unixfs-importer": "^8.0.0",
         "npm-run-all": "^4.1.5",
         "playwright-test": "^7.0.1",
@@ -17378,7 +17435,7 @@
         "browser-readablestream-to-it": "^1.0.2",
         "carbites": "^1.0.6",
         "files-from-path": "^0.2.0",
-        "ipfs-car": "^0.5.2",
+        "ipfs-car": "web3-storage/ipfs-car#feat/support-custom-max-children-per-node",
         "p-retry": "^4.5.0",
         "streaming-iterables": "^6.0.0"
       },
@@ -17406,6 +17463,20 @@
       "version": "8.2.2",
       "dev": true,
       "license": "MIT"
+    },
+    "packages/client/node_modules/fs-extra": {
+      "version": "9.1.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "at-least-node": "^1.0.0",
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
     },
     "packages/client/node_modules/typedoc": {
       "version": "0.20.36",
@@ -17502,7 +17573,7 @@
       "dependencies": {
         "conf": "^10.0.1",
         "enquirer": "^2.3.6",
-        "ipfs-car": "^0.5.1",
+        "ipfs-car": "web3-storage/ipfs-car#feat/support-custom-max-children-per-node",
         "ora": "^5.4.1",
         "sade": "^1.7.4",
         "web3.storage": "^2.0.0"
@@ -17517,7 +17588,7 @@
     },
     "packages/website": {
       "name": "@web3-storage/website",
-      "version": "0.0.0",
+      "version": "1.0.0",
       "dependencies": {
         "@magic-ext/oauth": "^0.7.0",
         "@tailwindcss/typography": "^0.4.1",
@@ -17534,6 +17605,7 @@
         "react-markdown": "^6.0.2",
         "react-query": "^3.13.9",
         "react-syntax-highlighter": "^11.0.3",
+        "remark-slug": "^6.1.0",
         "web3.storage": "^2.0.1"
       },
       "devDependencies": {
@@ -17590,6 +17662,10 @@
         "@magic-sdk/types": "^1.1.0",
         "crypto-js": "^3.3.0"
       }
+    },
+    "packages/website/node_modules/@magic-sdk/types": {
+      "version": "1.6.0",
+      "license": "MIT"
     },
     "packages/website/node_modules/astral-regex": {
       "version": "2.0.0",
@@ -19137,9 +19213,9 @@
       "integrity": "sha512-sqKVVVOe5ivCaXDWivIJYVSaEgdQK9ul7a4Kity5Iw7u9+wBAPbX1RMSnLLmp7O4Vzj0WOWwMAJsTL00xwaNug=="
     },
     "@ipld/car": {
-      "version": "3.1.7",
-      "resolved": "https://registry.npmjs.org/@ipld/car/-/car-3.1.7.tgz",
-      "integrity": "sha512-+rCR5rxPBpU9V9aVmCUujrli3V0t9qb4pLozhrHeUjJJS1PaF/D5zgIfTpzRsuQWp2O0ZriYzuwyppuPCqhAWw==",
+      "version": "3.1.8",
+      "resolved": "https://registry.npmjs.org/@ipld/car/-/car-3.1.8.tgz",
+      "integrity": "sha512-6GbVnsgjlhia3glezx1Rbc4FPU9ZKS94GQwjab1J3auxIYXHrxQ3SV1WUUCjX5lO9qGCB10KiyiKEIY2Mj8/jA==",
       "requires": {
         "@ipld/dag-cbor": "^6.0.0",
         "@types/varint": "^6.0.0",
@@ -19157,9 +19233,9 @@
       }
     },
     "@ipld/dag-pb": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/@ipld/dag-pb/-/dag-pb-2.1.4.tgz",
-      "integrity": "sha512-aRGX6NVUuv18/lrD1vPpthIbwUMb4TAuwLG15IZrvWNVrZasRLJhnU18jT+eans6OZe5fWzo0wb0UgORFx8iXg==",
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@ipld/dag-pb/-/dag-pb-2.1.5.tgz",
+      "integrity": "sha512-mdUiUZa+QFT0aPwjeU4mltrtCjl4ugxWgK5JluBV3F+mds7HANoWSuCvmK9f4qJYWEwN5xOHgZyFp3sQqSEmzw==",
       "requires": {
         "multiformats": "^9.0.0"
       }
@@ -19462,9 +19538,9 @@
       }
     },
     "@rollup/plugin-node-resolve": {
-      "version": "13.0.2",
-      "resolved": "https://registry.npmjs.org/@rollup/plugin-node-resolve/-/plugin-node-resolve-13.0.2.tgz",
-      "integrity": "sha512-hv+eAMcA2hQ7qvPVcXbtIyc0dtue4jMyA2sCW4IMkrmh+SeDDEHg1MXTv65VPpKdtjvWzN3+4mHAEl4rT+zgzQ==",
+      "version": "13.0.4",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-node-resolve/-/plugin-node-resolve-13.0.4.tgz",
+      "integrity": "sha512-eYq4TFy40O8hjeDs+sIxEH/jc9lyuI2k9DM557WN6rO5OpnC2qXMBNj4IKH1oHrnAazL49C5p0tgP0/VpqJ+/w==",
       "dev": true,
       "requires": {
         "@rollup/pluginutils": "^3.1.0",
@@ -19801,9 +19877,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "16.4.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.4.1.tgz",
-      "integrity": "sha512-UW7cbLqf/Wu5XH2RKKY1cHwUNLicIDRLMraYKz+HHAerJ0ZffUEk+fMnd8qU2JaS6cAy0r8tsaf7yqHASf/Y0Q=="
+      "version": "16.4.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.4.3.tgz",
+      "integrity": "sha512-GKM4FLMkWDc0sfx7tXqPWkM6NBow1kge0fgQh0bOnlqo4iT1kvTvMEKE0c1RtUGnbLlGRXiAA8SumE//90uKAg=="
     },
     "@types/normalize-package-data": {
       "version": "2.4.1",
@@ -19835,9 +19911,9 @@
       "dev": true
     },
     "@types/react": {
-      "version": "17.0.14",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.14.tgz",
-      "integrity": "sha512-0WwKHUbWuQWOce61UexYuWTGuGY/8JvtUe/dtQ6lR4sZ3UiylHotJeWpf3ArP9+DSGUoLY3wbU59VyMrJps5VQ==",
+      "version": "17.0.15",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.15.tgz",
+      "integrity": "sha512-uTKHDK9STXFHLaKv6IMnwp52fm0hwU+N89w/p9grdUqcFA6WuqDyPhaWopbNyE1k/VhgzmHl8pu1L4wITtmlLw==",
       "requires": {
         "@types/prop-types": "*",
         "@types/scheduler": "*",
@@ -19944,9 +20020,9 @@
       }
     },
     "@web-std/file": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@web-std/file/-/file-1.1.1.tgz",
-      "integrity": "sha512-ZrmLDdCGsmj1MRBLhAa7lEbd2edi6os7A9VGfkOAum5EqdK6nPCWIeZPsk8KaSsLDkw0P2rbnITiT/mdkB8fEA==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@web-std/file/-/file-1.1.2.tgz",
+      "integrity": "sha512-ecmKSJswuBJTxcrAQ1CYwVud9Ax/8F3gOD5fgHDjxbf8dW92twiQD+A9tHvoZ2E5pkOvLHYDyQhO4tQeBD0MYA==",
       "requires": {
         "@web-std/blob": "^2.1.0"
       }
@@ -19975,7 +20051,7 @@
         "@web3-storage/db": "^1.0.0",
         "assert": "^2.0.0",
         "buffer": "^6.0.3",
-        "ipfs-car": "^0.5.1",
+        "ipfs-car": "web3-storage/ipfs-car#feat/support-custom-max-children-per-node",
         "ipfs-unixfs-importer": "^8.0.0",
         "itty-router": "^2.3.10",
         "multiformats": "^9.0.4",
@@ -20041,7 +20117,7 @@
         "conf": "^10.0.1",
         "enquirer": "^2.3.6",
         "execa": "^5.1.1",
-        "ipfs-car": "^0.5.1",
+        "ipfs-car": "web3-storage/ipfs-car#feat/support-custom-max-children-per-node",
         "mocha": "^8.3.2",
         "ora": "^5.4.1",
         "sade": "^1.7.4",
@@ -20081,6 +20157,7 @@
         "react-markdown": "^6.0.2",
         "react-query": "^3.13.9",
         "react-syntax-highlighter": "^11.0.3",
+        "remark-slug": "^6.1.0",
         "tailwindcss": "^2.2.4",
         "typescript": "^4.3.5",
         "web3.storage": "^2.0.1"
@@ -20114,6 +20191,9 @@
             "@magic-sdk/types": "^1.1.0",
             "crypto-js": "^3.3.0"
           }
+        },
+        "@magic-sdk/types": {
+          "version": "1.6.0"
         },
         "astral-regex": {
           "version": "2.0.0",
@@ -21578,9 +21658,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001246",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001246.tgz",
-      "integrity": "sha512-Tc+ff0Co/nFNbLOrziBXmMVtpt9S2c2Y+Z9Nk9Khj09J+0zR9ejvIW5qkZAErCbOrVODCx/MN+GpB5FNBs5GFA=="
+      "version": "1.0.30001247",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001247.tgz",
+      "integrity": "sha512-4rS7co+7+AoOSPRPOPUt5/GdaqZc0EsUpWk66ofE3HJTAajUK2Ss2VwoNzVN69ghg8lYYlh0an0Iy4LIHHo9UQ=="
     },
     "carbites": {
       "version": "1.0.6",
@@ -22730,9 +22810,9 @@
       }
     },
     "electron-to-chromium": {
-      "version": "1.3.785",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.785.tgz",
-      "integrity": "sha512-WmCgAeURsMFiyoJ646eUaJQ7GNfvMRLXo+GamUyKVNEM4MqTAsXyC0f38JEB4N3BtbD0tlAKozGP5E2T9K3YGg=="
+      "version": "1.3.786",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.786.tgz",
+      "integrity": "sha512-AmvbLBj3hepRk8v/DHrFF8gINxOFfDbrn6Ts3PcK46/FBdQb5OMmpamSpZQXSkfi77FfBzYtQtAk+00LCLYMVw=="
     },
     "elliptic": {
       "version": "6.5.4",
@@ -23442,14 +23522,6 @@
         "onetime": "^5.1.2",
         "signal-exit": "^3.0.3",
         "strip-final-newline": "^2.0.0"
-      },
-      "dependencies": {
-        "get-stream": {
-          "version": "6.0.1",
-          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
-          "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
-          "dev": true
-        }
       }
     },
     "expand-template": {
@@ -23565,6 +23637,17 @@
         "debug": "^4.1.1",
         "get-stream": "^5.1.0",
         "yauzl": "^2.10.0"
+      },
+      "dependencies": {
+        "get-stream": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
+          "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
+          "dev": true,
+          "requires": {
+            "pump": "^3.0.0"
+          }
+        }
       }
     },
     "fast-deep-equal": {
@@ -24025,13 +24108,10 @@
       "dev": true
     },
     "get-stream": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
-      "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
-      "dev": true,
-      "requires": {
-        "pump": "^3.0.0"
-      }
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
+      "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
+      "dev": true
     },
     "github-build": {
       "version": "1.2.2",
@@ -24047,6 +24127,21 @@
       "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
       "integrity": "sha1-l/tdlr/eiXMxPyDoKI75oWf6ZM4=",
       "dev": true
+    },
+    "github-slugger": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/github-slugger/-/github-slugger-1.3.0.tgz",
+      "integrity": "sha512-gwJScWVNhFYSRDvURk/8yhcFBee6aFjye2a7Lhb2bUyRulpIoek9p0I9Kt7PT67d/nUlZbFu8L9RLiA0woQN8Q==",
+      "requires": {
+        "emoji-regex": ">=6.0.0 <=6.1.1"
+      },
+      "dependencies": {
+        "emoji-regex": {
+          "version": "6.1.1",
+          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-6.1.1.tgz",
+          "integrity": "sha1-xs0OwbBkLio8Z6ETfvxeeW2k+I4="
+        }
+      }
     },
     "glob": {
       "version": "7.1.7",
@@ -24603,9 +24698,8 @@
       "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g=="
     },
     "ipfs-car": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/ipfs-car/-/ipfs-car-0.5.2.tgz",
-      "integrity": "sha512-f86WKOgqm4l1YvA6EsjVY0dqePFe0IaNaxBQqd7qfXRorvDy5sa8E6gZVyknRpsFLisYxw10ueowR8KwAmv87g==",
+      "version": "git+ssh://git@github.com/web3-storage/ipfs-car.git#f3d5f7c6ea7939548c79ffbbc6b2245d51c11c60",
+      "from": "ipfs-car@web3-storage/ipfs-car#feat/support-custom-max-children-per-node",
       "requires": {
         "@ipld/car": "^3.1.4",
         "@web-std/blob": "^2.1.1",
@@ -25208,9 +25302,9 @@
       "dev": true
     },
     "is-stream": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.0.tgz",
-      "integrity": "sha512-XCoy+WlUr7d1+Z8GgSuXmpuUFC9fOhRXglJMx+dwLKTkL44Cjd4W1Z5P+BQZpr+cR93aGP4S/s7Ftw6Nd/kiEw==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
       "dev": true
     },
     "is-string": {
@@ -25969,6 +26063,21 @@
         "micromark": "~2.11.0",
         "parse-entities": "^2.0.0",
         "unist-util-stringify-position": "^2.0.0"
+      },
+      "dependencies": {
+        "parse-entities": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-2.0.0.tgz",
+          "integrity": "sha512-kkywGpCcRYhqQIchaWqZ875wzpS/bMKhz5HnN3p7wveJTkTtyAB/AlnS0f8DFSqYW1T82t6yEAkEcB+A1I3MbQ==",
+          "requires": {
+            "character-entities": "^1.0.0",
+            "character-entities-legacy": "^1.0.0",
+            "character-reference-invalid": "^1.0.0",
+            "is-alphanumerical": "^1.0.0",
+            "is-decimal": "^1.0.0",
+            "is-hexadecimal": "^1.0.0"
+          }
+        }
       }
     },
     "mdast-util-to-hast": {
@@ -26175,6 +26284,21 @@
       "requires": {
         "debug": "^4.0.0",
         "parse-entities": "^2.0.0"
+      },
+      "dependencies": {
+        "parse-entities": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-2.0.0.tgz",
+          "integrity": "sha512-kkywGpCcRYhqQIchaWqZ875wzpS/bMKhz5HnN3p7wveJTkTtyAB/AlnS0f8DFSqYW1T82t6yEAkEcB+A1I3MbQ==",
+          "requires": {
+            "character-entities": "^1.0.0",
+            "character-entities-legacy": "^1.0.0",
+            "character-reference-invalid": "^1.0.0",
+            "is-alphanumerical": "^1.0.0",
+            "is-decimal": "^1.0.0",
+            "is-hexadecimal": "^1.0.0"
+          }
+        }
       }
     },
     "micromatch": {
@@ -27837,9 +27961,9 @@
       "integrity": "sha512-X4kUkCTHU1N/kEbwK9FpUJ0UZQa90VzeczfS704frR30gljxDG0pSziws06XlK+CGRSo/1wtG1mFIdBFQTMQNw=="
     },
     "parse-entities": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-2.0.0.tgz",
-      "integrity": "sha512-kkywGpCcRYhqQIchaWqZ875wzpS/bMKhz5HnN3p7wveJTkTtyAB/AlnS0f8DFSqYW1T82t6yEAkEcB+A1I3MbQ==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-1.2.2.tgz",
+      "integrity": "sha512-NzfpbxW/NPrzZ/yYSoQxyqUZMZXIdCfE0OIN4ESsnptHJECoUk3FZktxNuzQf4tjt5UEopnxpYJbvYuxIFDdsg==",
       "requires": {
         "character-entities": "^1.0.0",
         "character-entities-legacy": "^1.0.0",
@@ -28735,9 +28859,9 @@
       }
     },
     "react-query": {
-      "version": "3.19.0",
-      "resolved": "https://registry.npmjs.org/react-query/-/react-query-3.19.0.tgz",
-      "integrity": "sha512-AaerSVsmBG2iIciwX2x8cWZS4Htw/4u2GFTYK8oiicpX3PY5mvat/8/Y3wZhM47KlllAzvC+P9MW81oHuEt2wg==",
+      "version": "3.19.1",
+      "resolved": "https://registry.npmjs.org/react-query/-/react-query-3.19.1.tgz",
+      "integrity": "sha512-tMBVKlmWevPHYWgI8ZBEgsTulJXSuXsxDbxqANODRnPI+3hd5GRVcc7nNIYSUx3aaULt08rN3EhTMHyTcFUNJw==",
       "requires": {
         "@babel/runtime": "^7.5.5",
         "broadcast-channel": "^3.4.1",
@@ -28861,19 +28985,6 @@
         "prismjs": "~1.17.0"
       },
       "dependencies": {
-        "parse-entities": {
-          "version": "1.2.2",
-          "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-1.2.2.tgz",
-          "integrity": "sha512-NzfpbxW/NPrzZ/yYSoQxyqUZMZXIdCfE0OIN4ESsnptHJECoUk3FZktxNuzQf4tjt5UEopnxpYJbvYuxIFDdsg==",
-          "requires": {
-            "character-entities": "^1.0.0",
-            "character-entities-legacy": "^1.0.0",
-            "character-reference-invalid": "^1.0.0",
-            "is-alphanumerical": "^1.0.0",
-            "is-decimal": "^1.0.0",
-            "is-hexadecimal": "^1.0.0"
-          }
-        },
         "prismjs": {
           "version": "1.17.1",
           "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.17.1.tgz",
@@ -28989,6 +29100,23 @@
       "integrity": "sha512-EbCu9kHgAxKmW1yEYjx3QafMyGY3q8noUbNUI5xyKbaFP89wbhDrKxyIQNukNYthzjNHZu6J7hwFg7hRm1svYA==",
       "requires": {
         "mdast-util-to-hast": "^10.2.0"
+      }
+    },
+    "remark-slug": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/remark-slug/-/remark-slug-6.1.0.tgz",
+      "integrity": "sha512-oGCxDF9deA8phWvxFuyr3oSJsdyUAxMFbA0mZ7Y1Sas+emILtO+e5WutF9564gDsEN4IXaQXm5pFo6MLH+YmwQ==",
+      "requires": {
+        "github-slugger": "^1.0.0",
+        "mdast-util-to-string": "^1.0.0",
+        "unist-util-visit": "^2.0.0"
+      },
+      "dependencies": {
+        "mdast-util-to-string": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-1.1.0.tgz",
+          "integrity": "sha512-jVU0Nr2B9X3MU4tSK7JP1CMkSvOj7X5l/GboG1tKRw52lLF1x2Ju92Ms9tNetCcbfX3hzlM73zYo2NKkWSfF/A=="
+        }
       }
     },
     "remove-accents": {
@@ -30148,9 +30276,9 @@
       }
     },
     "tailwindcss": {
-      "version": "2.2.6",
-      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-2.2.6.tgz",
-      "integrity": "sha512-hyYAltGfxf7zPpB9lImj7uUCoa0gdUKhG91J1JXdlLq2bTAgessoA0doJ1FhKc1KwSUfx0hiohPQbMfNFgQO1A==",
+      "version": "2.2.7",
+      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-2.2.7.tgz",
+      "integrity": "sha512-jv35rugP5j8PpzbXnsria7ZAry7Evh0KtQ4MZqNd+PhF+oIKPwJTVwe/rmfRx9cZw3W7iPZyzBmeoAoNwfJ1yg==",
       "requires": {
         "arg": "^5.0.0",
         "bytes": "^3.0.0",
@@ -31027,7 +31155,7 @@
         "del-cli": "^4.0.0",
         "files-from-path": "^0.2.0",
         "hundreds": "0.0.9",
-        "ipfs-car": "^0.5.2",
+        "ipfs-car": "web3-storage/ipfs-car#feat/support-custom-max-children-per-node",
         "mocha": "8.3.2",
         "multiformats": "^9.1.2",
         "npm-run-all": "^4.1.5",
@@ -31046,6 +31174,16 @@
         "@types/mocha": {
           "version": "8.2.2",
           "dev": true
+        },
+        "fs-extra": {
+          "version": "9.1.0",
+          "dev": true,
+          "requires": {
+            "at-least-node": "^1.0.0",
+            "graceful-fs": "^4.2.0",
+            "jsonfile": "^6.0.1",
+            "universalify": "^2.0.0"
+          }
         },
         "typedoc": {
           "version": "0.20.36",

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -24,7 +24,7 @@
     "@types/mocha": "^8.2.2",
     "assert": "^2.0.0",
     "buffer": "^6.0.3",
-    "ipfs-car": "^0.5.1",
+    "ipfs-car": "web3-storage/ipfs-car#feat/support-custom-max-children-per-node",
     "ipfs-unixfs-importer": "^8.0.0",
     "npm-run-all": "^4.1.5",
     "playwright-test": "^7.0.1",

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -24,7 +24,7 @@
     "@types/mocha": "^8.2.2",
     "assert": "^2.0.0",
     "buffer": "^6.0.3",
-    "ipfs-car": "web3-storage/ipfs-car#feat/support-custom-max-children-per-node",
+    "ipfs-car": "^0.5.3",
     "ipfs-unixfs-importer": "^8.0.0",
     "npm-run-all": "^4.1.5",
     "playwright-test": "^7.0.1",

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -37,7 +37,7 @@
     "browser-readablestream-to-it": "^1.0.2",
     "carbites": "^1.0.6",
     "files-from-path": "^0.2.0",
-    "ipfs-car": "^0.5.2",
+    "ipfs-car": "web3-storage/ipfs-car#feat/support-custom-max-children-per-node",
     "p-retry": "^4.5.0",
     "streaming-iterables": "^6.0.0"
   },

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -37,7 +37,7 @@
     "browser-readablestream-to-it": "^1.0.2",
     "carbites": "^1.0.6",
     "files-from-path": "^0.2.0",
-    "ipfs-car": "web3-storage/ipfs-car#feat/support-custom-max-children-per-node",
+    "ipfs-car": "^0.5.3",
     "p-retry": "^4.5.0",
     "streaming-iterables": "^6.0.0"
   },

--- a/packages/client/src/lib.js
+++ b/packages/client/src/lib.js
@@ -117,7 +117,9 @@ class Web3Storage {
           content: f.stream()
         })),
         blockstore,
-        wrapWithDirectory
+        wrapWithDirectory,
+        maxChunkSize: 1048576,
+        maxChildrenPerNode: 1024
       })
       carRoot = root.toString()
 

--- a/packages/w3/package.json
+++ b/packages/w3/package.json
@@ -25,7 +25,7 @@
   "dependencies": {
     "conf": "^10.0.1",
     "enquirer": "^2.3.6",
-    "ipfs-car": "web3-storage/ipfs-car#feat/support-custom-max-children-per-node",
+    "ipfs-car": "^0.5.3",
     "ora": "^5.4.1",
     "sade": "^1.7.4",
     "web3.storage": "^2.0.0"

--- a/packages/w3/package.json
+++ b/packages/w3/package.json
@@ -25,7 +25,7 @@
   "dependencies": {
     "conf": "^10.0.1",
     "enquirer": "^2.3.6",
-    "ipfs-car": "^0.5.1",
+    "ipfs-car": "web3-storage/ipfs-car#feat/support-custom-max-children-per-node",
     "ora": "^5.4.1",
     "sade": "^1.7.4",
     "web3.storage": "^2.0.0"


### PR DESCRIPTION
This makes `ipfs-car` packing with a `maxChunkSize` of  1048576  and a `maxChildrenPerNode` 1024.

We will keep using `sha256` hasher instead of [@multiformats/blake2](https://www.npmjs.com/package/@multiformats/blake2) given it is way slower (a minimal set of tests showed ~6x slower)

Needs:

- [x] https://github.com/web3-storage/ipfs-car/pull/67

resolves #173