### PR TITLE
fix: pin sync request history

### DIFF
--- a/packages/db/fauna/resources/Function/deletePinSyncRequests.js
+++ b/packages/db/fauna/resources/Function/deletePinSyncRequests.js
@@ -12,7 +12,7 @@ const {
   Map,
   Collection,
   Ref,
-  Delete
+  Call
 } = fauna
 
 const name = 'deletePinSyncRequests'
@@ -21,7 +21,7 @@ const body = Query(
     ['requests'],
     Map(
       Var('requests'),
-      Lambda(['id'], Delete(Ref(Collection('PinSyncRequest'), Var('id'))))
+      Lambda('id', Call('deleteWithHistory', Ref(Collection('PinSyncRequest'), Var('id'))))
     )
   )
 )

--- a/packages/db/fauna/resources/Function/deleteWithHistory.js
+++ b/packages/db/fauna/resources/Function/deleteWithHistory.js
@@ -1,0 +1,58 @@
+import fauna from 'faunadb'
+
+const {
+  Function,
+  CreateFunction,
+  Query,
+  Lambda,
+  Let,
+  Var,
+  If,
+  Do,
+  Update,
+  Exists,
+  Paginate,
+  Events,
+  IsNull,
+  Delete,
+  Get,
+  Foreach,
+  Remove,
+  Select
+} = fauna
+
+const name = 'deleteWithHistory'
+const body = Query(
+  Lambda(
+    ['ref'],
+    Let(
+      {
+        events: Paginate(Events(Var('ref'))),
+        after: Select(['after'], Var('events'), null),
+        result: If(IsNull(Var('after')), Get(Var('ref')), Delete(Var('ref')))
+      },
+      Do(
+        Foreach(
+          Var('events'),
+          Lambda(
+            'event',
+            Let(
+              {
+                ts: Select(['ts'], Var('event')),
+                action: Select(['action'], Var('event'))
+              },
+              Remove(Var('ref'), Var('ts'), Var('action'))
+            )
+          )
+        ),
+        Var('result')
+      )
+    )
+  )
+)
+
+export default If(
+  Exists(Function(name)),
+  Update(Function(name), { name, body }),
+  CreateFunction({ name, body })
+)


### PR DESCRIPTION
Stops history accumulating on `PinSyncRequest` collection.

`deleteWithHistory` provided by Fauna support.

Currently deployed to prod.