### PR TITLE
fix: website maintenance banner

### DIFF
--- a/packages/website/lib/api.js
+++ b/packages/website/lib/api.js
@@ -177,11 +177,9 @@ export async function getVersion() {
     },
   })
 
-  const body = await res.json()
-
-  if (body.ok) {
-    return body
+  if (res.ok) {
+    return await res.json()
   } else {
-    throw new Error(body.error.message)
+    throw new Error(await res.text())
   }
 }


### PR DESCRIPTION
This PR fixes the website banner added in https://github.com/web3-storage/web3.storage/pull/544

It was not properly parsing the HTTP response, resulting in errors and not showing up the banner. You can see the errors in https://staging.web3.storage/

Just tested this fix in my local env and everything looks fixed now