### PR TITLE
fix: upload type in upload should be blob or directory

### DIFF
--- a/packages/api/src/upload.js
+++ b/packages/api/src/upload.js
@@ -21,8 +21,6 @@ export async function uploadPost (request, env, ctx) {
   }
 
   let input
-  // NOTE: this is tracked in the db to allow us to query for content that was uploaded as raw files vs as CARs.
-  let uploadType
   if (contentType.includes('multipart/form-data')) {
     const form = await toFormData(request)
     const files = form.getAll('file')
@@ -30,7 +28,6 @@ export async function uploadPost (request, env, ctx) {
       path: f.name,
       content: f.stream()
     }))
-    uploadType = 'Multipart'
   } else if (contentType.includes('application/car')) {
     throw new HTTPError('Please POST Content-addressed Archives to /car', 400)
   } else {
@@ -39,11 +36,12 @@ export async function uploadPost (request, env, ctx) {
       throw new Error('Empty payload')
     }
     input = [blob]
-    uploadType = 'Blob'
   }
   // TODO: do we want to wrap file uploads like we do car uploads from the client?
   // this path used to send the files to cluster and we didn't wrap, so we dont here for consistency with the old ways.
   const { car } = await packToBlob({ input, wrapWithDirectory: false })
 
+  // NOTE: this is tracked in the db to allow us to query for content that was uploaded as raw files vs as CARs.
+  const uploadType = 'Upload'
   return handleCarUpload(request, env, ctx, car, uploadType)
 }

--- a/packages/db/fauna/schema.graphql
+++ b/packages/db/fauna/schema.graphql
@@ -265,6 +265,10 @@ enum UploadType {
   """
   Car
   """
+  Files uploaded and converteded into a CAR file.
+  """
+  Upload
+  """
   A raw blob upload in the request body.
   """
   Blob

--- a/packages/db/fauna/schema.graphql
+++ b/packages/db/fauna/schema.graphql
@@ -265,7 +265,7 @@ enum UploadType {
   """
   Car
   """
-  Files uploaded and converteded into a CAR file.
+  Files uploaded and converted into a CAR file.
   """
   Upload
   """


### PR DESCRIPTION
The PR to unify /car and /upload https://github.com/web3-storage/web3.storage/pull/480 was merged and changed the Upload type provided to the Database from `Directory` / `Blob` to `Upload`, keeping `Car` to when using the /car endpoint.

This is causing problems in production because `enum type 'UploadType'. Known values are: Car, Blob, Multipart` per https://github.com/web3-storage/web3.storage/blob/website-v1.4.0/packages/db/fauna/schema.graphql#L262-L274

This PR reverts this back to the original behaviour. However, given everything is going to be stored as a Car, maybe the best solution is to either drop this property, or really change its type to `Upload` in the Database schema.