### PR TITLE
chore: add chores and refactors to the changelog

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -73,6 +73,7 @@ jobs:
           package-name: ${{ matrix.package }}
           monorepo-tags: true
           command: release-pr
+          changelog-types: '[{"type":"feat","section":"Features","hidden":false},{"type":"fix","section":"Bug Fixes","hidden":false},{"type":"refactor","section":"Changes","hidden":false},{"type":"chore","section":"Changes","hidden":false}]'
 
   release:
     runs-on: ubuntu-latest


### PR DESCRIPTION
We want to see all the interesting changes in the changelog, even chores and refactors.

see: https://github.com/marketplace/actions/release-please-action#overriding-the-changelog-sections


License: (Apache-2.0 AND MIT)
Signed-off-by: Oli Evans <oli@tableflip.io>