### PR TITLE
fix: account page ui makeover

### DIFF
--- a/packages/api/src/user.js
+++ b/packages/api/src/user.js
@@ -218,7 +218,7 @@ export async function userTokensGet (request, env) {
           name
           secret
           created
-          uploads {
+          uploads(_size: 1) {
             data {
               _id
             }

--- a/packages/api/src/user.js
+++ b/packages/api/src/user.js
@@ -228,6 +228,12 @@ export async function userTokensGet (request, env) {
     }
   `, { user: request.auth.user._id })
 
+  res.findAuthTokensByUser.data = res.findAuthTokensByUser.data.map(t => {
+    t.hasUploads = Boolean(t.uploads.data.length)
+    delete t.uploads
+    return t
+  })
+
   return new JSONResponse(res.findAuthTokensByUser.data)
 }
 

--- a/packages/api/src/user.js
+++ b/packages/api/src/user.js
@@ -218,6 +218,11 @@ export async function userTokensGet (request, env) {
           name
           secret
           created
+          uploads {
+            data {
+              _id
+            }
+          }
         }
       }
     }

--- a/packages/website/components/types.d.ts
+++ b/packages/website/components/types.d.ts
@@ -15,10 +15,12 @@ export interface LayoutProps {
 }
 
 export interface LayoutChildrenProps {
-  user?: {
-    issuer: string | null
-    publicAddress: string | null
-    email: string | null
-  },
+  user?: LayoutUser
   data: any
+}
+
+export interface LayoutUser {
+  issuer: string | null
+  publicAddress: string | null
+  email: string | null
 }

--- a/packages/website/content/file-a-request.js
+++ b/packages/website/content/file-a-request.js
@@ -4,9 +4,9 @@
 */
 
 export default ({
-    "mail": "support@web3.storage",
-    "subject": "Account Limit Increase Request",
-    "body": [
+    mail: "support@web3.storage",
+    subject: "Account Limit Increase Request",
+    body: [
         "### Name",
         "``` Please share the user authentication method (Github, Email) associated with your account ```",
         "",

--- a/packages/website/lib/api.js
+++ b/packages/website/lib/api.js
@@ -34,6 +34,22 @@ export async function getTokens() {
   return res.json()
 }
 
+export async function getStorage() {
+  const res = await fetch(API + '/user/account', {
+    method: 'GET',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: 'Bearer ' + (await getToken()),
+    },
+  })
+
+  if (!res.ok) {
+    throw new Error(`failed to get storage info: ${await res.text()}`)
+  }
+
+  return res.json()
+}
+
 /**
  * Delete Token
  *

--- a/packages/website/pages/account.js
+++ b/packages/website/pages/account.js
@@ -96,6 +96,7 @@ export default function Account({ user }) {
 
   const isLoaded = !isLoading && !isFetching
 
+  const hasUsedTokensToUploadBefore = tokens.some(t => Object.entries(t.uploads?.data || {}).length > 0)
   /**
    * @param {import('react').ChangeEvent<HTMLFormElement>} e
    */
@@ -124,55 +125,61 @@ export default function Account({ user }) {
             </div>
           </When>
           <When condition={isLoaded}>
-            <When condition={tokens.length === 0}>
+            <When condition={tokens.length === 0 || !hasUsedTokensToUploadBefore}>
               <div className="mt-9">
                 <h3 className="font-normal">Getting started</h3>
                 <div className="flex flex-wrap gap-x-10">
-                  <div className="flex flex-col items-center mt-10 justify-between h-96 max-w-full bg-white border border-w3storage-red py-12 px-10 text-center" style={{ maxWidth: '24rem'}}>
-                    <h3 className="font-normal">Create your first API token</h3>
-                    <p>
-                      Generate an API Token to embed into your projects!
-                    </p>
-                    <Button href='/new-token'>
-                      Create an API Token
-                    </Button>
-                  </div>
-                  <div className="flex flex-col items-center mt-10 justify-between h-96 max-w-full bg-white border border-w3storage-red py-12 px-10 text-center" style={{ maxWidth: '24rem'}}>
-                    <h3 className="font-normal">Start building</h3>
-                    <p>
-                      Start storing and retrieving files using our client library! See the docs for guides and walkthroughs!
-                    </p>
-                    <Button href="https://docs.web3.storage">
-                      Explore the docs
-                    </Button>
-                  </div>
+                  <When condition={tokens.length === 0}>
+                    <div className="flex flex-col items-center mt-10 justify-between h-96 max-w-full bg-white border border-w3storage-red py-12 px-10 text-center" style={{ maxWidth: '24rem'}}>
+                      <h3 className="font-normal">Create your first API token</h3>
+                      <p>
+                        Generate an API Token to embed into your projects!
+                      </p>
+                      <Button href='/new-token'>
+                        Create an API Token
+                      </Button>
+                    </div>
+                  </When>
+                  <When condition={tokens.length === 0 || !hasUsedTokensToUploadBefore}>
+                    <div className="flex flex-col items-center mt-10 justify-between h-96 max-w-full bg-white border border-w3storage-red py-12 px-10 text-center" style={{ maxWidth: '24rem'}}>
+                      <h3 className="font-normal">Start building</h3>
+                      <p>
+                        Start storing and retrieving files using our client library! See the docs for guides and walkthroughs!
+                      </p>
+                      <Button href="https://docs.web3.storage">
+                        Explore the docs
+                      </Button>
+                    </div>
+                  </When>
                 </div>
               </div>
             </When>
-            <div className="mt-9">
-              <h3 id="api-tokens" className="font-normal">API tokens</h3>
-              <div className="flex flex-wrap gap-x-14 mt-10">
-                <Link href='/new-token'>
-                  <button type="button" className="flex items-center justify-center text-center bg-w3storage-pink border-w3storage-red w-64 h-60 mb-12 p-9 hover:bg-w3storage-white">
-                    <p className="typography-body-title px-8">Create an API token</p>
-                  </button>
-                </Link>
-                {tokens.slice(0, 5).map(t => (
-                  <form
-                    key={t._id}
-                    data-value={t.secret}
-                    onSubmit={handleCopyToken}
-                    className="flex flex-col justify-between items-center text-center bg-white border border-w3storage-red w-64 h-60 mb-12 px-8 py-9"
-                  >
-                    <p className="text-xl break-all">{t.name}</p>
-                    <Button type="submit" wrapperClassName="w-full">{copied === t.secret ? 'Copied!' : 'Copy'}</Button>
-                  </form>
-                ))}
+            <When condition={tokens.length > 0}>
+              <div className="mt-9">
+                <h3 id="api-tokens" className="font-normal">API tokens</h3>
+                <div className="flex flex-wrap gap-x-14 mt-10">
+                  <Link href='/new-token'>
+                    <button type="button" className="flex items-center justify-center text-center bg-w3storage-pink border-w3storage-red w-64 h-60 mb-12 p-9 hover:bg-w3storage-white">
+                      <p className="typography-body-title px-8">Create an API token</p>
+                    </button>
+                  </Link>
+                  {tokens.slice(0, 5).map(t => (
+                    <form
+                      key={t._id}
+                      data-value={t.secret}
+                      onSubmit={handleCopyToken}
+                      className="flex flex-col justify-between items-center text-center bg-white border border-w3storage-red w-64 h-60 mb-12 px-8 py-9"
+                    >
+                      <p className="text-xl break-all">{t.name}</p>
+                      <Button type="submit" wrapperClassName="w-full">{copied === t.secret ? 'Copied!' : 'Copy'}</Button>
+                    </form>
+                  ))}
+                </div>
+                <div className="w-64">
+                  <Button href="/tokens">Manage tokens</Button>
+                </div>
               </div>
-              <div className="w-64">
-                <Button href="/tokens">Manage tokens</Button>
-              </div>
-            </div>
+            </When>
           </When>
         </main>
       </div>

--- a/packages/website/pages/account.js
+++ b/packages/website/pages/account.js
@@ -50,7 +50,7 @@ const StorageInfo = ({ user }) => {
   }, [])
 
   const isLoaded = !isLoading && !isFetching
-  const percentage = Math.ceil(storageData.usedStorage / MAX_STORAGE * 100)
+  const percentage = Math.ceil((storageData.usedStorage || 0) / MAX_STORAGE * 100)
 
   return <div>
     <When condition={ isLoaded }>

--- a/packages/website/pages/account.js
+++ b/packages/website/pages/account.js
@@ -112,7 +112,7 @@ export default function Account({ user }) {
     <div className="relative overflow-hidden z-0">
       <When condition={isLoaded}>
         <div className="absolute top-10 right-0 pointer-events-none bottom-0 hidden sm:block z-n1">
-          <VerticalLines className="h-full" style={{ maxWidth: 200 }} />
+          <VerticalLines className="h-full"/>
         </div>
       </When>
       <div className="layout-margins">

--- a/packages/website/pages/account.js
+++ b/packages/website/pages/account.js
@@ -162,10 +162,10 @@ export default function Account({ user }) {
                     key={t._id}
                     data-value={t.secret}
                     onSubmit={handleCopyToken}
-                    className="flex flex-col justify-between items-center text-center bg-white border border-w3storage-red w-64 h-60 mb-12 p-9"
+                    className="flex flex-col justify-between items-center text-center bg-white border border-w3storage-red w-64 h-60 mb-12 px-8 py-9"
                   >
-                    <p className="typography-body-title px-8">{t.name}</p>
-                    <Button type="submit">{copied === t.secret ? 'Copied!' : 'Copy'}</Button>
+                    <p className="text-xl break-all">{t.name}</p>
+                    <Button type="submit" wrapperClassName="w-full">{copied === t.secret ? 'Copied!' : 'Copy'}</Button>
                   </form>
                 ))}
               </div>

--- a/packages/website/pages/account.js
+++ b/packages/website/pages/account.js
@@ -96,7 +96,7 @@ export default function Account({ user }) {
 
   const isLoaded = !isLoading && !isFetching
 
-  const hasUsedTokensToUploadBefore = tokens.some(t => Object.entries(t.uploads?.data || {}).length > 0)
+  const hasUsedTokensToUploadBefore = tokens.some(t => t.hasUploads)
   /**
    * @param {import('react').ChangeEvent<HTMLFormElement>} e
    */

--- a/packages/website/pages/tokens.js
+++ b/packages/website/pages/tokens.js
@@ -6,7 +6,8 @@ import { deleteToken, getTokens } from '../lib/api'
 import Button from '../components/button.js'
 import Loading from '../components/loading.js'
 
-/** @typedef {{ _id: string, name: string, secret: string }} Token */
+/** @typedef {{ data: Object[] }} TokenUploads */
+/** @typedef {{ _id: string, name: string, secret: string, uploads?: TokenUploads }} Token */
 
 /**
  * @returns {{ props: import('../components/types.js').LayoutProps}}

--- a/packages/website/pages/tokens.js
+++ b/packages/website/pages/tokens.js
@@ -6,8 +6,7 @@ import { deleteToken, getTokens } from '../lib/api'
 import Button from '../components/button.js'
 import Loading from '../components/loading.js'
 
-/** @typedef {{ data: Object[] }} TokenUploads */
-/** @typedef {{ _id: string, name: string, secret: string, uploads?: TokenUploads }} Token */
+/** @typedef {{ _id: string, name: string, secret: string, hasUploads?: boolean }} Token */
 
 /**
  * @returns {{ props: import('../components/types.js').LayoutProps}}

--- a/packages/website/styles/global.css
+++ b/packages/website/styles/global.css
@@ -210,6 +210,14 @@ body {
   animation: appear-bottom-then-go-away 3s ease-in-out both;
 }
 
+@keyframes grow-width {
+  from   { width: 0  }
+}
+
+.grow-width {
+  animation: grow-width 1s ease-in-out both;
+}
+
 .prose h1 > a,
 .prose h2 > a,
 .prose h3 > a,


### PR DESCRIPTION
- Makes the account page a beautiful pixel-perfect page by matching the figma specs
![image](https://user-images.githubusercontent.com/24696635/127490382-6e77b199-2018-4cfd-828d-d9e581d126d1.png)

- Account page now fetches storage capacity and shows it accordingly (with a sexy animation)

https://user-images.githubusercontent.com/24696635/127491981-a16b1b7e-8439-4a68-86b6-5bfc00969989.mov


- Fixes token cards with huge titles 
![image](https://user-images.githubusercontent.com/24696635/127491583-a102ed23-30ca-4b53-b908-7abd9059028e.png)

