### PR TITLE
feat: add migration tracker table

### DIFF
--- a/packages/db/postgres/tables.sql
+++ b/packages/db/postgres/tables.sql
@@ -175,3 +175,14 @@ CREATE TABLE IF NOT EXISTS pin_sync_request
   pin_id          BIGINT                                                        NOT NULL UNIQUE REFERENCES pin (id),
   inserted_at     TIMESTAMP WITH TIME ZONE DEFAULT timezone('utc'::text, now()) NOT NULL
 );
+
+-- A migration tracker.
+CREATE TABLE IF NOT EXISTS migration_tracker
+(
+  id              BIGSERIAL PRIMARY KEY,
+  cid             TEXT                                                          NOT NULL,
+  duration        BIGINT,
+  dump_started_at TIMESTAMP WITH TIME ZONE,
+  dump_ended_at   TIMESTAMP WITH TIME ZONE NOT NULL,
+  inserted_at     TIMESTAMP WITH TIME ZONE DEFAULT timezone('utc'::text, now()) NOT NULL
+)


### PR DESCRIPTION
This PR adds a migration tracker, so that we can do:

1. Full Fauna dump
2. Partial Fauna dumps over time to update Postgres with the new changes within a cron job that inserts its data into the Postgres Table (csv directory is added to IPFS for ease of consulting)
3. Run validation scripts with data from partial migrations