### PR TITLE
fix: delete fauna history when deleting PinRequest

### DIFF
--- a/packages/cron/src/jobs/pinata.js
+++ b/packages/cron/src/jobs/pinata.js
@@ -25,9 +25,9 @@ const FIND_BATCH = gql`
   }
 `
 
-const DELETE_ONE = gql`
-  mutation DeletePinRequest($_id: ID!) {
-    deletePinRequest(id: $_id){
+const DELETE_PIN_REQUESTS = gql`
+  mutation DeletePinRequests($requests: [ID!]!) {
+    deletePinRequests(requests: $requests){
       _id
     }
   }
@@ -84,7 +84,7 @@ export async function pinToPinata ({ db, pinata }) {
       await pinata.pinByHash(cid)
       log(`📌 ${cid} ${count}/${total} pinned on Pinata! `)
       // Remove from the queue. Not awaiting, just move on.
-      db.query(DELETE_ONE, { _id })
+      db.query(DELETE_PIN_REQUESTS, { requests: [_id] })
       ok++
     } catch (err) {
       if (attempts < MAX_ATTEMPTS) {
@@ -92,7 +92,7 @@ export async function pinToPinata ({ db, pinata }) {
         db.query(INCREMENT_ATTEMPTS, { _id })
       } else {
         log(`❌ ${cid} ${count}/${total} failed to pin ${attempts} times. Deleting Pin Request`, err)
-        db.query(DELETE_ONE, { _id })
+        db.query(DELETE_PIN_REQUESTS, { requests: [_id] })
       }
     }
   }

--- a/packages/db/fauna/resources/Function/deletePinRequests.js
+++ b/packages/db/fauna/resources/Function/deletePinRequests.js
@@ -1,0 +1,33 @@
+import fauna from 'faunadb'
+
+const {
+  Function,
+  CreateFunction,
+  Query,
+  Lambda,
+  Var,
+  If,
+  Update,
+  Exists,
+  Map,
+  Collection,
+  Ref,
+  Call
+} = fauna
+
+const name = 'deletePinRequests'
+const body = Query(
+  Lambda(
+    ['requests'],
+    Map(
+      Var('requests'),
+      Lambda('id', Call('deleteWithHistory', Ref(Collection('PinRequest'), Var('id'))))
+    )
+  )
+)
+
+export default If(
+  Exists(Function(name)),
+  Update(Function(name), { name, body }),
+  CreateFunction({ name, body })
+)

--- a/packages/db/fauna/schema.graphql
+++ b/packages/db/fauna/schema.graphql
@@ -445,6 +445,7 @@ type Mutation {
   createOrUpdatePin(data: CreateOrUpdatePinInput): Pin! @resolver
   updateContentDagSize(content: ID!, dagSize: Long!): Content! @resolver
   createPinRequest(cid: String!): PinRequest! @resolver
+  deletePinRequests(requests: [ID!]!): [PinRequest!]! @resolver
   incrementPinRequestAttempts(pinRequest: ID!): PinRequest! @resolver
   incrementUserUsedStorage(user: ID!, amount: Long!): User! @resolver
   createOrUpdateMetric(data: CreateOrUpdateMetricInput!): Metric! @resolver


### PR DESCRIPTION
Suggested by the fauna team, a similar fix to https://github.com/web3-storage/web3.storage/pull/385. The code was calling the auto-generated `deletePinRequest` function, which does not delete the document snapshots, and leads to a build of of data that slows down queries until they fail to complete within the time budget.


License: (Apache-2.0 AND MIT)
Signed-off-by: Oli Evans <oli@tableflip.io>