### PR TITLE
feat: cron to update status for PinError pins

### DIFF
--- a/.github/workflows/cron-pins-failures.yml
+++ b/.github/workflows/cron-pins-failures.yml
@@ -1,0 +1,35 @@
+name: Cron Pins (Failures)
+
+on:
+  schedule:
+    - cron: '0 16 * * *'
+
+jobs:
+  update:
+    name: Update pin statuses and size for pins with PinError status
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        env: ['staging', 'production']
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Setup node
+        uses: actions/setup-node@v1
+        with:
+          node-version: 16
+
+      - name: Install dependencies
+        uses: bahmutov/npm-install@v1
+
+      - name: Run job
+        env:
+          DEBUG: '*'
+          ENV: ${{ matrix.env }}
+          FAUNA_KEY: ${{ secrets.PROD_FAUNA_KEY }}
+          STAGING_FAUNA_KEY: ${{ secrets.STAGING_FAUNA_KEY }}
+          CLUSTER_API_URL: ${{ secrets.CLUSTER_API_URL }}
+          CLUSTER_BASIC_AUTH_TOKEN: ${{ secrets.CLUSTER_BASIC_AUTH_TOKEN }}
+          CLUSTER_IPFS_PROXY_API_URL: ${{ secrets.CLUSTER_IPFS_PROXY_API_URL }}
+          CLUSTER_IPFS_PROXY_BASIC_AUTH_TOKEN: ${{ secrets.CLUSTER_IPFS_PROXY_BASIC_AUTH_TOKEN }}
+        run: npm run start:pins:failures -w packages/cron

--- a/packages/cron/package.json
+++ b/packages/cron/package.json
@@ -9,6 +9,7 @@
     "start": "run-s start:*",
     "start:metrics": "node src/bin/metrics.js",
     "start:pins": "node src/bin/pins.js",
+    "start:pins:failures": "node src/bin/pins.js PinError",
     "start:pinata": "node src/bin/pinata.js"
   },
   "author": "Alan Shaw",

--- a/packages/cron/src/bin/pins.js
+++ b/packages/cron/src/bin/pins.js
@@ -14,7 +14,10 @@ async function main () {
   const ipfs = getClusterIPFSProxy(process.env)
   const db = getDBClient(process.env)
 
-  await updatePinStatuses({ env, db, cluster, ipfs })
+  let statuses = process.argv.slice(2)
+  statuses = statuses.length ? statuses : ['Unpinned', 'PinQueued', 'Pinning']
+
+  await updatePinStatuses(statuses, { env, db, cluster, ipfs })
 }
 
 dotenv.config()

--- a/packages/cron/src/jobs/pins.js
+++ b/packages/cron/src/jobs/pins.js
@@ -44,7 +44,7 @@ const UPDATE_CONTENT_DAG_SIZE = gql`
 `
 
 /**
- * @param {import('@web3-storage/api/src/utils/pin.js').PinStatus} statuses Update pins with these statuses.
+ * @param {import('@web3-storage/api/src/utils/pin.js').PinStatus[]} statuses Update pins with these statuses.
  * @param {{
  *   cluster: import('@nftstorage/ipfs-cluster').Cluster
  *   db: import('@web3-storage/db').DBClient

--- a/packages/cron/src/jobs/pins.js
+++ b/packages/cron/src/jobs/pins.js
@@ -7,8 +7,8 @@ import { piggyback } from 'piggybacker'
 const log = debug('pins:updatePinStatuses')
 
 const FIND_PENDING_PINS = gql`
-  query FindPinsByStatus($after: String) {
-    findPinsByStatus(statuses: [Unpinned, PinQueued, Pinning], _size: 2000, _cursor: $after) {
+  query FindPinsByStatus($statuses: [PinStatus!]!, $after: String) {
+    findPinsByStatus(statuses: $statuses, _size: 2000, _cursor: $after) {
       data {
         _id
         content {
@@ -44,16 +44,19 @@ const UPDATE_CONTENT_DAG_SIZE = gql`
 `
 
 /**
+ * @param {import('@web3-storage/api/src/utils/pin.js').PinStatus} statuses Update pins with these statuses.
  * @param {{
  *   cluster: import('@nftstorage/ipfs-cluster').Cluster
  *   db: import('@web3-storage/db').DBClient
  *   ipfs: import('../lib/ipfs').IPFS
  * }} config
  */
-export async function updatePinStatuses ({ cluster, db, ipfs }) {
+export async function updatePinStatuses (statuses, { cluster, db, ipfs }) {
   if (!log.enabled) {
     console.log('ℹ️ Enable logging by setting DEBUG=pins:updatePinStatuses')
   }
+
+  log(`ℹ️ Updating pin statuses for pins with current status: ${statuses}`)
 
   // Cached status responses - since we pin on multiple nodes we'll often ask
   // multiple times about the same CID.
@@ -82,7 +85,7 @@ export async function updatePinStatuses ({ cluster, db, ipfs }) {
   let queryRes, after
   let i = 0
   while (true) {
-    queryRes = await retry(() => db.query(FIND_PENDING_PINS, { after }))
+    queryRes = await retry(() => db.query(FIND_PENDING_PINS, { statuses, after }))
     log(`📥 Processing ${i} -> ${i + queryRes.findPinsByStatus.data.length}`)
     const checkDagSizePins = []
     const pinUpdates = await Promise.all(queryRes.findPinsByStatus.data.map(async pin => {


### PR DESCRIPTION
Adds a cron job to run once a day and check in with cluster on pins that have the status PinError.

If a pin gets the status `PinError` then we currently do not check again on it. Howveer Cluster does not stop trying to retrieve the CID and in the case of a failed upload the user may successfully re-upload it.

I ran this locally and it updated the status of 4,424 pins that were in the `PinError` state.