### PR TITLE
feat: additional UDFs for admin purposes

### DIFF
--- a/packages/db/fauna/resources/Function/deleteUploadByUserAndContent.js
+++ b/packages/db/fauna/resources/Function/deleteUploadByUserAndContent.js
@@ -1,0 +1,55 @@
+import fauna from 'faunadb'
+
+const {
+  Function,
+  CreateFunction,
+  Query,
+  Lambda,
+  Let,
+  Var,
+  If,
+  Update,
+  Exists,
+  Now,
+  Ref,
+  Abort,
+  Collection,
+  Get,
+  Match,
+  IsEmpty,
+  Select,
+  Index
+} = fauna
+
+const name = 'deleteUploadByUserAndContent'
+const body = Query(
+  Lambda(
+    ['userId', 'contentId'],
+    Let(
+      {
+        userRef: Ref(Collection('User'), Var('userId')),
+        contentRef: Ref(Collection('Content'), Var('contentId')),
+        uploadMatch: Match(
+          Index('upload_by_user_and_content'),
+          Var('userRef'),
+          Var('contentRef'),
+          true
+        )
+      },
+      If(
+        IsEmpty(Var('uploadMatch')),
+        Abort('upload not found'),
+        Update(
+          Select(['ref'], Get(Var('uploadMatch'))),
+          { data: { deleted: Now() } }
+        )
+      )
+    )
+  )
+)
+
+export default If(
+  Exists(Function(name)),
+  Update(Function(name), { name, body }),
+  CreateFunction({ name, body })
+)

--- a/packages/db/fauna/resources/Function/findContentByCreated.js
+++ b/packages/db/fauna/resources/Function/findContentByCreated.js
@@ -1,0 +1,52 @@
+import fauna from 'faunadb'
+
+const {
+  Function,
+  CreateFunction,
+  Query,
+  Lambda,
+  Var,
+  Exists,
+  If,
+  Update,
+  Paginate,
+  Map,
+  Equals,
+  Let,
+  Range,
+  Match,
+  Index,
+  Get
+} = fauna
+
+const name = 'findContentByCreated'
+const body = Query(
+  Lambda(
+    ['from', 'to', 'size', 'after', 'before'],
+    Let(
+      {
+        range: Range(
+          Match(Index('content_sort_by_created_asc')),
+          Var('from'),
+          Var('to')
+        ),
+        page: If(
+          Equals(Var('before'), null),
+          If(
+            Equals(Var('after'), null),
+            Paginate(Var('range'), { size: Var('size') }),
+            Paginate(Var('range'), { size: Var('size'), after: Var('after') })
+          ),
+          Paginate(Var('range'), { size: Var('size'), before: Var('before') })
+        )
+      },
+      Map(Var('page'), Lambda(['created', 'ref'], Get(Var('ref'))))
+    )
+  )
+)
+
+export default If(
+  Exists(Function(name)),
+  Update(Function(name), { name, body }),
+  CreateFunction({ name, body })
+)

--- a/packages/db/fauna/schema.graphql
+++ b/packages/db/fauna/schema.graphql
@@ -389,6 +389,7 @@ type Query {
   findUploadsCreatedAfter(since: Time!): [Upload!]! @resolver(paginated: true)
   findUploadsByUser(where: FindUploadsByUserInput!): [Upload!]! @resolver(paginated: true)
   findContentByCid(cid: String!): Content @resolver
+  findContentByCreated(from: Time!, to: Time): [Content!]! @resolver(paginated: true)
   findUserByIssuer(issuer: String!): User @resolver
   findAuthTokensByUser(user: ID!): [AuthToken!]! @resolver(paginated: true)
   """
@@ -414,6 +415,7 @@ type Mutation {
   createUpload(data: CreateUploadInput!): Upload! @resolver
   deleteAuthToken(user: ID!, authToken: ID!): AuthToken! @resolver
   deleteUserUpload(user: ID!, cid: String!): Upload! @resolver
+  deleteUploadByUserAndContent(user: ID!, content: ID!): Upload! @resolver
   createAggregate(data: CreateAggregateInput!): Aggregate! @resolver
   """
   Adds new entries to the aggregate, existing entries are ignored.


### PR DESCRIPTION
* `deleteUploadByUserAndContent` for cleaning up when we receive partial DAG and the full `dagSize` is never calculated. The existing UDF `deleteUserUpload` cannot be used for this purpose as it requires a `dagSize` so that it can do data usage accounting.
* `findContentByCreated` is for metrics generation on content.