### PR TITLE
chore: unify /upload and /car uploads

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17569,7 +17569,7 @@
     },
     "packages/api": {
       "name": "@web3-storage/api",
-      "version": "3.3.2",
+      "version": "3.4.0",
       "license": "(Apache-2.0 AND MIT)",
       "dependencies": {
         "@ipld/car": "^3.1.4",
@@ -17580,6 +17580,7 @@
         "@nftstorage/ipfs-cluster": "^3.3.1",
         "@web3-storage/db": "^2.0.0",
         "@web3-storage/multipart-parser": "^1.0.0",
+        "ipfs-car": "^0.5.8",
         "itty-router": "^2.3.10",
         "multiformats": "^9.0.4",
         "p-retry": "^4.6.1"
@@ -17592,7 +17593,6 @@
         "buffer": "^6.0.3",
         "dotenv": "^10.0.0",
         "git-revision-webpack-plugin": "^5.0.0",
-        "ipfs-car": "^0.5.8",
         "ipfs-unixfs-importer": "^9.0.4",
         "npm-run-all": "^4.1.5",
         "playwright-test": "^7.0.1",
@@ -17606,7 +17606,7 @@
     },
     "packages/client": {
       "name": "web3.storage",
-      "version": "3.3.1",
+      "version": "3.3.2",
       "license": "(Apache-2.0 AND MIT)",
       "dependencies": {
         "@ipld/car": "^3.1.4",
@@ -17718,7 +17718,7 @@
     },
     "packages/db": {
       "name": "@web3-storage/db",
-      "version": "2.1.0",
+      "version": "2.2.0",
       "license": "(Apache-2.0 AND MIT)",
       "dependencies": {
         "graphql-request": "^3.4.0"
@@ -17788,7 +17788,7 @@
     },
     "packages/website": {
       "name": "@web3-storage/website",
-      "version": "1.2.4",
+      "version": "1.4.0",
       "dependencies": {
         "@magic-ext/oauth": "^0.7.0",
         "@tailwindcss/typography": "^0.4.1",

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -26,7 +26,6 @@
     "buffer": "^6.0.3",
     "dotenv": "^10.0.0",
     "git-revision-webpack-plugin": "^5.0.0",
-    "ipfs-car": "^0.5.8",
     "ipfs-unixfs-importer": "^9.0.4",
     "npm-run-all": "^4.1.5",
     "playwright-test": "^7.0.1",
@@ -46,6 +45,7 @@
     "@nftstorage/ipfs-cluster": "^3.3.1",
     "@web3-storage/db": "^2.0.0",
     "@web3-storage/multipart-parser": "^1.0.0",
+    "ipfs-car": "^0.5.8",
     "itty-router": "^2.3.10",
     "multiformats": "^9.0.4",
     "p-retry": "^4.6.1"

--- a/packages/api/src/car.js
+++ b/packages/api/src/car.js
@@ -135,6 +135,7 @@ export async function carPost (request, env, ctx) {
  * @param {import('./env').Env} env
  * @param {import('./index').Ctx} ctx
  * @param {Blob} car
+ * @param {string} [uploadType = 'Car']
  */
 export async function handleCarUpload (request, env, ctx, car, uploadType = 'Car') {
   const { user, authToken } = request.auth

--- a/packages/api/src/car.js
+++ b/packages/api/src/car.js
@@ -320,7 +320,7 @@ async function carStat (carBlob) {
  * @returns {number} the size of the DAG in bytes
  */
 function cumulativeSize (pbNodeBytes, pbNode) {
-  // NOTE: Tsize is optional, but all ipfs implementations we know of set it. 
+  // NOTE: Tsize is optional, but all ipfs implementations we know of set it.
   // It's metadata, that could be missing or deliberately set to an incorrect value.
   // This logic is the same as used by go/js-ipfs to display the cumulative size of a dag-pb dag.
   return pbNodeBytes.length + pbNode.Links.reduce((acc, curr) => acc + (curr.Tsize || 0), 0)

--- a/packages/api/src/car.js
+++ b/packages/api/src/car.js
@@ -122,14 +122,14 @@ export async function carGet (request, env, ctx) {
  */
 export async function carPost (request, env, ctx) {
   let blob = await request.blob()
-  // Ensure car blob.type is set; it is used by the cluster client to set the foramt=car flag on the /add call.
+  // Ensure car blob.type is set; it is used by the cluster client to set the format=car flag on the /add call.
   blob = blob.slice(0, blob.size, 'application/car')
 
   return handleCarUpload(request, env, ctx, blob)
 }
 
 /**
- * Post a CAR file.
+ * Request handler for a CAR file upload.
  *
  * @param {import('./user').AuthenticatedRequest} request
  * @param {import('./env').Env} env

--- a/packages/api/src/upload.js
+++ b/packages/api/src/upload.js
@@ -2,6 +2,7 @@
 import { packToBlob } from 'ipfs-car/pack/blob'
 import { handleCarUpload } from './car.js'
 import { toFormData } from './utils/form-data.js'
+import { HTTPError } from './errors.js'
 
 /**
  * Post a File/Directory.

--- a/packages/api/src/upload.js
+++ b/packages/api/src/upload.js
@@ -28,7 +28,7 @@ export async function uploadPost (request, env, ctx) {
       content: f.stream()
     }))
   } else if (contentType.includes('application/car')) {
-    throw new Error('Please POST Content-addressed Archives to /car')
+    throw new HTTPError('Please POST Content-addressed Archives to /car', 400)
   } else {
     const blob = await request.blob()
     if (blob.size === 0) {

--- a/packages/api/src/upload.js
+++ b/packages/api/src/upload.js
@@ -32,7 +32,7 @@ export async function uploadPost (request, env, ctx) {
     }
     files.push(blob)
   }
-  console.log('/upload', files)
+
   const { car } = await packToBlob({ input: files })
   return handleCarUpload(request, env, ctx, car)
 }

--- a/packages/api/src/upload.js
+++ b/packages/api/src/upload.js
@@ -39,5 +39,8 @@ export async function uploadPost (request, env, ctx) {
   // TODO: do we want to wrap file uploads like we do car uploads from the client?
   // this path used to send the files to cluster and we didn't wrap, so we dont here for consistency with the old ways.
   const { car } = await packToBlob({ input, wrapWithDirectory: false })
-  return handleCarUpload(request, env, ctx, car)
+
+  // NOTE: this is tracked in the db to allow us to query for content that was uploaded as raw files vs as CARs.
+  const uploadType = 'Upload'
+  return handleCarUpload(request, env, ctx, car, uploadType)
 }

--- a/packages/api/webpack.config.js
+++ b/packages/api/webpack.config.js
@@ -18,6 +18,10 @@ export default {
   mode: 'development',
   devtool: 'source-map',
   plugins: [
+    // no chunking plz. it's "server-side"
+    new webpack.optimize.LimitChunkCountPlugin({
+      maxChunks: 1
+    }),
     new webpack.ProvidePlugin({
       process: 'process/browser.js',
       Buffer: ['buffer', 'Buffer']


### PR DESCRIPTION
- Have the API pack uploaded files into a CAR, to make the two paths more similar and ideally simplify the upload to S3 path.
  -  We need to test this out on staging to see how it impacts the total file size folks can upload, as now we have to have the upload and the CAR in memory at the same time.
- Simplify dagSize calcualtion. If it's a dag-pb root, then just derive the cumulative size of the dag in the same way that ipfs does from the sum of the link sizes and the node size. if it's not dag-pb, just use the sum of the block sizes in the CAR. 
  - This means we dont have to walk the entire DAG and we can get a dagSize figure for dags that are split across mutiple CARs (assuming they stick to the treewalk strategy from carbites, and each contain the root block).

License: (Apache-2.0 AND MIT)
Signed-off-by: Oli Evans <oli@tableflip.io>