### PR TITLE
chore: bring upload car settings inline with client

### DIFF
--- a/packages/api/src/upload.js
+++ b/packages/api/src/upload.js
@@ -39,7 +39,12 @@ export async function uploadPost (request, env, ctx) {
   }
   // TODO: do we want to wrap file uploads like we do car uploads from the client?
   // this path used to send the files to cluster and we didn't wrap, so we dont here for consistency with the old ways.
-  const { car } = await packToBlob({ input, wrapWithDirectory: false })
+  const { car } = await packToBlob({
+    input,
+    maxChunkSize: 1048576,
+    maxChildrenPerNode: 1024,
+    wrapWithDirectory: false
+  })
 
   // NOTE: this is tracked in the db to allow us to query for content that was uploaded as raw files vs as CARs.
   const uploadType = 'Upload'


### PR DESCRIPTION
Use the same maxChunkSize & maxChildrenPerNode values as the js-client

Follow on from #480 

License: (Apache-2.0 AND MIT)
Signed-off-by: Oli Evans <oli@tableflip.io>