### PR TITLE
fix: remove second spinner for the account page

### DIFF
--- a/packages/website/pages/account.js
+++ b/packages/website/pages/account.js
@@ -28,7 +28,7 @@ const MAX_STORAGE = 1.1e+12 /* 1 TB */
     }
 }
 
-/** 
+/**
  * @typedef {Object} StorageData
  * @property {Number} usedStorage
  */
@@ -72,9 +72,6 @@ const StorageInfo = ({ isLoggedIn }) => {
           </span>
         </a>
       </p>
-    </When>
-    <When condition={ !isLoaded }>
-      <div className="relative w-52 p-10"><Loading /></div>
     </When>
   </div>
 }


### PR DESCRIPTION
Removes the second spinner for the account page - they're using the same variable so it's redundant to have both

Closes #337