### PR TITLE
chore: deploy website to cloudflare pages on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -142,6 +142,13 @@ jobs:
           FAUNA_KEY: ${{ secrets.PROD_FAUNA_KEY }}
 
       # --- Website deploy steps ----------------------------------------------
+      - name: Deploy to Cloudflare pages
+        if: ${{ steps.tag-release.outputs.release_created && matrix.package == 'website' }}
+        # Reset the `website-prod` branch to trigger a production build & deploy on Cloudflare Pages.
+        run: |
+          git push origin --delete website-prod
+          git push origin main:website-prod
+
       - run: npm run build -w packages/client
         if: ${{ steps.tag-release.outputs.release_created && matrix.package == 'website' }}
       - run: npm run build -w packages/website


### PR DESCRIPTION
The `website-prod` branch is configured on Cloudflare pages to be our production branch. The CI job updates that branch after a website release PR is merged.

This set up makes it so cloudflares view of what is our production deployment matches our view of it. Keeping that in sync means we can use the built in Rollback a deployment feature on Pages, and is less confusing for the bleary eyed fire-fighter.

<img width="1285" alt="Screenshot 2021-09-02 at 15 35 02" src="https://user-images.githubusercontent.com/58871/131866685-2a62b1b4-629e-4fbe-8b35-f6fa62ce3845.png">

All other branches get preview builds on Cloudflare. We can't have that be more selective, so all PRs regardless of what code they touch will get a Cloudflare Pages status. To be less noisy I have disabled the "add a comment to the PR" option. The check is still available in the list at the bottom of the PR which should be suffcient.

All of the `add-to-web3` plubming is left in place, so that we continue provide the web3.storage over ipfs for user with ipfs enabled browers.

Note: this PR leaves staging hosted on the ipfs.io gateway. Cloudflare does not support promoting production and staging builds, only production. I'm not keen on the complexity of searching through the cloudflare pages build logs and waiting for the build to be complete, and i'd like to be able to compare the gateway hosted website perf with the pages hosted one for a few weeks, now things are more stable.

TODO
- [x] add preview env vars to cf
- [x] add production env vars to cf
- [ ] update web3.storage CNAME record

License: (Apache-2.0 AND MIT)
Signed-off-by: Oli Evans <oli@tableflip.io>