### PR TITLE
feat: `w3 put --no-retry`

### DIFF
--- a/packages/w3/bin.js
+++ b/packages/w3/bin.js
@@ -13,12 +13,13 @@ cli
 cli.command('token')
   .option('--api', 'URL for the Web3 Storage API. Default: https://api.web3.storage')
   .option('--delete', 'Delete your saved token')
-  .describe('Save an API token to use for all requests.')
+  .describe('Save an API token to use for all requests')
   .action(token)
 
 cli.command('put <path>')
   .describe('Upload a file or directory to web3.storage')
-  .option('--no-wrap', 'Dont wrap input files with a directory.')
+  .option('--no-wrap', 'Dont wrap input files with a directory')
+  .option('--no-retry', 'Dont try the upload again if it fails')
   .action(put)
 
 cli.command('list')
@@ -35,7 +36,7 @@ cli.command('get <cid>')
   .action(get)
 
 cli.command('status <cid>')
-  .describe('Get the Filecoin deals and IPFS pins that contain a given CID, as JSON.')
+  .describe('Get the Filecoin deals and IPFS pins that contain a given CID, as JSON')
   .example('status bafkreigh2akiscaildcqabsyg3dfr6chu3fgpregiymsck7e7aqa4s52zy')
   .action(status)
 

--- a/packages/w3/index.js
+++ b/packages/w3/index.js
@@ -139,10 +139,20 @@ export async function list (opts = {}) {
  * @param {string} [opts.api]
  * @param {string} [opts.token]
  * @param {string} [opts.wrap] wrap with directory
+ * @param {boolean|number} [opts.retry] set maxRetries for client.put
  * @param {string[]} opts._ additonal paths to add
  */
 export async function put (path, opts) {
   const client = getClient(opts)
+
+  // pass either --no-retry or --retry <number>
+  const maxRetries = Number.isInteger(Number(opts.retry))
+    ? Number(opts.retry)
+    : opts.retry === false ? 0 : undefined
+  if (maxRetries !== undefined) {
+    console.log(`⁂ maxRetries: ${maxRetries}`)
+  }
+
   const spinner = ora('Packing files').start()
   const paths = [path, ...opts._]
   const files = []
@@ -156,7 +166,9 @@ export async function put (path, opts) {
     }
   }
   let rootCid = ''
+
   const root = await client.put(files, {
+    maxRetries,
     wrapWithDirectory: opts.wrap,
     onRootCidReady: (cid) => {
       rootCid = cid


### PR DESCRIPTION
- Pass `--no-retry` to `w3 put` to have it fail on the first error. Useful for debugging.
- If you want to get really specific you can pass `--retry <number>` to assert how many times you want to try.

```console
$ w3 put pinpie.jpg --no-retry
⁂ using api-staging.web3.storage
⁂ maxRetries: 0
...
```

```console
$ w3 put -h

  Description
    Upload a file or directory to web3.storage

  Usage
    $ w3 put <path> [options]

  Options
    --no-wrap     Dont wrap input files with a directory.
    --no-retry    Dont try the upload again if it errors.
    -h, --help    Displays this message
```

License: (Apache-2.0 AND MIT)
Signed-off-by: Oli Evans <oli@tableflip.io>