### PR TITLE
Chore: files page date format

### DIFF
--- a/packages/website/pages/files.js
+++ b/packages/website/pages/files.js
@@ -32,7 +32,7 @@ export function getStaticProps() {
  * @returns {string}
  */
 const formatTimestamp = (timestamp) => {
-  return new Date(timestamp).toLocaleDateString('pt-pt', {
+  return new Date(timestamp).toLocaleDateString(undefined, {
     year: 'numeric',
     month: 'numeric',
     day: 'numeric',

--- a/packages/website/pages/files.js
+++ b/packages/website/pages/files.js
@@ -32,20 +32,12 @@ export function getStaticProps() {
  * @returns {string}
  */
 const formatTimestamp = (timestamp) => {
-  const date = new Date(timestamp)
-  const today = new Date();
-  const isSameDay = date.getUTCDay() === today.getUTCDay() && date.getUTCMonth() === today.getUTCMonth() && date.getFullYear() === today.getFullYear()
-
-  if(isSameDay) {
-    return new Date(timestamp).toLocaleTimeString(undefined, {
-      hour: '2-digit',
-      minute:'2-digit',
-    })
-  }
-  return new Date(timestamp).toLocaleDateString(undefined, {
+  return new Date(timestamp).toLocaleDateString('pt-pt', {
     year: 'numeric',
     month: 'numeric',
     day: 'numeric',
+    hour: 'numeric',
+    minute: 'numeric',
   }) 
 }
 
@@ -116,7 +108,7 @@ const UploadItem = ({ upload, index, toggle, selectedFiles }) => {
         <Checkbox className="mr-2" checked={checked} onChange={() => toggle(upload.cid)}/>
       </td>
       <TableElement {...sharedArgs}>
-        <span title={upload.created}>{formatTimestamp(upload.created)}</span>
+        <span title={upload.created} className="break-normal">{formatTimestamp(upload.created)}</span>
       </TableElement>
       <TableElement {...sharedArgs} important>{upload.name}</TableElement>
       <TableElement {...sharedArgs} important>


### PR DESCRIPTION
Now the date always show Date + Time depending on the user's locale

American: 
![image](https://user-images.githubusercontent.com/24696635/127013283-b9fdc2de-6c9d-4f14-a9db-dbbb7ff23d68.png)

Portuguese:
![image](https://user-images.githubusercontent.com/24696635/127013314-4cd3b864-592b-4842-801f-25dbf05867cc.png)


Closes https://github.com/web3-storage/web3.storage/issues/164