### PR TITLE
fix: find pins by status sort by created DESC

### DIFF
--- a/packages/db/fauna/resources/Function/findPinsByStatus.js
+++ b/packages/db/fauna/resources/Function/findPinsByStatus.js
@@ -28,7 +28,7 @@ const body = Query(
         match: Union(
           Map(
             Var('statuses'),
-            Lambda('status', Match(Index('pin_by_status'), Var('status')))
+            Lambda('status', Match(Index('pin_by_status_sort_by_created_desc'), Var('status')))
           )
         ),
         page: If(

--- a/packages/db/fauna/resources/Function/findPinsByStatus.js
+++ b/packages/db/fauna/resources/Function/findPinsByStatus.js
@@ -41,7 +41,7 @@ const body = Query(
           Paginate(Var('match'), { size: Var('size'), before: Var('before') })
         )
       },
-      Map(Var('page'), Lambda(['ref'], Get(Var('ref'))))
+      Map(Var('page'), Lambda(['created', 'ref'], Get(Var('ref'))))
     )
   )
 )

--- a/packages/db/fauna/resources/Index/pinByStatusSortByCreatedDesc.js
+++ b/packages/db/fauna/resources/Index/pinByStatusSortByCreatedDesc.js
@@ -12,13 +12,17 @@ const {
 /**
  * Usage:
  *
- * Match(Index('pin_by_status'), "Pinning")
+ * Match(Index('pin_by_status_sort_by_created_desc'), "Pinning")
  */
 const index = {
-  name: 'pin_by_status',
+  name: 'pin_by_status_sort_by_created_desc',
   source: Collection('Pin'),
   terms: [
     { field: ['data', 'status'] }
+  ],
+  values: [
+    { field: ['data', 'created'], reverse: true },
+    { field: 'ref' }
   ]
 }
 


### PR DESCRIPTION
This means we process the head of the queue first.