### PR TITLE
fix: fauna webpack config

### DIFF
--- a/packages/api/README.md
+++ b/packages/api/README.md
@@ -197,3 +197,13 @@ Production vars should be set in Github Actions secrets.
 ## S3 Setup
 
 We use [S3](https://aws.amazon.com/s3/) for backup and disaster recovery. For production an account on AWS needs to be created.
+
+## Local DB Setup
+
+Inside the `/packages/api` folder create a file called `.env.local` with the following content.
+
+```ini
+DATABASE=<name> # either "fauna" or "postgres"
+```
+
+Production vars should be set in Github Actions secrets.

--- a/packages/api/webpack.config.js
+++ b/packages/api/webpack.config.js
@@ -30,6 +30,15 @@ const require = createRequire(__dirname)
 // see: https://docs.sentry.io/platforms/javascript/guides/cordova/configuration/releases/
 const SENTRY_RELEASE = `web3-api@${process.env.npm_package_version}`
 
+const alias = {
+  // node-fetch and cross-fetch causes TypeError: Illegal invocation in Cloudflare Workers
+  'node-fetch': path.resolve(__dirname, 'src', 'utils', 'fetch.js')
+}
+
+if (process.env.DATABASE === 'postgres') {
+  alias['cross-fetch'] = path.resolve(__dirname, 'src', 'utils', 'fetch.js')
+}
+
 export default {
   target: 'webworker',
   mode: 'development',
@@ -75,11 +84,7 @@ export default {
     fallback: {
       stream: require.resolve('stream-browserify')
     },
-    alias: {
-      // node-fetch and cross-fetch causes TypeError: Illegal invocation in Cloudflare Workers
-      'node-fetch': path.resolve(__dirname, 'src', 'utils', 'fetch.js'),
-      'cross-fetch': path.resolve(__dirname, 'src', 'utils', 'fetch.js')
-    }
+    alias
   },
   optimization: {
     minimize: true,


### PR DESCRIPTION
This PR fixes fauna webpack config. We added alias for `cross-fetch` because of Postgrest, however this causes fauna queries to error with `Right-hand side of 'instanceof' is not an object`.

Given we want to support both DBs until Postgres is live (swappable via ENV var), I tweaked the webpack config to only add cross-fetch alias when we have Postgres.