### PR TITLE
chore: enable cron jobs for prod

### DIFF
--- a/.github/workflows/cron-pinata.yml
+++ b/.github/workflows/cron-pinata.yml
@@ -10,8 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        # env: ['staging', 'production']
-        env: ['staging']
+        env: ['staging', 'production']
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/cron-pins.yml
+++ b/.github/workflows/cron-pins.yml
@@ -10,8 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        # env: ['staging', 'production']
-        env: ['staging']
+        env: ['staging', 'production']
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
Start the crons for prod to set pin status, dag size, and backup to pinata

License: (Apache-2.0 AND MIT)
Signed-off-by: Oli Evans <oli@tableflip.io>