### PR TITLE
fix: increment user used storage in waitUntil

### DIFF
--- a/packages/db/fauna/resources/Function/createUpload.js
+++ b/packages/db/fauna/resources/Function/createUpload.js
@@ -24,8 +24,7 @@ const {
   Not,
   Do,
   Call,
-  Foreach,
-  Add
+  Foreach
 } = fauna
 
 const name = 'createUpload'
@@ -63,17 +62,7 @@ const body = Query(
               },
               If(
                 IsNonEmpty(Var('uploadMatch')),
-                Do(
-                  Update(Var('userRef'), {
-                    data: {
-                      usedStorage: Add(
-                        Select(['data', 'usedStorage'], Get(Var('userRef')), 0),
-                        Select(['chunkSize'], Var('data'))
-                      )
-                    }
-                  }),
-                  Get(Var('uploadMatch'))
-                ),
+                Get(Var('uploadMatch')),
                 Let(
                   {
                     upload: Create('Upload', {
@@ -99,15 +88,6 @@ const body = Query(
                         })
                       )
                     ),
-                    // Update user storage size
-                    Update(Var('userRef'), {
-                      data: {
-                        usedStorage: Add(
-                          Select(['data', 'usedStorage'], Get(Var('userRef')), 0),
-                          Select(['chunkSize'], Var('data'))
-                        )
-                      }
-                    }),
                     Var('upload')
                   )
                 )
@@ -154,15 +134,6 @@ const body = Query(
                     })
                   )
                 ),
-                // Update user storage size
-                Update(Var('userRef'), {
-                  data: {
-                    usedStorage: Add(
-                      Select(['data', 'usedStorage'], Get(Var('userRef')), 0),
-                      Select(['chunkSize'], Var('data'))
-                    )
-                  }
-                }),
                 Var('upload')
               )
             )

--- a/packages/db/fauna/resources/Function/incrementUserUsedStorage.js
+++ b/packages/db/fauna/resources/Function/incrementUserUsedStorage.js
@@ -1,0 +1,42 @@
+import fauna from 'faunadb'
+
+const {
+  Function,
+  CreateFunction,
+  Query,
+  Lambda,
+  Let,
+  Var,
+  If,
+  Update,
+  Exists,
+  Ref,
+  Collection,
+  Get,
+  Add,
+  Select
+} = fauna
+
+const name = 'incrementUserUsedStorage'
+const body = Query(
+  Lambda(
+    ['userId', 'amount'],
+    Let(
+      {
+        userRef: Ref(Collection('User'), Var('userId')),
+        usedStorage: Select(['data', 'usedStorage'], Get(Var('userRef')), 0)
+      },
+      Update(Var('userRef'), {
+        data: {
+          usedStorage: Add(Var('usedStorage'), Var('amount'))
+        }
+      })
+    )
+  )
+)
+
+export default If(
+  Exists(Function(name)),
+  Update(Function(name), { name, body }),
+  CreateFunction({ name, body })
+)

--- a/packages/db/fauna/schema.graphql
+++ b/packages/db/fauna/schema.graphql
@@ -404,6 +404,7 @@ type Mutation {
   updateContentDagSize(content: ID!, dagSize: Long!): Content! @resolver
   createPinRequest(cid: String!): PinRequest! @resolver
   incrementPinRequestAttempts(pinRequest: ID!): PinRequest! @resolver
+  incrementUserUsedStorage(user: ID!, amount: Long!): User! @resolver
 }
 
 type Metrics {
@@ -470,7 +471,7 @@ input CreateUploadInput {
   type: UploadType!
   name: String
   dagSize: Long
-  chunkSize: Long!
+  chunkSize: Long # decremented, unused
   pins: [PinInput!]!
 }
 


### PR DESCRIPTION
This PR alters the `createUpload` UDF to not update the user's `usedStorage` and changes the API to call a separate small UDF called `incrementUserUsedStorage` as a background task.

Having a separate function just for updating `usedStorage` will hopefully decrease lock contention and running in `waitUntil` ensures the overall request does not fail even if we're not able to do the accounting.