### PR TITLE
chore: change ci node version to 16.5

### DIFF
--- a/.github/workflows/api.yml
+++ b/.github/workflows/api.yml
@@ -21,7 +21,7 @@ jobs:
       - uses: microsoft/playwright-github-action@v1
       - uses: actions/setup-node@v2
         with:
-          node-version: 16
+          node-version: 16.5
       - uses: bahmutov/npm-install@v1
       - run: npm run build --workspace packages/api
       - run: npm test --workspace packages/api
@@ -35,7 +35,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
         with:
-          node-version: 16
+          node-version: 16.5
       - uses: bahmutov/npm-install@v1
       - name: Publish api worker
         # workaround for https://github.com/cloudflare/wrangler-action/issues/59 to use node 16

--- a/.github/workflows/client.yml
+++ b/.github/workflows/client.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
         with:
-          node-version: 16
+          node-version: 16.5
       - uses: bahmutov/npm-install@v1
       - run: npm run build --workspace packages/client
       - run: npm test --workspace packages/client

--- a/.github/workflows/cron-pinata.yml
+++ b/.github/workflows/cron-pinata.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Setup node
         uses: actions/setup-node@v1
         with:
-          node-version: 16
+          node-version: 16.5
 
       - name: Install dependencies
         uses: bahmutov/npm-install@v1

--- a/.github/workflows/cron-pins.yml
+++ b/.github/workflows/cron-pins.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Setup node
         uses: actions/setup-node@v1
         with:
-          node-version: 16
+          node-version: 16.5
 
       - name: Install dependencies
         uses: bahmutov/npm-install@v1

--- a/.github/workflows/db.yml
+++ b/.github/workflows/db.yml
@@ -24,7 +24,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
         with:
-          node-version: 16
+          node-version: 16.5
       - uses: bahmutov/npm-install@v1
       - name: Update FaunaDB resources
         run: npm run import -w packages/db

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -14,6 +14,6 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
         with:
-          node-version: 16
+          node-version: 16.5
       - uses: bahmutov/npm-install@v1
       - run: npm run lint

--- a/.github/workflows/w3.yml
+++ b/.github/workflows/w3.yml
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
         with:
-          node-version: 16
+          node-version: 16.5
       # Only install the deps directly listed... dont do workspace magic.
       # Running install from the root gets you all the deps for all the packages.
       # which can easily mask missing deps if another modules also depends on it.

--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
         with:
-          node-version: 16
+          node-version: 16.5
       - uses: bahmutov/npm-install@v1
       - run: npm test --workspace packages/website
 
@@ -33,7 +33,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
         with:
-          node-version: 16
+          node-version: 16.5
       - uses: bahmutov/npm-install@v1
       - run: npm run build -w packages/client
       - run: npm run build -w packages/website

--- a/package-lock.json
+++ b/package-lock.json
@@ -17514,7 +17514,7 @@
     },
     "packages/api": {
       "name": "@web3-storage/api",
-      "version": "3.1.0",
+      "version": "3.1.1",
       "license": "(Apache-2.0 AND MIT)",
       "dependencies": {
         "@ipld/car": "^3.1.4",


### PR DESCRIPTION
`npm run build --workspace=packages/api` fails with node 16.6, so we should stick to node 16.5 for now.