### PR TITLE
chore: fix fauna_key used in cron

### DIFF
--- a/.github/workflows/cron-pinata.yml
+++ b/.github/workflows/cron-pinata.yml
@@ -28,7 +28,7 @@ jobs:
         env:
           DEBUG: '*'
           ENV: ${{ matrix.env }}
-          FAUNA_KEY: ${{ secrets.FAUNA_KEY }}
+          FAUNA_KEY: ${{ secrets.PROD_FAUNA_KEY }}
           STAGING_FAUNA_KEY: ${{ secrets.STAGING_FAUNA_KEY }}
           PINATA_JWT: ${{ secrets.PINATA_JWT }}
         run: npm run start:pinata -w packages/cron

--- a/.github/workflows/cron-pins.yml
+++ b/.github/workflows/cron-pins.yml
@@ -28,7 +28,7 @@ jobs:
         env:
           DEBUG: '*'
           ENV: ${{ matrix.env }}
-          FAUNA_KEY: ${{ secrets.FAUNA_KEY }}
+          FAUNA_KEY: ${{ secrets.PROD_FAUNA_KEY }}
           STAGING_FAUNA_KEY: ${{ secrets.STAGING_FAUNA_KEY }}
           CLUSTER_API_URL: ${{ secrets.CLUSTER_API_URL }}
           CLUSTER_BASIC_AUTH_TOKEN: ${{ secrets.CLUSTER_BASIC_AUTH_TOKEN }}


### PR DESCRIPTION
it `PROD_FAUNA_KEY`

License: (Apache-2.0 AND MIT)
Signed-off-by: Oli Evans <oli@tableflip.io>