### PR TITLE
fix: get version of w3 cmd from package.json

### DIFF
--- a/packages/w3/bin.js
+++ b/packages/w3/bin.js
@@ -1,11 +1,12 @@
 #!/usr/bin/env node
 
 import sade from 'sade'
-import { get, put, status, token } from './index.js'
+import { get, put, status, token, getPkg } from './index.js'
 
 const cli = sade('w3')
 
 cli
+  .version(getPkg().version)
   .example('put path/to/files')
   .example('get bafkreigh2akiscaildcqabsyg3dfr6chu3fgpregiymsck7e7aqa4s52zy -o room-guardian.jpg')
 

--- a/packages/w3/index.js
+++ b/packages/w3/index.js
@@ -1,3 +1,4 @@
+import fs from 'fs'
 import { writeFiles } from 'ipfs-car/unpack/fs'
 import { Web3Storage, filesFromPath } from 'web3.storage'
 import enquirer from 'enquirer'
@@ -5,7 +6,11 @@ import Conf from 'conf'
 import ora from 'ora'
 
 const API = 'https://api.web3.storage'
-const config = new Conf()
+
+const config = new Conf({
+  projectName: 'w3',
+  projectVersion: getPkg().version
+})
 
 /**
  * Get a new API client configured either from opts or config
@@ -136,4 +141,8 @@ export async function put (path, opts) {
 function filesize (bytes) {
   const size = bytes / 1024 / 1024
   return `${size.toFixed(1)}MB`
+}
+
+export function getPkg () {
+  return JSON.parse(fs.readFileSync(new URL('./package.json', import.meta.url)))
 }

--- a/packages/w3/test/bin.spec.js
+++ b/packages/w3/test/bin.spec.js
@@ -11,6 +11,11 @@ describe('w3', () => {
       assert.match(err.stderr, /No command specified./)
     }
   })
+
+  it('--version', () => {
+    const { stdout } = execa.sync('./bin.js', ['--version'])
+    assert.match(stdout, /w3, \d.\d.\d/)
+  })
 })
 
 describe('w3 put', () => {


### PR DESCRIPTION
- Auto resolving of the package.json does not work for `sade` or `conf` in ESM world, so we do it manually.

```console
$ w3 --version
w3, 1.1.0
```

fixes #167
see: https://github.com/sindresorhus/conf/issues/150


License: (Apache-2.0 AND MIT)
Signed-off-by: Oli Evans <oli@tableflip.io>