### PR TITLE
fix: add on conflict clause to create backup

### DIFF
--- a/packages/db/postgres/functions.sql
+++ b/packages/db/postgres/functions.sql
@@ -109,7 +109,8 @@ BEGIN
                         inserted_at)
     values (inserted_upload_id,
             backup_url,
-            (data ->> 'inserted_at')::timestamptz);
+            (data ->> 'inserted_at')::timestamptz)
+    ON CONFLICT ( url ) DO NOTHING;
   end loop;
 
   return inserted_upload_id;

--- a/packages/db/test/upload.spec.js
+++ b/packages/db/test/upload.spec.js
@@ -119,8 +119,7 @@ describe('upload', () => {
     const followUpUpload = await client.getUpload(cid, user._id)
 
     assert(followUpUpload, 'follow up upload created')
-    // TODO: when unique constraint
-    // assert.notStrictEqual(followUpUpload.updated, upload.updated, 'upload has updated timestamp')
+    assert.notStrictEqual(followUpUpload.updated, upload.updated, 'upload has updated timestamp')
     assert.strictEqual(followUpUpload.created, upload.created, 'upload has inserted timestamp')
     assert.strictEqual(followUpUpload.type, upload.type, 'upload has same type')
     assert.strictEqual(followUpUpload.name, upload.name, 'upload has same name')


### PR DESCRIPTION
#580 had removed this for data ingestion, but forgot it on https://github.com/web3-storage/web3.storage/pull/597

Already updated function in production schema