### PR TITLE
fix: source mapping and commit info in sentry

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20373,7 +20373,7 @@
     },
     "packages/api": {
       "name": "@web3-storage/api",
-      "version": "3.4.0",
+      "version": "3.5.1",
       "license": "(Apache-2.0 AND MIT)",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.28.0",
@@ -20524,7 +20524,7 @@
     },
     "packages/db": {
       "name": "@web3-storage/db",
-      "version": "2.2.0",
+      "version": "2.3.1",
       "license": "(Apache-2.0 AND MIT)",
       "dependencies": {
         "graphql-request": "^3.4.0"
@@ -24101,7 +24101,7 @@
         "assert": "^2.0.0",
         "buffer": "^6.0.3",
         "dotenv": "^10.0.0",
-        "git-revision-webpack-plugin": "^5.0.0",
+        "git-revision-webpack-plugin": "*",
         "ipfs-car": "^0.5.8",
         "ipfs-unixfs-importer": "^9.0.4",
         "itty-router": "^2.3.10",

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "type": "module",
   "license": "(Apache-2.0 AND MIT)",
-  "main": "dist/main.js",
+  "main": "dist/worker.js",
   "scripts": {
     "lt": "npm run lt:cluster",
     "lt:cluster": "npx localtunnel --port 9094 --subdomain \"$(whoami)-cluster-api-web3-storage\"",
@@ -55,7 +55,7 @@
   },
   "bundlesize": [
     {
-      "path": "./dist/main.js",
+      "path": "./dist/worker.js",
       "maxSize": "1 MB"
     }
   ]

--- a/packages/api/src/env.js
+++ b/packages/api/src/env.js
@@ -1,4 +1,4 @@
-/* global MAGIC_SECRET_KEY FAUNA_ENDPOINT FAUNA_KEY SALT CLUSTER_BASIC_AUTH_TOKEN CLUSTER_API_URL SENTRY_DSN, VERSION DANGEROUSLY_BYPASS_MAGIC_AUTH S3_BUCKET_ENDPOINT S3_BUCKET_NAME S3_BUCKET_REGION S3_ACCESS_KEY_ID S3_SECRET_ACCESS_KEY_ID ENV */
+/* global MAGIC_SECRET_KEY FAUNA_ENDPOINT FAUNA_KEY SALT CLUSTER_BASIC_AUTH_TOKEN CLUSTER_API_URL SENTRY_DSN SENTRY_RELEASE DANGEROUSLY_BYPASS_MAGIC_AUTH S3_BUCKET_ENDPOINT S3_BUCKET_NAME S3_BUCKET_REGION S3_ACCESS_KEY_ID S3_SECRET_ACCESS_KEY_ID ENV */
 import Toucan from 'toucan-js'
 import { S3Client } from '@aws-sdk/client-s3'
 import { Magic } from '@magic-sdk/admin'
@@ -34,12 +34,8 @@ export function envAll (_, env, event) {
       root: '/'
     },
     environment: env.ENV || ENV,
-    release: env.VERSION || VERSION,
-    pkg: {
-      ...pkg,
-      // sentry cannot deal with "/" in version
-      name: pkg.name.replace('@web3-storage/', '')
-    }
+    release: env.SENTRY_RELEASE || SENTRY_RELEASE,
+    pkg
   })
   env.magic = new Magic(env.MAGIC_SECRET_KEY || MAGIC_SECRET_KEY)
 

--- a/packages/api/src/env.js
+++ b/packages/api/src/env.js
@@ -33,7 +33,7 @@ export function envAll (_, env, event) {
     rewriteFrames: {
       root: '/'
     },
-    env: env.ENV || ENV,
+    environment: env.ENV || ENV,
     release: env.VERSION || VERSION,
     pkg: {
       ...pkg,

--- a/packages/api/src/env.js
+++ b/packages/api/src/env.js
@@ -1,4 +1,4 @@
-/* global MAGIC_SECRET_KEY FAUNA_ENDPOINT FAUNA_KEY SALT CLUSTER_BASIC_AUTH_TOKEN CLUSTER_API_URL SENTRY_DSN, VERSION DANGEROUSLY_BYPASS_MAGIC_AUTH S3_BUCKET_ENDPOINT S3_BUCKET_NAME S3_BUCKET_REGION S3_ACCESS_KEY_ID S3_SECRET_ACCESS_KEY_ID */
+/* global MAGIC_SECRET_KEY FAUNA_ENDPOINT FAUNA_KEY SALT CLUSTER_BASIC_AUTH_TOKEN CLUSTER_API_URL SENTRY_DSN, VERSION DANGEROUSLY_BYPASS_MAGIC_AUTH S3_BUCKET_ENDPOINT S3_BUCKET_NAME S3_BUCKET_REGION S3_ACCESS_KEY_ID S3_SECRET_ACCESS_KEY_ID ENV */
 import Toucan from 'toucan-js'
 import { S3Client } from '@aws-sdk/client-s3'
 import { Magic } from '@magic-sdk/admin'
@@ -26,14 +26,15 @@ import pkg from '../package.json'
 export function envAll (_, env, event) {
   env.sentry = (env.SENTRY_DSN || typeof SENTRY_DSN !== 'undefined') && new Toucan({
     dsn: env.SENTRY_DSN || SENTRY_DSN,
-    event,
+    context: event,
     allowedHeaders: ['user-agent'],
     allowedSearchParams: /(.*)/,
     debug: false,
     rewriteFrames: {
       root: '/'
     },
-    version: env.VERSION || VERSION,
+    env: env.ENV || ENV,
+    release: env.VERSION || VERSION,
     pkg: {
       ...pkg,
       // sentry cannot deal with "/" in version

--- a/packages/api/webpack.config.js
+++ b/packages/api/webpack.config.js
@@ -52,5 +52,8 @@ export default {
   optimization: {
     minimize: true,
     usedExports: true
+  },
+  output: {
+    filename: 'worker.js'
   }
 }

--- a/packages/api/webpack.config.js
+++ b/packages/api/webpack.config.js
@@ -16,7 +16,7 @@ const require = createRequire(__dirname)
 export default {
   target: 'webworker',
   mode: 'development',
-  devtool: 'source-map',
+  devtool: 'hidden-cheap-module-source-map',
   plugins: [
     // no chunking plz. it's "server-side"
     new webpack.optimize.LimitChunkCountPlugin({

--- a/packages/api/webpack.config.js
+++ b/packages/api/webpack.config.js
@@ -13,10 +13,16 @@ const gitRevisionPlugin = new GitRevisionPlugin()
 const __dirname = path.dirname(new URL(import.meta.url).pathname)
 const require = createRequire(__dirname)
 
+// relaase name cannot contain slashes, and are global per org, so we prefix here.
+// see: https://docs.sentry.io/platforms/javascript/guides/cordova/configuration/releases/
+const SENTRY_RELEASE = `web3-api@${process.env.npm_package_version}`
+
 export default {
   target: 'webworker',
   mode: 'development',
-  devtool: 'hidden-cheap-module-source-map',
+  // `hidden` removes sourceMappingURL from the end of the bundle which magically makes sentry source mapping work...
+  // see: https://github.com/robertcepa/toucan-js/issues/54#issuecomment-930416972
+  devtool: 'hidden-source-map',
   plugins: [
     // no chunking plz. it's "server-side"
     new webpack.optimize.LimitChunkCountPlugin({
@@ -27,11 +33,15 @@ export default {
       Buffer: ['buffer', 'Buffer']
     }),
     new webpack.DefinePlugin({
-      VERSION: JSON.stringify(gitRevisionPlugin.version())
+      VERSION: JSON.stringify(gitRevisionPlugin.version()),
+      SENTRY_RELEASE: JSON.stringify(SENTRY_RELEASE)
     }),
     process.env.SENTRY_UPLOAD === 'true' &&
       new SentryWebpackPlugin({
-        release: gitRevisionPlugin.version(),
+        setCommits: {
+          auto: true
+        },
+        release: SENTRY_RELEASE, // This must match the `release` option passed to toucan-js
         include: './dist',
         urlPrefix: '/',
         org: 'protocol-labs-it',


### PR DESCRIPTION
Match up the release name reported during deploy with the release name reported at run time. This PR lines things up so releases appear in sentry like `web3-api@<semver>` which it automagically parses nicely. We currently we deploy as `<sort git sha>` but we report as `api-<semver>`.

see: https://sentry.io/organizations/protocol-labs-it/releases/web3-api%403.5.1/?project=5866408

- `SENTRY_RELEASE` env var is set during the build, and used for both creating the release at build time and on error reports so they get matched up and our sourcemap is used to unravel the stacktrace.
- Rename the bundle to be `worker.js` as that is what cloudflare renames (!?) it to on deploy, and errors are reported as coming from `worker.js` in production, so that has to match or else the source map is not applied.
- remove the `//# sourceMappingURL=...` link from the end of the js bundle by switching to `devtool: hidden-source-map` in the webpack config. I have no idea whey this is necessary. see: https://github.com/robertcepa/toucan-js/issues/54#issuecomment-930416972
- add commit info to releases in a way that sentry understands, and can match up to our repo with `setCommits: { auto: true }` see: https://github.com/getsentry/sentry-webpack-plugin#optionssetcommits

This fixes our double release counting in sentry and make source maps work for _much error readability_!

<img width="848" alt="Screenshot 2021-09-29 at 16 24 53" src="https://user-images.githubusercontent.com/58871/135340773-7f321748-4aae-401e-9dc9-c4ae5d19a696.png">

I have also connected up the repo in Sentry so we can see the commits that go in to the release.

<img width="364" alt="Screenshot 2021-09-29 at 21 09 37" src="https://user-images.githubusercontent.com/58871/135341267-d67026d7-881f-4f7b-a314-fbc102c75d37.png">


### Follow on work

- We can spare ourselves from cf worker upload errors by just not uploading our 4MB source map as part of deployment. Use the webpack remove files plugin to delete the source map after it has been uploaded to sentry, as we're just not using in cloudflare! would fix #499 
- Add COMMITSHA and BRANCH env vars, and a `/version` endpoint to report it as nft.storage does. https://github.com/ipfs-shipyard/nft.storage/blob/7102ad5fc06d90a85027e40fa0aece3429b833e7/packages/api/src/index.js#L58-L64

License: (Apache-2.0 AND MIT)
Signed-off-by: Oli Evans <oli@tableflip.io>