### PR TITLE
fix: api dev mode without backup secrets

### DIFF
--- a/packages/api/src/env.js
+++ b/packages/api/src/env.js
@@ -58,7 +58,7 @@ export function envAll (_, env, event) {
   env.cluster = new Cluster(env.CLUSTER_API_URL || CLUSTER_API_URL, { headers })
 
   // backups not required in dev mode
-  if (env.ENV === 'dev' && !(env.S3_ACCESS_KEY_ID || typeof S3_ACCESS_KEY_ID !== 'undefined')) {
+  if ((env.ENV === 'dev' || ENV === 'dev') && !(env.S3_ACCESS_KEY_ID || typeof S3_ACCESS_KEY_ID !== 'undefined')) {
     console.log('running without backups wired up')
   } else {
     const s3Endpoint = env.S3_BUCKET_ENDPOINT || (typeof S3_BUCKET_ENDPOINT === 'undefined' ? undefined : S3_BUCKET_ENDPOINT)

--- a/packages/api/test/scripts/worker-globals.js
+++ b/packages/api/test/scripts/worker-globals.js
@@ -5,6 +5,7 @@ export const caches = {
   }
 }
 
+export const ENV = 'dev'
 export const SALT = 'test-salt'
 export const FAUNA_ENDPOINT = 'http://localhost:9086/graphql'
 export const FAUNA_KEY = 'test-fauna-key'


### PR DESCRIPTION
wrangler config file injects env variables as globals and the condition to allow no backups in dev was not met.

This only affects dev mode