### PR TITLE
fix: metrics immutable headers

### DIFF
--- a/packages/api/src/cors.js
+++ b/packages/api/src/cors.js
@@ -57,6 +57,9 @@ export function withCorsHeaders (handler) {
  * @returns {Response}
  */
 export function addCorsHeaders (request, response) {
+  // Clone the response so that it's no longer immutable
+  response = new Response(response.body)
+
   const origin = request.headers.get('origin')
   if (origin) {
     response.headers.set('Access-Control-Allow-Origin', origin)

--- a/packages/api/src/cors.js
+++ b/packages/api/src/cors.js
@@ -57,9 +57,8 @@ export function withCorsHeaders (handler) {
  * @returns {Response}
  */
 export function addCorsHeaders (request, response) {
-  // Clone the response so that it's no longer immutable
-  response = new Response(response.body)
-
+  // Clone the response so that it's no longer immutable (like if it comes from cache or fetch)
+  response = new Response(response.body, response)
   const origin = request.headers.get('origin')
   if (origin) {
     response.headers.set('Access-Control-Allow-Origin', origin)

--- a/packages/api/src/metrics.js
+++ b/packages/api/src/metrics.js
@@ -70,10 +70,13 @@ export async function metricsGet (request, env, ctx) {
     `web3storage_pins_status_failed_total ${findMetrics.pinsFailedTotal}`
   ].join('\n')
 
-  res = new Response(metrics)
+  res = new Response(metrics, {
+    headers: {
+      // cache metrics response
+      'Cache-Control': `public, max-age=${METRICS_CACHE_MAX_AGE}`
+    }
+  })
 
-  // cache metrics response
-  res.headers.set('Cache-Control', `public, max-age=${METRICS_CACHE_MAX_AGE}`)
   ctx.waitUntil(cache.put(request, res.clone()))
 
   return res


### PR DESCRIPTION
In production, GET /metrics was failing due to immutable headers. Let's just add them when creating the response