### PR TITLE
fix: fauna pins cron

### DIFF
--- a/packages/db/fauna/client.js
+++ b/packages/db/fauna/client.js
@@ -294,7 +294,7 @@ export class FaunaClient {
           _id
         }
       }
-    `, { pins })
+    `, { pins: pins.map(p => ({ pin: p.id, status: p.status })) })
   }
 
   /**


### PR DESCRIPTION
Fauna Graphql query can only receive what `UpdatePinInput` type contains