### PR TITLE
feat: restrict block size

### DIFF
--- a/packages/api/src/constants.js
+++ b/packages/api/src/constants.js
@@ -3,3 +3,5 @@ export const JWT_ISSUER = 'web3-storage'
 export const METRICS_CACHE_MAX_AGE = 10 * 60 // in seconds (10 minutes)
 export const LOCAL_ADD_THRESHOLD = 1024 * 1024 * 2.5
 export const DAG_SIZE_CALC_LIMIT = 1024 * 1024 * 9
+// Maximum permitted block size in bytes.
+export const MAX_BLOCK_SIZE = 1 << 20 // 1MiB

--- a/packages/api/test/mocks/db/post_graphql.js
+++ b/packages/api/test/mocks/db/post_graphql.js
@@ -34,7 +34,10 @@ module.exports = ({ body }) => {
           _id: 'test-auth-token',
           name: 'Test Auth Token',
           secret: 'test-auth-token-secret',
-          created: Date.now()
+          created: Date.now(),
+          uploads: {
+            data: []
+          }
         }]
       }
     })


### PR DESCRIPTION
Adds a restriction to CAR uploads to ensure we don't store a block that cannot be transferred over the IPFS network.