### PR TITLE
fix: api webpack build compatible with both dbs and swappable on runtime

### DIFF
--- a/packages/api/src/utils/fetch.js
+++ b/packages/api/src/utils/fetch.js
@@ -1,3 +1,5 @@
 // Needed by @magic-sdk/admin.
 // In webpack config we replace node-fetch with this file.
 export default globalThis.fetch.bind(globalThis)
+
+export const Headers = globalThis.Headers

--- a/packages/api/webpack.config.js
+++ b/packages/api/webpack.config.js
@@ -31,15 +31,6 @@ const require = createRequire(__dirname)
 // see: https://docs.sentry.io/platforms/javascript/guides/cordova/configuration/releases/
 const SENTRY_RELEASE = `web3-api@${process.env.npm_package_version}`
 
-const alias = {
-  // node-fetch and cross-fetch causes TypeError: Illegal invocation in Cloudflare Workers
-  'node-fetch': path.resolve(__dirname, 'src', 'utils', 'fetch.js')
-}
-
-if (process.env.DATABASE === 'postgres') {
-  alias['cross-fetch'] = path.resolve(__dirname, 'src', 'utils', 'fetch.js')
-}
-
 export default {
   target: 'webworker',
   mode: 'development',
@@ -87,7 +78,11 @@ export default {
     fallback: {
       stream: require.resolve('stream-browserify')
     },
-    alias
+    alias: {
+      // node-fetch and cross-fetch causes TypeError: Illegal invocation in Cloudflare Workers
+      'node-fetch': path.resolve(__dirname, 'src', 'utils', 'fetch.js'),
+      'cross-fetch': path.resolve(__dirname, 'src', 'utils', 'fetch.js')
+    }
   },
   optimization: {
     minimize: true,


### PR DESCRIPTION
In https://github.com/web3-storage/web3.storage/pull/550 I fixed the webpack build to work both with Postgres and Graphql client.

That fix was motivated by a problem when using FaunaDB. When we use Fauna DB(+ graphql client) and we added an alias for `cross-fetch` (which is needed by `@supabase/postgrest-js`) we started to have requests failing to Fauna with the error: `TypeError: Right-hand side of 'instanceof' is not an object`

The easy fix at the time was #550 , that is, only add alias for `cross-fetch` when using Postgres DB (with env var). However, we want to be able to change databases on runtime by simply swapping a wrangler secret DATABASE from `fauna` to `postgres`. And of course this is problematic.

The root reason behind the issue was https://github.com/prisma-labs/graphql-request/blob/v3.6.1/src/index.ts#L18 . So, this PR also exports Headers in the alias module of fetch to have it working as expected.