### PR TITLE
fix: force webpack to load ESM config

### DIFF
--- a/.github/workflows/api.yml
+++ b/.github/workflows/api.yml
@@ -21,7 +21,7 @@ jobs:
       - uses: microsoft/playwright-github-action@v1
       - uses: actions/setup-node@v2
         with:
-          node-version: 16.5
+          node-version: 16
       - uses: bahmutov/npm-install@v1
       - run: npm run build --workspace packages/api
       - run: npm test --workspace packages/api
@@ -35,7 +35,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
         with:
-          node-version: 16.5
+          node-version: 16
       - uses: bahmutov/npm-install@v1
       - name: Publish api worker
         # workaround for https://github.com/cloudflare/wrangler-action/issues/59 to use node 16

--- a/.github/workflows/client.yml
+++ b/.github/workflows/client.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
         with:
-          node-version: 16.5
+          node-version: 16
       - uses: bahmutov/npm-install@v1
       - run: npm run build --workspace packages/client
       - run: npm test --workspace packages/client

--- a/.github/workflows/cron-pinata.yml
+++ b/.github/workflows/cron-pinata.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Setup node
         uses: actions/setup-node@v1
         with:
-          node-version: 16.5
+          node-version: 16
 
       - name: Install dependencies
         uses: bahmutov/npm-install@v1

--- a/.github/workflows/cron-pins.yml
+++ b/.github/workflows/cron-pins.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Setup node
         uses: actions/setup-node@v1
         with:
-          node-version: 16.5
+          node-version: 16
 
       - name: Install dependencies
         uses: bahmutov/npm-install@v1

--- a/.github/workflows/db.yml
+++ b/.github/workflows/db.yml
@@ -24,7 +24,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
         with:
-          node-version: 16.5
+          node-version: 16
       - uses: bahmutov/npm-install@v1
       - name: Update FaunaDB resources
         run: npm run import -w packages/db

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -14,6 +14,6 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
         with:
-          node-version: 16.5
+          node-version: 16
       - uses: bahmutov/npm-install@v1
       - run: npm run lint

--- a/.github/workflows/w3.yml
+++ b/.github/workflows/w3.yml
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
         with:
-          node-version: 16.5
+          node-version: 16
       # Only install the deps directly listed... dont do workspace magic.
       # Running install from the root gets you all the deps for all the packages.
       # which can easily mask missing deps if another modules also depends on it.

--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
         with:
-          node-version: 16.5
+          node-version: 16
       - uses: bahmutov/npm-install@v1
       - run: npm test --workspace packages/website
 
@@ -33,7 +33,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
         with:
-          node-version: 16.5
+          node-version: 16
       - uses: bahmutov/npm-install@v1
       - run: npm run build -w packages/client
       - run: npm run build -w packages/website

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -11,7 +11,7 @@
     "start": "wrangler dev --env $(whoami)",
     "dev": "wrangler dev --env $(whoami)",
     "publish": "wrangler publish --env $(whoami)",
-    "build": "webpack",
+    "build": "WEBPACK_CLI_FORCE_LOAD_ESM_CONFIG=true webpack",
     "test": "npm-run-all -p -r mock:cluster mock:db test:e2e -s test:size",
     "test:size": "bundlesize",
     "test:e2e": "playwright-test \"test/**/*.spec.js\" --sw src/index.js -b webkit",


### PR DESCRIPTION
since node 16.6 webpack-cli fails to load esm config unless WEBPACK_CLI_FORCE_LOAD_ESM_CONFIG=true

see: https://github.com/nodejs/node/pull/39175
see: https://github.com/webpack/webpack-cli/blob/a660ffcbeb2807bce1554f787297e697464abd59/packages/webpack-cli/lib/webpack-cli.js#L50-L51

License: (Apache-2.0 AND MIT)
Signed-off-by: Oli Evans <oli@tableflip.io>