### PR TITLE
chore: fix upload test cron

### DIFF
--- a/.github/workflows/api.yml
+++ b/.github/workflows/api.yml
@@ -52,4 +52,4 @@ jobs:
         run: |
           npm run build -w packages/client
           echo "$(date --utc --iso-8601=seconds) web3.storage upload test" > ./upload-test-small
-          ./packages/w3/bin.js ./upload-test-small --api https://api-staging.web3.storage --token ${{ secrets.STAGING_WEB3_TOKEN }}
+          ./packages/w3/bin.js put ./upload-test-small --api https://api-staging.web3.storage --token ${{ secrets.STAGING_WEB3_TOKEN }}

--- a/.github/workflows/api.yml
+++ b/.github/workflows/api.yml
@@ -48,3 +48,8 @@ jobs:
           apiToken: ${{ secrets.CF_API_TOKEN }}
           workingDirectory: 'packages/api'
           environment: 'staging'
+      - name: Test upload to staging
+        run: |
+          npm run build -w packages/client
+          echo "$(date --utc --iso-8601=seconds) web3.storage upload test" > ./upload-test-small
+          packages/w3/bin.js ./upload-test-small --api https://api-staging.web3.storage --token ${{ secrets.STAGING_WEB3_TOKEN }}

--- a/.github/workflows/api.yml
+++ b/.github/workflows/api.yml
@@ -52,4 +52,4 @@ jobs:
         run: |
           npm run build -w packages/client
           echo "$(date --utc --iso-8601=seconds) web3.storage upload test" > ./upload-test-small
-          packages/w3/bin.js ./upload-test-small --api https://api-staging.web3.storage --token ${{ secrets.STAGING_WEB3_TOKEN }}
+          ./packages/w3/bin.js ./upload-test-small --api https://api-staging.web3.storage --token ${{ secrets.STAGING_WEB3_TOKEN }}

--- a/.github/workflows/client.yml
+++ b/.github/workflows/client.yml
@@ -3,9 +3,15 @@ on:
   push:
     branches:
       - main
+    paths:
+      - 'packages/client/**'
+      - '.github/workflows/client.yml'
   pull_request:
     branches:
       - main
+    paths:
+      - 'packages/client/**'
+      - '.github/workflows/client.yml'
 jobs:
   test:
     runs-on: ubuntu-latest
@@ -18,3 +24,8 @@ jobs:
       - uses: bahmutov/npm-install@v1
       - run: npm run build --workspace packages/client
       - run: npm test --workspace packages/client
+      - name: Test upload to staging
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        run: |
+          echo "$(date --utc --iso-8601=seconds) web3.storage upload test" > ./upload-test-small
+          packages/w3/bin.js ./upload-test-small --api https://api-staging.web3.storage --token ${{ secrets.STAGING_WEB3_TOKEN }}

--- a/.github/workflows/client.yml
+++ b/.github/workflows/client.yml
@@ -28,4 +28,4 @@ jobs:
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         run: |
           echo "$(date --utc --iso-8601=seconds) web3.storage upload test" > ./upload-test-small
-          ./packages/w3/bin.js ./upload-test-small --api https://api-staging.web3.storage --token ${{ secrets.STAGING_WEB3_TOKEN }}
+          ./packages/w3/bin.js put ./upload-test-small --api https://api-staging.web3.storage --token ${{ secrets.STAGING_WEB3_TOKEN }}

--- a/.github/workflows/client.yml
+++ b/.github/workflows/client.yml
@@ -28,4 +28,4 @@ jobs:
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         run: |
           echo "$(date --utc --iso-8601=seconds) web3.storage upload test" > ./upload-test-small
-          packages/w3/bin.js ./upload-test-small --api https://api-staging.web3.storage --token ${{ secrets.STAGING_WEB3_TOKEN }}
+          ./packages/w3/bin.js ./upload-test-small --api https://api-staging.web3.storage --token ${{ secrets.STAGING_WEB3_TOKEN }}

--- a/.github/workflows/cron-test.yml
+++ b/.github/workflows/cron-test.yml
@@ -9,25 +9,16 @@ jobs:
     name: Upload test
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    strategy:
-      matrix: 
-        # COOL! https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#using-environment-variables-in-a-matrix
-        # NOTE: you can't use secrets here, so we set the name of a secret and then look it up in the run step. see: https://github.community/t/secrets-in-matrix/17307
-        include:
-          - api: https://api.web3.storage
-            token_name: WEB3_TOKEN
-          - api: https://api-staging.web3.storage
-            token_name: STAGING_WEB3_TOKEN
     steps:
-      - uses: actions/setup-node@v1
+      - uses: actions/setup-node@v2
         with:
           node-version: 16
       - name: Add small file via w3
         run: |
           echo "$(date --utc --iso-8601=seconds) web3.storage upload test" > ./upload-test-small 
-          npx @web3-storage/w3 put ./upload-test-small --api ${{ matrix.api }} --token ${{ secrets[matrix.token_name] }}
+          npx @web3-storage/w3 put ./upload-test-small --token ${{ secrets.WEB3_TOKEN }}
       # test adding a file larger than LOCAL_ADD_THRESHOLD see: packages/api/src/constants.js
       - name: Add 3MiB file via w3
         run: |
           dd if=/dev/urandom of=./upload-test-3mib bs=1024 count=3072
-          npx @web3-storage/w3 put ./upload-test-3mib --api ${{ matrix.api }} --token ${{ secrets[matrix.token_name] }}
+          npx @web3-storage/w3 put ./upload-test-3mib --token ${{ secrets.WEB3_TOKEN }}

--- a/.github/workflows/cron-test.yml
+++ b/.github/workflows/cron-test.yml
@@ -10,23 +10,24 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     strategy:
-      matrix:
-        # cool! https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#using-environment-variables-in-a-matrix
+      matrix: 
+        # COOL! https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#using-environment-variables-in-a-matrix
+        # NOTE: you can't use secrets here, so we set the name of a secret and then look it up in the run step. see: https://github.community/t/secrets-in-matrix/17307
         include:
           - api: https://api.web3.storage
-            token: ${{ secrets.WEB3_TOKEN }}
+            token_name: WEB3_TOKEN
           - api: https://api-staging.web3.storage
-            token: ${{ secrets.STAGING_WEB3_TOKEN }}
+            token_name: STAGING_WEB3_TOKEN
     steps:
       - uses: actions/setup-node@v1
         with:
           node-version: 16
       - name: Add small file via w3
         run: |
-          echo "$(date --utc --iso-8601=seconds) web3.storage upload test" > ./date 
-          npx @web3-storage/w3 put ./date --api {{ matrix.api }} --token ${{ matrix.token }}
+          echo "$(date --utc --iso-8601=seconds) web3.storage upload test" > ./upload-test-small 
+          npx @web3-storage/w3 put ./upload-test-small --api ${{ matrix.api }} --token ${{ secrets[matrix.token_name] }}
       # test adding a file larger than LOCAL_ADD_THRESHOLD see: packages/api/src/constants.js
       - name: Add 3MiB file via w3
         run: |
-          dd if=/dev/urandom of=./foo bs=1024 count=3072
-          npx @web3-storage/w3 put ./medium --api {{ matrix.api }} --token ${{ matrix.token }}
+          dd if=/dev/urandom of=./upload-test-3mib bs=1024 count=3072
+          npx @web3-storage/w3 put ./upload-test-3mib --api ${{ matrix.api }} --token ${{ secrets[matrix.token_name] }}

--- a/.github/workflows/db.yml
+++ b/.github/workflows/db.yml
@@ -34,4 +34,4 @@ jobs:
         run: |
           npm run build -w packages/client
           echo "$(date --utc --iso-8601=seconds) web3.storage upload test" > ./upload-test-small
-          ./packages/w3/bin.js ./upload-test-small --api https://api-staging.web3.storage --token ${{ secrets.STAGING_WEB3_TOKEN }}
+          ./packages/w3/bin.js put ./upload-test-small --api https://api-staging.web3.storage --token ${{ secrets.STAGING_WEB3_TOKEN }}

--- a/.github/workflows/db.yml
+++ b/.github/workflows/db.yml
@@ -30,3 +30,8 @@ jobs:
         run: npm run import -w packages/db
         env:
           FAUNA_KEY: ${{ secrets.STAGING_FAUNA_KEY }}
+      - name: Test upload to staging
+        run: |
+          npm run build -w packages/client
+          echo "$(date --utc --iso-8601=seconds) web3.storage upload test" > ./upload-test-small
+          packages/w3/bin.js ./upload-test-small --api https://api-staging.web3.storage --token ${{ secrets.STAGING_WEB3_TOKEN }}

--- a/.github/workflows/db.yml
+++ b/.github/workflows/db.yml
@@ -34,4 +34,4 @@ jobs:
         run: |
           npm run build -w packages/client
           echo "$(date --utc --iso-8601=seconds) web3.storage upload test" > ./upload-test-small
-          packages/w3/bin.js ./upload-test-small --api https://api-staging.web3.storage --token ${{ secrets.STAGING_WEB3_TOKEN }}
+          ./packages/w3/bin.js ./upload-test-small --api https://api-staging.web3.storage --token ${{ secrets.STAGING_WEB3_TOKEN }}

--- a/.github/workflows/w3.yml
+++ b/.github/workflows/w3.yml
@@ -28,3 +28,20 @@ jobs:
         working-directory: packages/w3
       - run: npm test
         working-directory: packages/w3
+
+  test-e2e:
+    runs-on: ubuntu-latest
+    name: Test
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: 16
+      # Use workspace deps here to test the workspace version of the client against the staging api.
+      # We want this one to fail if we can't upload to the staging api using the workspace version of the client.
+      - uses: bahmutov/npm-install@v1
+      - name: Test upload to staging
+        run: |
+          npm run build -w packages/client
+          echo "$(date --utc --iso-8601=seconds) web3.storage upload test" > ./upload-test-small
+          packages/w3/bin.js ./upload-test-small --api https://api-staging.web3.storage --token ${{ secrets.STAGING_WEB3_TOKEN }}

--- a/.github/workflows/w3.yml
+++ b/.github/workflows/w3.yml
@@ -44,4 +44,4 @@ jobs:
         run: |
           npm run build -w packages/client
           echo "$(date --utc --iso-8601=seconds) web3.storage upload test" > ./upload-test-small
-          ./packages/w3/bin.js ./upload-test-small --api https://api-staging.web3.storage --token ${{ secrets.STAGING_WEB3_TOKEN }}
+          ./packages/w3/bin.js put ./upload-test-small --api https://api-staging.web3.storage --token ${{ secrets.STAGING_WEB3_TOKEN }}

--- a/.github/workflows/w3.yml
+++ b/.github/workflows/w3.yml
@@ -44,4 +44,4 @@ jobs:
         run: |
           npm run build -w packages/client
           echo "$(date --utc --iso-8601=seconds) web3.storage upload test" > ./upload-test-small
-          packages/w3/bin.js ./upload-test-small --api https://api-staging.web3.storage --token ${{ secrets.STAGING_WEB3_TOKEN }}
+          ./packages/w3/bin.js ./upload-test-small --api https://api-staging.web3.storage --token ${{ secrets.STAGING_WEB3_TOKEN }}

--- a/.github/workflows/w3.yml
+++ b/.github/workflows/w3.yml
@@ -31,7 +31,7 @@ jobs:
 
   test-e2e:
     runs-on: ubuntu-latest
-    name: Test
+    name: Test e2e
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2


### PR DESCRIPTION
- Simplify and fix cron end-to-end test. It just tests against production now.
- Add an e2e upload test as the last step in CI for each of the relevant components [api,client,db,w3]

License: (Apache-2.0 AND MIT)
Signed-off-by: Oli Evans <oli@tableflip.io>