### PR TITLE
fix: update usedStorage for chunked uploads

### DIFF
--- a/packages/db/fauna/resources/Function/createUpload.js
+++ b/packages/db/fauna/resources/Function/createUpload.js
@@ -63,7 +63,17 @@ const body = Query(
               },
               If(
                 IsNonEmpty(Var('uploadMatch')),
-                Get(Var('uploadMatch')),
+                Do(
+                  Update(Var('userRef'), {
+                    data: {
+                      usedStorage: Add(
+                        Select(['usedStorage'], Get(Var('userRef')), 0),
+                        Select(['chunkSize'], Var('data'))
+                      )
+                    }
+                  }),
+                  Get(Var('uploadMatch'))
+                ),
                 Let(
                   {
                     upload: Create('Upload', {


### PR DESCRIPTION
If an existing upload object is found we currently return it, without updating the user's `usedStorage` with the `chunkSize`.

It's more likely that this is a chunked upload and we need to add on the chunk size to the user's `usedStorage`.