### PR TITLE
chore: test upload via w3 on cron

### DIFF
--- a/.github/workflows/cron-test.yml
+++ b/.github/workflows/cron-test.yml
@@ -1,0 +1,32 @@
+name: Cron Pins
+
+on:
+  schedule:
+    - cron: '*/10 * * * *'
+
+jobs:
+  upload-test:
+    name: Upload test
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    strategy:
+      matrix:
+        # cool! https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#using-environment-variables-in-a-matrix
+        include:
+          - api: https://api.web3.storage
+            token: ${{ secrets.WEB3_TOKEN }}
+          - api: https://api-staging.web3.storage
+            token: ${{ secrets.STAGING_WEB3_TOKEN }}
+    steps:
+      - uses: actions/setup-node@v1
+        with:
+          node-version: 16
+      - name: Add small file via w3
+        run: |
+          echo "$(date --utc --iso-8601=seconds) web3.storage upload test" > ./date 
+          npx @web3-storage/w3 put ./date --api {{ matrix.api }} --token ${{ matrix.token }}
+      # test adding a file larger than LOCAL_ADD_THRESHOLD see: packages/api/src/constants.js
+      - name: Add 3MiB file via w3
+        run: |
+          dd if=/dev/urandom of=./foo bs=1024 count=3072
+          npx @web3-storage/w3 put ./medium --api {{ matrix.api }} --token ${{ matrix.token }}

--- a/.github/workflows/cron-test.yml
+++ b/.github/workflows/cron-test.yml
@@ -1,4 +1,4 @@
-name: Cron Pins
+name: Upload test
 
 on:
   schedule:


### PR DESCRIPTION
The pit canary. A minimally viable smoke test for uploading to web3.storage that can run frequently and alert us if it dies.

In it's current form it will test both staging and production with small files and random files sligtly larger than the local add threshold. I'd like to replace the random files with wikipedia pages or similar, but this will do for now.

it'll let us know when the latest published `w3` command, using the latest published `web3.storage` client is working, which is nice.

WIP on https://github.com/web3-storage/web3.storage/issues/421

License: (Apache-2.0 AND MIT)
Signed-off-by: Oli Evans <oli@tableflip.io>