### PR TITLE
feat: support any IPLD decoder

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1834,6 +1834,16 @@
         "multiformats": "^9.0.0"
       }
     },
+    "node_modules/@ipld/dag-json": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@ipld/dag-json/-/dag-json-8.0.0.tgz",
+      "integrity": "sha512-LOzxRV+EaU5+KBeQuNrsITqYyOZQxYmlo7dIjuRYPFHt52nqhPdKpzf2WdQOgNK1LE3mo2F0Xa5nWMYcZcfypg==",
+      "dev": true,
+      "dependencies": {
+        "cborg": "^1.4.0",
+        "multiformats": "^9.0.0"
+      }
+    },
     "node_modules/@ipld/dag-pb": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@ipld/dag-pb/-/dag-pb-2.1.5.tgz",
@@ -4493,9 +4503,9 @@
       }
     },
     "node_modules/cborg": {
-      "version": "1.3.6",
-      "resolved": "https://registry.npmjs.org/cborg/-/cborg-1.3.6.tgz",
-      "integrity": "sha512-PsJqI9K9uieA4dqCfVb5gzWI0EO0axzr+LCWrETc0YmzqkLQswtVeDfhJcD7pTmkSjaVlwcQ3BybT7gcmIDMFw==",
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/cborg/-/cborg-1.4.1.tgz",
+      "integrity": "sha512-qlyweQ/ULUS41psb7YZdmWkRMVZDQGfkqp/WVGrU4XR1L7ZlVFJvKJNebYyDzw9Jck85O/Lyg2zAF60hi54N2Q==",
       "bin": {
         "cborg": "cli.js"
       }
@@ -17636,6 +17646,7 @@
         "streaming-iterables": "^6.0.0"
       },
       "devDependencies": {
+        "@ipld/dag-json": "^8.0.0",
         "@rollup/plugin-commonjs": "^19.0.0",
         "@rollup/plugin-node-resolve": "^13.0.0",
         "@types/mocha": "8.2.2",
@@ -19428,6 +19439,16 @@
         "multiformats": "^9.0.0"
       }
     },
+    "@ipld/dag-json": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@ipld/dag-json/-/dag-json-8.0.0.tgz",
+      "integrity": "sha512-LOzxRV+EaU5+KBeQuNrsITqYyOZQxYmlo7dIjuRYPFHt52nqhPdKpzf2WdQOgNK1LE3mo2F0Xa5nWMYcZcfypg==",
+      "dev": true,
+      "requires": {
+        "cborg": "^1.4.0",
+        "multiformats": "^9.0.0"
+      }
+    },
     "@ipld/dag-pb": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@ipld/dag-pb/-/dag-pb-2.1.5.tgz",
@@ -20357,7 +20378,7 @@
     "@web3-storage/w3": {
       "version": "file:packages/w3",
       "requires": {
-        "@ipld/car": "*",
+        "@ipld/car": "^3.1.16",
         "conf": "^10.0.1",
         "enquirer": "^2.3.6",
         "execa": "^5.1.1",
@@ -21907,9 +21928,9 @@
       }
     },
     "cborg": {
-      "version": "1.3.6",
-      "resolved": "https://registry.npmjs.org/cborg/-/cborg-1.3.6.tgz",
-      "integrity": "sha512-PsJqI9K9uieA4dqCfVb5gzWI0EO0axzr+LCWrETc0YmzqkLQswtVeDfhJcD7pTmkSjaVlwcQ3BybT7gcmIDMFw=="
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/cborg/-/cborg-1.4.1.tgz",
+      "integrity": "sha512-qlyweQ/ULUS41psb7YZdmWkRMVZDQGfkqp/WVGrU4XR1L7ZlVFJvKJNebYyDzw9Jck85O/Lyg2zAF60hi54N2Q=="
     },
     "chalk": {
       "version": "4.1.1",
@@ -31517,6 +31538,7 @@
       "version": "file:packages/client",
       "requires": {
         "@ipld/car": "^3.1.4",
+        "@ipld/dag-json": "*",
         "@rollup/plugin-commonjs": "^19.0.0",
         "@rollup/plugin-node-resolve": "^13.0.0",
         "@types/mocha": "8.2.2",

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -43,6 +43,7 @@
     "streaming-iterables": "^6.0.0"
   },
   "devDependencies": {
+    "@ipld/dag-json": "^8.0.0",
     "@rollup/plugin-commonjs": "^19.0.0",
     "@rollup/plugin-node-resolve": "^13.0.0",
     "@types/mocha": "8.2.2",

--- a/packages/client/src/lib.js
+++ b/packages/client/src/lib.js
@@ -129,7 +129,8 @@ class Web3Storage {
   static async putCar ({ endpoint, token }, car, {
     name,
     onStoredChunk,
-    maxRetries = MAX_PUT_RETRIES
+    maxRetries = MAX_PUT_RETRIES,
+    decoders
   } = {}) {
     const targetSize = MAX_CHUNK_SIZE
     const url = new URL('/car', endpoint)
@@ -148,7 +149,7 @@ class Web3Storage {
     }
 
     const carRoot = roots[0].toString()
-    const splitter = new TreewalkCarSplitter(car, targetSize)
+    const splitter = new TreewalkCarSplitter(car, targetSize, { decoders })
 
     /**
      * @param {AsyncIterable<Uint8Array>} car

--- a/packages/client/src/lib/interface.ts
+++ b/packages/client/src/lib/interface.ts
@@ -2,6 +2,7 @@ import type { UnixFSEntry } from 'ipfs-car/unpack'
 import type { CID } from 'multiformats'
 export type { CID, UnixFSEntry }
 import type { CarReader } from '@ipld/car/api'
+import type { BlockDecoder } from 'multiformats/codecs/interface'
 
 /**
  * Define nominal type of U based on type of T. Similar to Opaque types in Flow
@@ -137,6 +138,13 @@ export type PutCarOptions = {
    * Maximum times to retry a failed upload. Default: 5
    */
    maxRetries?: number
+   /**
+    * Additional IPLD block decoders. Used to interpret the data in the CAR file
+    * and split it into multiple chunks. Note these are only required if the CAR
+    * file was not encoded using the default encoders: `dag-pb`, `dag-cbor` and
+    * `raw`.
+    */
+   decoders?: BlockDecoder<any, any>[]
 }
 
 export interface Web3File extends File {


### PR DESCRIPTION
This PR adds an optional parameter to `putCar` called `decoders`. It's an array of IPLD `BlockDecoder`.

It's needed when the DAG in the CAR file was not encoded using the default encoders `dag-pb`, `dag-cbor` and `raw`.