### PR TITLE
feat: use web3.storage gateway

### DIFF
--- a/packages/api/src/car.js
+++ b/packages/api/src/car.js
@@ -98,7 +98,7 @@ export async function carGet (request, env, ctx) {
   // gateway does not support `carversion` yet.
   // using it now means we can skip the cache if it is supported in the future
   const url = new URL(`/api/v0/dag/export?arg=${cid}&carversion=1`, GATEWAY)
-  res = await fetch(url, { method: 'POST' })
+  res = await fetch(url)
   if (!res.ok) {
     // bail early. dont cache errors.
     return res

--- a/packages/api/src/constants.js
+++ b/packages/api/src/constants.js
@@ -1,4 +1,4 @@
-export const GATEWAY = new URL('https://ipfs.io')
+export const GATEWAY = new URL('https://gateway.web3.storage')
 export const JWT_ISSUER = 'web3-storage'
 export const METRICS_CACHE_MAX_AGE = 10 * 60 // in seconds (10 minutes)
 export const LOCAL_ADD_THRESHOLD = 1024 * 1024 * 2.5

--- a/packages/website/pages/files.js
+++ b/packages/website/pages/files.js
@@ -434,7 +434,7 @@ export default function Files({ isLoggedIn }) {
  */
 function GatewayLink({ cid }) {
   const href = cid.startsWith('Qm')
-    ? `https://ipfs.io/ipfs/${cid}`
+    ? `https://gateway.web3.storage/ipfs/${cid}`
     : `https://${cid}.ipfs.dweb.link`
   return (
     <a href={href} target="_blank" rel="noopener noreferrer" className="black underline">


### PR DESCRIPTION
This PR makes web3.storage use its own gateway instead of ipfs.io per https://github.com/web3-storage/web3.storage/issues/138
