### PR TITLE
fix: query cluster until we get a preferable pin status

### DIFF
--- a/packages/api/src/car.js
+++ b/packages/api/src/car.js
@@ -114,7 +114,7 @@ export async function carPost (request, env, ctx) {
     local: blob.size > LOCAL_ADD_THRESHOLD
   })
 
-  /** @type {ReturnType<toPins>[]} */
+  /** @type {ReturnType<toPins>} */
   let pins
   // Retrieve current pin status and info about the nodes pinning the content.
   // Keep querying Cluster until one of the nodes reports something other than

--- a/packages/website/pages/files.js
+++ b/packages/website/pages/files.js
@@ -62,6 +62,21 @@ const TableElement = ({ children, index = 0, checked, breakAll = true, centered,
 )
 
 /**
+ * @param {import('web3.storage/src/lib/interface').Pin[]} pins
+ * @returns {import('web3.storage/src/lib/interface').Pin['status'] | 'Queuing'}
+ */
+const getBestPinStatus = pins => {
+  const pin = pins.find(byStatus('Pinned')) || pins.find(byStatus('Pinning')) || pins.find(byStatus('PinQueued'))
+  return pin ? pin.status : 'Queuing'
+}
+
+/**
+ * @param {import('web3.storage/src/lib/interface').Pin['status']} status
+ * @returns {(pin: import('web3.storage/src/lib/interface').Pin) => boolean}
+ */
+const byStatus = status => pin => pin.status === status
+
+/**
  * @param {Object} props
  * @param {Upload} props.upload
  * @param {number} props.index
@@ -71,13 +86,7 @@ const TableElement = ({ children, index = 0, checked, breakAll = true, centered,
 const UploadItem = ({ upload, index, toggle, selectedFiles }) => {
   const checked = selectedFiles.includes(upload.cid)
   const sharedArgs = { index, checked }
-
-  let pinStatus = '-'
-  if (upload.pins.length) {
-    pinStatus = upload.pins.some(p => p.status === 'Pinned')
-      ? 'Pinned'
-      : upload.pins[0].status
-  }
+  const pinStatus = getBestPinStatus(upload.pins)
 
   const deals = upload.deals
     .filter(d => d.status !== 'Queued')


### PR DESCRIPTION
After initial add, Cluster will usually report "Unpinned" when queried immediately. This PR polls cluster for status after adding until a preferable pin status is obtained from at least one of the nodes i.e. PinQueued, Pinning or Pinned.

The UI now shows the best pin status we have across all pins.