### PR TITLE
fix: move pin ok status polling into waitUntil

### DIFF
--- a/packages/api/src/utils/pin.js
+++ b/packages/api/src/utils/pin.js
@@ -1,3 +1,20 @@
+/**
+ * @typedef {import('@nftstorage/ipfs-cluster').TrackerStatus} TrackerStatus
+ * @typedef {'Undefined'
+ *  | 'ClusterError'
+ *  | 'PinError'
+ *  | 'UnpinError'
+ *  | 'Pinned'
+ *  | 'Pinning'
+ *  | 'Unpinning'
+ *  | 'Unpinned'
+ *  | 'Remote'
+ *  | 'PinQueued'
+ *  | 'UnpinQueued'
+ *  | 'Sharded'} PinStatus
+ */
+
+/** @type {Record<TrackerStatus, PinStatus>} */
 const PinStatusMap = {
   undefined: 'Undefined',
   cluster_error: 'ClusterError',
@@ -15,7 +32,7 @@ const PinStatusMap = {
 
 /**
  * Converts from cluster status string to DB pin status enum string.
- * @param {import('@nftstorage/ipfs-cluster').TrackerStatus} trackerStatus
+ * @param {TrackerStatus} trackerStatus
  */
 export function toPinStatusEnum (trackerStatus) {
   if (typeof trackerStatus !== 'string') {


### PR DESCRIPTION
This PR moves the pin status polling into `waitUntil` and increases the periodi between polls and the max amount of time to spend polling.

This will hopefully result in faster uploads and quicker pin status updates.