### PR TITLE
Always show header links & login/out button

### DIFF
--- a/packages/website/components/button.js
+++ b/packages/website/components/button.js
@@ -17,7 +17,7 @@ import countly from '../lib/countly'
  * @prop { import('react').MouseEventHandler<HTMLButtonElement> } [onClick]
  * @prop {string} [href]
  * @prop {import('react').ButtonHTMLAttributes<HTMLButtonElement>["type"]} [type]
- * @prop {import('react').ReactChildren | string} children
+ * @prop {import('react').ReactNode | string} children
  * @prop {boolean} [disabled]
  * @prop {string} [id]
  * @prop {'dark' | 'light' | 'outlined' } [variant]

--- a/packages/website/components/layout.js
+++ b/packages/website/components/layout.js
@@ -33,8 +33,7 @@ export default function Layout({
     redirectIfFound,
     enabled: needsLoggedIn,
   })
-  const shouldWaitForLoggedIn = needsLoggedIn && isLoading
-
+  const shouldWaitForLoggedIn = needsLoggedIn && !isLoggedIn
   return (
     <div className={clsx(pageBgColor, 'flex flex-col min-h-screen')}>
       <Head>

--- a/packages/website/components/layout.js
+++ b/packages/website/components/layout.js
@@ -51,7 +51,11 @@ export default function Layout({
         <meta name="twitter:creator" content="@protocollabs" />
       </Head>
       {shouldWaitForLoggedIn ? (
-        <Loading />
+        <>
+          <Navbar isLoggedIn={isLoggedIn} isLoadingUser={isLoading || isFetching} bgColor={navBgColor} />
+            <Loading />
+          <Footer bgColor={footerBgColor} />
+        </>
       ) : callback ? (
         <>
           <Loading />

--- a/packages/website/components/navbar.js
+++ b/packages/website/components/navbar.js
@@ -105,7 +105,6 @@ export default function Navbar({ bgColor = '', isLoggedIn, isLoadingUser }) {
 
   const spinnerButton = (
     <Button href="#" id="loading-user" wrapperClassName="inline-block" small={isSmallVariant} >
-      {/* @ts-expect-error */ }
       <Loading className='user-spinner' fill='white' height={10} />
     </Button>
   )

--- a/packages/website/components/navbar.js
+++ b/packages/website/components/navbar.js
@@ -105,7 +105,8 @@ export default function Navbar({ bgColor = '', isLoggedIn, isLoadingUser }) {
 
   const spinnerButton = (
     <Button href="#" id="loading-user" wrapperClassName="inline-block" small={isSmallVariant} >
-      <Loading className='user-spinner' fill='white' height='10px' />
+      {/* @ts-expect-error */ }
+      <Loading className='user-spinner' fill='white' height={10} />
     </Button>
   )
 

--- a/packages/website/components/navbar.js
+++ b/packages/website/components/navbar.js
@@ -11,6 +11,7 @@ import Hamburger from '../icons/hamburger'
 
 import Logo from '../icons/w3storage-logo'
 import Cross from '../icons/cross'
+import Loading from './loading.js'
 
 /**
  * Navbar Component
@@ -43,11 +44,13 @@ export default function Navbar({ bgColor = '', isLoggedIn, isLoadingUser }) {
         link: 'https://docs.web3.storage/',
         name: 'Docs',
         spacing: `p-3 md:px-6 ${isLoggedIn ? '' : 'mr-6 md:mr-0'}`
-      }, {
+      },
+      {
         link: '/about',
         name: 'About',
         spacing: `p-3 md:px-6 ${isLoggedIn ? '' : 'mr-6 md:mr-0'}`
-    }, ...(isLoggedIn ? [{
+      },
+      {
         link: '/files',
         name: 'Files',
         spacing: `p-3 md:px-6`
@@ -57,8 +60,7 @@ export default function Navbar({ bgColor = '', isLoggedIn, isLoadingUser }) {
         name: 'Account',
         spacing: `p-3 md:px-6 mr-3 md:mr-6`
       }
-    ] : [])
-  ], [isLoggedIn])
+    ], [isLoggedIn])
 
   const queryClient = useQueryClient()
   const onLinkClick = useCallback((event) => {
@@ -78,6 +80,34 @@ export default function Navbar({ bgColor = '', isLoggedIn, isLoadingUser }) {
     isMenuOpen ? document.body.classList.remove('overflow-hidden') : document.body.classList.add('overflow-hidden')
     setMenuOpen(!isMenuOpen)
   }
+
+  const logoutButton = (
+    <Button
+      onClick={logout}
+      id="logout"
+      wrapperClassName="inline-block"
+      variant="outlined"
+      small={isSmallVariant}
+      tracking={{
+        event: countly.events.LOGOUT_CLICK,
+        ui: countly.ui.NAVBAR,
+        action: 'Logout'
+      }}>
+      Logout
+    </Button>
+  )
+
+  const loginButton = (
+    <Button href="/login" id="login" wrapperClassName="inline-block" small={isSmallVariant} tracking={{ ui: countly.ui.NAVBAR, action: 'Login' }}>
+      Login
+    </Button>
+    )
+
+  const spinnerButton = (
+    <Button href="#" id="loading-user" wrapperClassName="inline-block" small={isSmallVariant} >
+      <Loading className='user-spinner' fill='white' height='10px' />
+    </Button>
+  )
 
   return (
     <nav className={clsx(bgColor, 'w-full z-50', isSmallVariant ? 'sticky top-0' : '')} ref={containerRef}>
@@ -102,28 +132,10 @@ export default function Navbar({ bgColor = '', isLoggedIn, isLoadingUser }) {
             </a>
           ))}
           {isLoadingUser
-            ? null
+            ? spinnerButton
             : isLoggedIn
-              ? (
-                <Button
-                  onClick={logout}
-                  id="logout"
-                  wrapperClassName="inline-block"
-                  variant="outlined"
-                  small={isSmallVariant}
-                  tracking={{
-                    event: countly.events.LOGOUT_CLICK,
-                    ui: countly.ui.NAVBAR,
-                    action: 'Logout'
-                  }}>
-                  Logout
-                </Button>
-                )
-              : (
-                <Button href="/login" id="login" wrapperClassName="inline-block" small={isSmallVariant} tracking={{ ui: countly.ui.NAVBAR, action: 'Login' }}>
-                  Login
-                </Button>
-                )
+              ? logoutButton
+              : loginButton
           }
         </div>
       </div>

--- a/packages/website/pages/account.js
+++ b/packages/website/pages/account.js
@@ -22,7 +22,7 @@ const MAX_STORAGE = 1.1e+12 /* 1 TB */
     return {
       props: {
         title: 'Account - Web3 Storage',
-        redirectTo: '/',
+        redirectTo: '/login/',
         needsLoggedIn: true,
       },
     }

--- a/packages/website/pages/files.js
+++ b/packages/website/pages/files.js
@@ -29,7 +29,7 @@ export function getStaticProps() {
     props: {
       title: 'Files - Web3 Storage',
       pageBgColor: 'bg-w3storage-neutral-red',
-      redirectTo: '/',
+      redirectTo: '/login/',
       needsLoggedIn: true,
     },
   }


### PR DESCRIPTION
This makes the header less janky by always rendering the links to the Files and Account pages, which now redirect to `/login/` instead of `/` if you're not logged in.

It also renders a login button with a loading spinner while it's checking the auth state, instead of rendering nothing and popping in the button once the state resolves.

@olizilla you mentioned doing this yesterday, and I figured it would be a good stop-gap until we can make the actual auth flow faster.