### PR TITLE
chore: run pinata backup more frequently

### DIFF
--- a/.github/workflows/cron-pinata.yml
+++ b/.github/workflows/cron-pinata.yml
@@ -2,7 +2,7 @@ name: Cron Pinata
 
 on:
   schedule:
-    - cron: '*/10 * * * *'
+    - cron: '*/5 * * * *'
 
 jobs:
   update:
@@ -10,8 +10,8 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        env: ['staging', 'production']
-    timeout-minutes: 10
+        env: ['production']
+    timeout-minutes: 5
     steps:
       - uses: actions/checkout@v2
 

--- a/packages/cron/src/bin/pinata.js
+++ b/packages/cron/src/bin/pinata.js
@@ -7,7 +7,7 @@ import { getPinata, getDBClient } from '../lib/utils.js'
 async function main () {
   const env = process.env.ENV || 'dev'
   const db = getDBClient(process.env)
-  const pinata = getPinata(process.env, { reqsPerSec: 2 })
+  const pinata = getPinata(process.env, { reqsPerSec: 3 })
   await pinToPinata({ db, pinata, env })
 }
 


### PR DESCRIPTION
I can't seem to increase the batch size without upsetting the db, so here we run the cron more frequently and move the rate-limiter up to 3req/s to pinata (official rate limit is 180 reqs/min aka 3 req/s)

> the shortest interval you can run scheduled workflows is once every 5 minutes.
– https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#onschedule


License: (Apache-2.0 AND MIT)
Signed-off-by: Oli Evans <oli@tableflip.io>