### PR TITLE
fix: chunked backup creation

### DIFF
--- a/packages/db/fauna/resources/Function/createUpload.js
+++ b/packages/db/fauna/resources/Function/createUpload.js
@@ -63,7 +63,36 @@ const body = Query(
               },
               If(
                 IsNonEmpty(Var('uploadMatch')),
-                Get(Var('uploadMatch')),
+                Do(
+                  Foreach(
+                    Select('backupUrls', Var('data')),
+                    Lambda(
+                      ['url'],
+                      Let(
+                        {
+                          upload: Select('ref', Get(Var('uploadMatch'))),
+                          backupMatch: Match(
+                            Index('backup_by_upload_and_url'),
+                            Var('upload'),
+                            Var('url')
+                          )
+                        },
+                        If(
+                          IsNonEmpty(Var('backupMatch')),
+                          Get(Var('backupMatch')),
+                          Create('Backup', {
+                            data: {
+                              upload: Var('upload'),
+                              url: Var('url'),
+                              created: Now()
+                            }
+                          })
+                        )
+                      )
+                    )
+                  ),
+                  Get(Var('uploadMatch'))
+                ),
                 Let(
                   {
                     upload: Create('Upload', {

--- a/packages/db/fauna/resources/Index/backupByUploadAndUrl.js
+++ b/packages/db/fauna/resources/Index/backupByUploadAndUrl.js
@@ -1,0 +1,35 @@
+import fauna from 'faunadb'
+
+const {
+  CreateIndex,
+  Collection,
+  If,
+  Index,
+  Exists,
+  Not
+} = fauna
+
+/**
+ * Usage:
+ *
+ * Match(
+ *   Index('backup_by_upload_and_url'),
+ *   Ref(Collection('Upload'), Var('uploadId')),
+ *   Var('url')
+ * )
+ */
+const index = {
+  name: 'backup_by_upload_and_url',
+  source: Collection('Backup'),
+  terms: [
+    { field: ['data', 'upload'] },
+    { field: ['data', 'url'] }
+  ]
+}
+
+// indexes cannot be updated
+export default If(
+  Not(Exists(Index(index.name))),
+  CreateIndex(index),
+  Index(index.name)
+)


### PR DESCRIPTION
https://github.com/web3-storage/web3.storage/pull/417 was merged but follow up chunk backup URLs were not properly stored. Only the first one was stored, instead of each single one. This was because of the short circuit where we just return an upload if there is one. In this situation, we need to update the Backup collection

Considering comment https://github.com/web3-storage/web3.storage/pull/417#discussion_r707451630 , an index was also added to verify if the backup url for the given upload already exists. Considering that we will not create the upload entry and we will not create the content entry, this should not result in much more computing power to finish the mutation.