### PR TITLE
fix: backup should not have unique url

### DIFF
--- a/packages/db/postgres/client.js
+++ b/packages/db/postgres/client.js
@@ -468,9 +468,7 @@ export class PostgresClient {
       .upsert(pinSyncRequests.map(psr => ({
         pin_id: psr,
         inserted_at: new Date().toISOString()
-      })), {
-        onConflict: 'pin_id'
-      })
+      }))) // TODO: On conflict pin ID
 
     if (error) {
       throw new DBError(error)

--- a/packages/db/postgres/tables.sql
+++ b/packages/db/postgres/tables.sql
@@ -138,9 +138,8 @@ CREATE TABLE IF NOT EXISTS upload
   name            TEXT,
   inserted_at     TIMESTAMP WITH TIME ZONE DEFAULT timezone('utc'::text, now()) NOT NULL,
   updated_at      TIMESTAMP WITH TIME ZONE DEFAULT timezone('utc'::text, now()) NOT NULL,
-  deleted_at      TIMESTAMP WITH TIME ZONE,
-  -- deleted_at      TIMESTAMP WITH TIME ZONE, do we want?
-  UNIQUE (user_id, source_cid)
+  deleted_at      TIMESTAMP WITH TIME ZONE
+  -- UNIQUE (user_id, source_cid)
 );
 
 CREATE INDEX IF NOT EXISTS upload_updated_at_idx ON upload (updated_at);
@@ -152,7 +151,7 @@ CREATE TABLE IF NOT EXISTS backup
   -- Upload that resulted in this backup.
   upload_id       BIGINT                                                        NOT NULL REFERENCES upload (id) ON DELETE CASCADE,
   -- Backup url location.
-  url             TEXT                                                          NOT NULL UNIQUE,
+  url             TEXT                                                          NOT NULL,
   inserted_at     TIMESTAMP WITH TIME ZONE DEFAULT timezone('utc'::text, now()) NOT NULL
 );
 
@@ -172,7 +171,7 @@ CREATE TABLE IF NOT EXISTS pin_sync_request
 (
   id              BIGSERIAL PRIMARY KEY,
   -- Identifier for the pin to keep in sync.
-  pin_id          BIGINT                                                        NOT NULL UNIQUE REFERENCES pin (id),
+  pin_id          BIGINT                                                        NOT NULL REFERENCES pin (id),
   inserted_at     TIMESTAMP WITH TIME ZONE DEFAULT timezone('utc'::text, now()) NOT NULL
 );
 

--- a/packages/db/test/upload.spec.js
+++ b/packages/db/test/upload.spec.js
@@ -119,7 +119,8 @@ describe('upload', () => {
     const followUpUpload = await client.getUpload(cid, user._id)
 
     assert(followUpUpload, 'follow up upload created')
-    assert.notStrictEqual(followUpUpload.updated, upload.updated, 'upload has updated timestamp')
+    // TODO: when unique constraint
+    // assert.notStrictEqual(followUpUpload.updated, upload.updated, 'upload has updated timestamp')
     assert.strictEqual(followUpUpload.created, upload.created, 'upload has inserted timestamp')
     assert.strictEqual(followUpUpload.type, upload.type, 'upload has same type')
     assert.strictEqual(followUpUpload.name, upload.name, 'upload has same name')


### PR DESCRIPTION
In Fauna, when a user A deleted a given upload, if then the user uploads exactly the same file, a new Upload document was created, instead of flipping `deleted`. This means we will have same URLs. With Postgres we will not have this situation anymore. However, for DB migration let's allow replicated URLs to ingest data. Then we can remove replicated ones. Pin Sync requests currently also have multiple