### PR TITLE
perf: faster pin status sync

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12858,6 +12858,11 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/piggybacker": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/piggybacker/-/piggybacker-2.0.0.tgz",
+      "integrity": "sha512-t68lHZFQx2j03NtqzWPplWS+qind2ZtPZE0HOoiW9EDrV/FoLngZmPhSpbLawRGW7oy/b77PossrB74KJBPrnQ=="
+    },
     "node_modules/pkg-conf": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/pkg-conf/-/pkg-conf-3.1.0.tgz",
@@ -17615,7 +17620,7 @@
     },
     "packages/client": {
       "name": "web3.storage",
-      "version": "3.1.0",
+      "version": "3.2.0",
       "license": "(Apache-2.0 AND MIT)",
       "dependencies": {
         "@ipld/car": "^3.1.4",
@@ -17709,7 +17714,8 @@
         "dotenv": "^9.0.2",
         "limiter": "2.0.1",
         "node-fetch": "^2.6.1",
-        "p-retry": "^4.6.1"
+        "p-retry": "^4.6.1",
+        "piggybacker": "^2.0.0"
       },
       "devDependencies": {
         "@types/node": "^16.3.1",
@@ -20309,7 +20315,8 @@
         "limiter": "2.0.1",
         "node-fetch": "^2.6.1",
         "npm-run-all": "^4.1.5",
-        "p-retry": "^4.6.1"
+        "p-retry": "^4.6.1",
+        "piggybacker": "*"
       },
       "dependencies": {
         "dotenv": {
@@ -28354,6 +28361,11 @@
       "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
       "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
       "dev": true
+    },
+    "piggybacker": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/piggybacker/-/piggybacker-2.0.0.tgz",
+      "integrity": "sha512-t68lHZFQx2j03NtqzWPplWS+qind2ZtPZE0HOoiW9EDrV/FoLngZmPhSpbLawRGW7oy/b77PossrB74KJBPrnQ=="
     },
     "pkg-conf": {
       "version": "3.1.0",

--- a/packages/cron/package.json
+++ b/packages/cron/package.json
@@ -21,7 +21,8 @@
     "dotenv": "^9.0.2",
     "limiter": "2.0.1",
     "node-fetch": "^2.6.1",
-    "p-retry": "^4.6.1"
+    "p-retry": "^4.6.1",
+    "piggybacker": "^2.0.0"
   },
   "devDependencies": {
     "@types/node": "^16.3.1",

--- a/packages/db/fauna/resources/Function/updatePins.js
+++ b/packages/db/fauna/resources/Function/updatePins.js
@@ -1,0 +1,45 @@
+import fauna from 'faunadb'
+
+const {
+  Function,
+  CreateFunction,
+  Query,
+  Lambda,
+  Select,
+  Var,
+  If,
+  Update,
+  Exists,
+  Map,
+  Ref,
+  Collection,
+  Now
+} = fauna
+
+const name = 'updatePins'
+const body = Query(
+  Lambda(
+    ['pins'],
+    Map(
+      Var('pins'),
+      Lambda(
+        'data',
+        Update(
+          Ref(Collection('Pin'), Select('pin', Var('data'))),
+          {
+            data: {
+              status: Select('status', Var('data')),
+              updated: Now()
+            }
+          }
+        )
+      )
+    )
+  )
+)
+
+export default If(
+  Exists(Function(name)),
+  Update(Function(name), { name, body }),
+  CreateFunction({ name, body })
+)

--- a/packages/db/fauna/schema.graphql
+++ b/packages/db/fauna/schema.graphql
@@ -429,6 +429,7 @@ type Mutation {
   incrementPinRequestAttempts(pinRequest: ID!): PinRequest! @resolver
   incrementUserUsedStorage(user: ID!, amount: Long!): User! @resolver
   createOrUpdateMetric(data: CreateOrUpdateMetricInput!): Metric! @resolver
+  updatePins(pins: [UpdatePinInput!]!): [Pin!]! @resolver
 }
 
 input CreateAggregateInput {
@@ -506,4 +507,9 @@ input CreateOrUpdatePinInput {
 input CreateOrUpdateMetricInput {
   key: String!
   value: Long!
+}
+
+input UpdatePinInput {
+  pin: ID!
+  status: PinStatus!
 }


### PR DESCRIPTION
This reduces the time taken to update pin statuses for 1,000 pins from ~15m to ~5s.

Status requests from cluster are super quick, but DB requests are slower. This switches to using a bulk update UDF, called once per 1,000 pins.

resolves https://github.com/web3-storage/web3.storage/issues/273