### PR TITLE
fix: remove unused user metadata request

### DIFF
--- a/packages/website/components/layout.js
+++ b/packages/website/components/layout.js
@@ -3,7 +3,7 @@ import clsx from 'clsx'
 import Footer from './footer.js'
 import Navbar from './navbar.js'
 import Loading from './loading'
-import { useUser } from '../lib/user'
+import { useLoggedIn } from '../lib/user'
 
 /**
  * @typedef {import('react').ReactChildren} Children
@@ -16,7 +16,7 @@ import { useUser } from '../lib/user'
  */
 export default function Layout({
   callback,
-  needsUser = false,
+  needsLoggedIn = false,
   children,
   redirectTo,
   redirectIfFound = false,
@@ -28,12 +28,12 @@ export default function Layout({
   data = null,
   highlightMessage,
 }) {
-  const { user, isLoading, isFetching } = useUser({
+  const { isLoggedIn, isLoading, isFetching } = useLoggedIn({
     redirectTo,
     redirectIfFound,
-    enabled: needsUser,
+    enabled: needsLoggedIn,
   })
-  const shouldWaitForUser = needsUser && isLoading
+  const shouldWaitForLoggedIn = needsLoggedIn && isLoading
 
   return (
     <div className={clsx(pageBgColor, 'flex flex-col min-h-screen')}>
@@ -51,20 +51,20 @@ export default function Layout({
         <meta name="twitter:site" content="@protocollabs" />
         <meta name="twitter:creator" content="@protocollabs" />
       </Head>
-      {shouldWaitForUser ? (
+      {shouldWaitForLoggedIn ? (
         <Loading />
       ) : callback ? (
         <>
           <Loading />
-          {children({ user, data })}
+          {children({ isLoggedIn, data })}
         </>
       ) : (
         <>
           { highlightMessage &&
             <div className="w-full bg-w3storage-purple text-white typography-cta text-center py-1" dangerouslySetInnerHTML={{ __html: highlightMessage }} />
           }
-          <Navbar user={user} isLoadingUser={isLoading || isFetching} bgColor={navBgColor} />
-          {children({ user, data })}
+          <Navbar isLoggedIn={isLoggedIn} isLoadingUser={isLoading || isFetching} bgColor={navBgColor} />
+          {children({ isLoggedIn, data })}
           <Footer bgColor={footerBgColor} />
         </>
       )}

--- a/packages/website/components/navbar.js
+++ b/packages/website/components/navbar.js
@@ -11,10 +11,10 @@ import Button from './button.js'
  *
  * @param {Object} props
  * @param {string} [props.bgColor]
- * @param {any} [props.user]
+ * @param {boolean} [props.isLoggedIn]
  * @param {boolean} props.isLoadingUser
  */
-export default function Navbar({ bgColor = '', user, isLoadingUser }) {
+export default function Navbar({ bgColor = '', isLoggedIn, isLoadingUser }) {
   const queryClient = useQueryClient()
   const onLinkClick = useCallback((event) => {
     countly.trackCustomLinkClick(
@@ -45,7 +45,7 @@ export default function Navbar({ bgColor = '', user, isLoadingUser }) {
         <div className="flex items-center" style={{ minHeight: 52 }}>
           <Link href="https://docs.web3.storage/">
             <a
-              className={`text-sm text-w3storage-purple font-bold no-underline hover:underline align-middle p-3 py-3 md:px-6 ${user ? '' : 'mr-6 md:mr-0'}`}
+              className={`text-sm text-w3storage-purple font-bold no-underline hover:underline align-middle p-3 py-3 md:px-6 ${isLoggedIn ? '' : 'mr-6 md:mr-0'}`}
               onClick={onLinkClick}
             >
               Docs
@@ -53,13 +53,13 @@ export default function Navbar({ bgColor = '', user, isLoadingUser }) {
           </Link>
           <Link href="/about">
             <a 
-              className={`text-sm text-w3storage-purple font-bold no-underline hover:underline align-middle p-3 md:px-6 hidden md:inline-block ${user ? '' : 'md:mr-6'}`}
+              className={`text-sm text-w3storage-purple font-bold no-underline hover:underline align-middle p-3 md:px-6 hidden md:inline-block ${isLoggedIn ? '' : 'md:mr-6'}`}
               onClick={onLinkClick}
             >
               About
             </a>
           </Link>
-          {user ? (
+          {isLoggedIn ? (
             <>
               <Link href="/files">
                 <a
@@ -81,7 +81,7 @@ export default function Navbar({ bgColor = '', user, isLoadingUser }) {
           ) : null}
           {isLoadingUser
             ? null
-            : user
+            : isLoggedIn
               ? (
                 <Button
                   onClick={logout}

--- a/packages/website/components/types.d.ts
+++ b/packages/website/components/types.d.ts
@@ -2,7 +2,7 @@ import type { ReactChildren } from 'react'
 
 export interface LayoutProps {
   callback?: boolean
-  needsUser?: boolean
+  needsLoggedIn?: boolean
   redirectTo?: string
   redirectIfFound?: boolean
   title?: string
@@ -15,12 +15,6 @@ export interface LayoutProps {
 }
 
 export interface LayoutChildrenProps {
-  user?: LayoutUser
+  isLoggedIn?: boolean
   data: any
-}
-
-export interface LayoutUser {
-  issuer: string | null
-  publicAddress: string | null
-  email: string | null
 }

--- a/packages/website/lib/magic.js
+++ b/packages/website/lib/magic.js
@@ -41,15 +41,7 @@ export async function login(token, type = 'magic', data = {}) {
 }
 
 export async function isLoggedIn() {
-  const isLoggedIn = await getMagic().user.isLoggedIn()
-  if (isLoggedIn) {
-    const meta = await getMagic().user.getMetadata()
-    return {
-      ...meta, // we dont actually need the user info
-    }
-  } else {
-    return undefined
-  }
+  return getMagic().user.isLoggedIn()
 }
 
 /**

--- a/packages/website/lib/user.js
+++ b/packages/website/lib/user.js
@@ -5,7 +5,7 @@ import { useRouter } from 'next/router'
 import constants from './constants.js'
 
 /**
- * User Hook
+ * User Logged In Hook
  *
  * @param {Object} options
  * @param {string} [options.redirectTo]
@@ -13,15 +13,13 @@ import constants from './constants.js'
  * @param {boolean} [options.enabled]
  * @returns
  */
-export function useUser({ redirectTo, redirectIfFound, enabled } = {}) {
+export function useLoggedIn({ redirectTo, redirectIfFound, enabled } = {}) {
   const router = useRouter()
-  const { status, data, error, isFetching, isLoading } = useQuery('magic-user', isLoggedIn, {
+  const { status, data: loggedIn, error, isFetching, isLoading } = useQuery('magic-user', isLoggedIn, {
     staleTime: constants.MAGIC_TOKEN_LIFESPAN,
     refetchOnWindowFocus: false,
     refetchOnReconnect: false
   })
-  const user = data
-  const hasUser = Boolean(user)
 
   useEffect(() => {
     if (!redirectTo || isLoading || isFetching) {
@@ -29,13 +27,13 @@ export function useUser({ redirectTo, redirectIfFound, enabled } = {}) {
     }
     if (
       // If redirectTo is set, redirect if the user was not found.
-      (redirectTo && !redirectIfFound && !hasUser) ||
+      (redirectTo && !redirectIfFound && !loggedIn) ||
       // If redirectIfFound is also set, redirect if the user was found
-      (redirectIfFound && hasUser)
+      (redirectIfFound && loggedIn)
     ) {
       router.push(redirectTo)
     }
-  }, [redirectTo, redirectIfFound, status, isFetching, isLoading, hasUser, router, enabled])
+  }, [redirectTo, redirectIfFound, status, isFetching, isLoading, loggedIn, router, enabled])
 
-  return { status, user, error, isFetching, isLoading }
+  return { status, isLoggedIn: loggedIn, error, isFetching, isLoading }
 }

--- a/packages/website/pages/about.js
+++ b/packages/website/pages/about.js
@@ -12,7 +12,7 @@ import slug from 'remark-slug'
 
     return {
       props: {
-        needsUser: false,
+        needsLoggedIn: false,
         data: data.content,
       },
     }

--- a/packages/website/pages/account.js
+++ b/packages/website/pages/account.js
@@ -34,7 +34,8 @@ const MAX_STORAGE = 1.1e+12 /* 1 TB */
  */
 
 /**
- * @param {import('../components/types').LayoutChildrenProps} props
+ * @param {Object} props
+ * @param {boolean | undefined} [props.isLoggedIn]
  */
 const StorageInfo = ({ isLoggedIn }) => {
   const { data, isLoading, isFetching } = useQuery('get-storage', getStorage, {

--- a/packages/website/pages/account.js
+++ b/packages/website/pages/account.js
@@ -81,10 +81,10 @@ const StorageInfo = ({ isLoggedIn }) => {
 /**
  * @param {import('../components/types').LayoutChildrenProps} props
  */
-export default function Account({ user }) {
+export default function Account({ isLoggedIn }) {
   const [copied, setCopied] = useState('')
   const { data, isLoading, isFetching } = useQuery('get-tokens', getTokens, {
-    enabled: !!user
+    enabled: isLoggedIn
   })
   /** @type {import('./tokens').Token[]} */
   const tokens = data || []
@@ -131,7 +131,7 @@ export default function Account({ user }) {
       <div className="layout-margins">
         <main className="max-w-screen-lg mx-auto my-4 lg:my-16 text-w3storage-purple">
           <h3 className="mb-8">Your account</h3>
-          <StorageInfo user={user}/>
+          <StorageInfo isLoggedIn={isLoggedIn}/>
           <When condition={!isLoaded}>
             <div className="relative w-52 pt-60">
               <Loading />

--- a/packages/website/pages/account.js
+++ b/packages/website/pages/account.js
@@ -23,7 +23,7 @@ const MAX_STORAGE = 1.1e+12 /* 1 TB */
       props: {
         title: 'Account - Web3 Storage',
         redirectTo: '/',
-        needsUser: true,
+        needsLoggedIn: true,
       },
     }
 }
@@ -34,12 +34,11 @@ const MAX_STORAGE = 1.1e+12 /* 1 TB */
  */
 
 /**
- * @param {Object} props
- * @param {import('../components/types').LayoutUser} [props.user]
+ * @param {import('../components/types').LayoutChildrenProps} props
  */
-const StorageInfo = ({ user }) => {
+const StorageInfo = ({ isLoggedIn }) => {
   const { data, isLoading, isFetching } = useQuery('get-storage', getStorage, {
-    enabled: !!user,
+    enabled: isLoggedIn,
   })
 
   /** @type {StorageData} */

--- a/packages/website/pages/callback.js
+++ b/packages/website/pages/callback.js
@@ -11,7 +11,7 @@ export function getStaticProps() {
     props: {
       title: 'Login Redirect - Web3 Storage',
       callback: true,
-      needsUser: false,
+      needsLoggedIn: false,
     },
   }
 }

--- a/packages/website/pages/files.js
+++ b/packages/website/pages/files.js
@@ -27,7 +27,7 @@ export function getStaticProps() {
       title: 'Files - Web3 Storage',
       pageBgColor: 'bg-w3storage-neutral-red',
       redirectTo: '/',
-      needsUser: true,
+      needsLoggedIn: true,
     },
   }
 }
@@ -177,10 +177,8 @@ const UploadItem = ({ upload, index, toggle, selectedFiles, showCopiedMessage })
  * Files Page
  *
  * @param {import('../components/types.js').LayoutChildrenProps} props
- * @returns
-
  */
-export default function Files({ user }) {
+export default function Files({ isLoggedIn }) {
   /** @type string[] */
   const initialFiles = [];
 
@@ -197,7 +195,7 @@ export default function Files({ user }) {
     queryKey,
     (ctx) => getUploads(ctx.queryKey[1]),
     {
-      enabled: !!user,
+      enabled: isLoggedIn,
     }
   )
 

--- a/packages/website/pages/index.js
+++ b/packages/website/pages/index.js
@@ -24,7 +24,7 @@ import GettingStartedIllustration from '../illustrations/getting-started-illustr
 export function getStaticProps() {
   return {
     props: {
-      needsUser: false,
+      needsLoggedIn: false,
       navBgColor: 'bg-w3storage-red',
       footerBgColor: 'bg-w3storage-red',
       highlightMessage: `Looking to store NFTs? Check out <a class="underline" href="https://nft.storage">NFT.Storage</a>!</p>`

--- a/packages/website/pages/new-token.js
+++ b/packages/website/pages/new-token.js
@@ -16,7 +16,7 @@ export function getStaticProps() {
   return {
     props: {
       title: 'New API Token - Web3 Storage',
-      needsUser: true,
+      needsLoggedIn: true,
       redirectTo: '/',
     },
   }

--- a/packages/website/pages/tokens.js
+++ b/packages/website/pages/tokens.js
@@ -18,7 +18,7 @@ export function getStaticProps() {
     props: {
       title: 'Manage API Tokens - web3.storage',
       redirectTo: '/',
-      needsUser: true,
+      needsLoggedIn: true,
     },
   }
 }
@@ -95,12 +95,12 @@ const TokenRow = ({ token, index, copied, onCopy, deleting, onDelete }) => {
  * @param {import('../components/types.js').LayoutChildrenProps} props
  * @returns
  */
-export default function Tokens({ user }) {
+export default function Tokens({ isLoggedIn }) {
   const [deleting, setDeleting] = useState('')
   const [copied, setCopied] = useState('')
   const queryClient = useQueryClient()
   const { isLoading, isFetching, data } = useQuery('get-tokens', getTokens, {
-    enabled: !!user
+    enabled: isLoggedIn
   })
   /** @type Token[] */
   const tokens = data || []

--- a/packages/website/pages/upload.js
+++ b/packages/website/pages/upload.js
@@ -13,7 +13,7 @@ export function getStaticProps() {
     props: {
       title: "Upload - Web3 Storage",
       redirectTo: "/",
-      needsUser: true,
+      needsLoggedIn: true,
     },
   };
 }


### PR DESCRIPTION
This PR removes the call to `magic.user.getMetadata()`. We do no use the result of this call anywhere at the moment and it has been observed to add 0.5s onto the time it takes the site to determine if the user is logged in.