### PR TITLE
fix: incremental metrics

### DIFF
--- a/packages/cron/src/jobs/metrics.js
+++ b/packages/cron/src/jobs/metrics.js
@@ -140,7 +140,7 @@ async function createMetric (db, key, query, vars, dataProp) {
   })
 
   console.log(`💾 Saving value for "${key}": ${total}`)
-  await db.query(CREATE_OR_UPDATE_METRIC, { data: { key, value: total } })
+  await db.query(CREATE_OR_UPDATE_METRIC, { data: { key, value: total, updated: to.toISOString() } })
 }
 
 /**
@@ -167,5 +167,5 @@ async function updateMetric (db, key, query, vars, dataProp) {
   }
 
   console.log(`💾 Saving new value for "${key}": ${metric.value + total}`)
-  await db.query(CREATE_OR_UPDATE_METRIC, { data: { key, value: metric.value + total } })
+  await db.query(CREATE_OR_UPDATE_METRIC, { data: { key, value: metric.value + total, updated: to.toISOString() } })
 }

--- a/packages/db/fauna/resources/Function/createOrUpdateMetric.js
+++ b/packages/db/fauna/resources/Function/createOrUpdateMetric.js
@@ -25,6 +25,7 @@ const body = Query(
     ['data'],
     Let(
       {
+        updated: Select('updated', Var('data'), Now()),
         match: Match(
           Index('unique_Metric_key'),
           Select('key', Var('data'))
@@ -36,13 +37,13 @@ const body = Query(
           data: {
             key: Select('key', Var('data')),
             value: Select('value', Var('data')),
-            updated: Now()
+            updated: Var('updated')
           }
         }),
         Update(Select('ref', Get(Var('match'))), {
           data: {
             value: Select('value', Var('data')),
-            updated: Now()
+            updated: Var('updated')
           }
         })
       )

--- a/packages/db/fauna/schema.graphql
+++ b/packages/db/fauna/schema.graphql
@@ -509,6 +509,7 @@ input CreateOrUpdatePinInput {
 input CreateOrUpdateMetricInput {
   key: String!
   value: Long!
+  updated: Time
 }
 
 input UpdatePinInput {


### PR DESCRIPTION
Allow specify the time the metric was updated. The "to date" is chosen when the cron starts and when it finishes it saves a metric with an updated date that is much further in the future than the chosen "to date". This PR changes the mutation and UDF to accept an `updated` date so next time the cron runs, it's "from date" is the previous runs "to date" and we don't miss any data in the counts.