### PR TITLE
chore: use prod api when adding to web3

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -168,8 +168,6 @@ jobs:
         with:
           path_to_add: packages/website/out
           web3_token: ${{ secrets.WEB3_TOKEN }}
-          # TODO: move to prod once we can get a token
-          web3_api: https://api-staging.web3.storage
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -51,7 +51,6 @@ jobs:
         with:
           path_to_add: packages/website/out
           web3_token: ${{ secrets.WEB3_TOKEN }}
-          web3_api: https://api-staging.web3.storage
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       


### PR DESCRIPTION
Ensure that the add-to-web3 github action uses the prod api.

License: (Apache-2.0 AND MIT)
Signed-off-by: Oli Evans <oli@tableflip.io>