### PR TITLE
fix: create key mock

### DIFF
--- a/.github/workflows/api.yml
+++ b/.github/workflows/api.yml
@@ -5,10 +5,12 @@ on:
       - main
     paths:
       - 'packages/api/**'
+      - 'packages/db/**'
       - '.github/workflows/api.yml'
   pull_request:
     paths:
       - 'packages/api/**'
+      - 'packages/db/**'
       - '.github/workflows/api.yml'
 jobs:
   test:

--- a/packages/api/test/mocks/pgrest/post_rpc#create_key.js
+++ b/packages/api/test/mocks/pgrest/post_rpc#create_key.js
@@ -1,8 +1,9 @@
 /**
  * https://github.com/sinedied/smoke#javascript-mocks
  */
-module.exports = ({ body }) => {
+module.exports = () => {
   return {
-    id: 1
+    statusCode: 200,
+    body: '1' // key ID
   }
 }


### PR DESCRIPTION
We changed the create key to be a rpc call instead of a post. But mocks in the API were not updated and tests are now failing...

I also made the API CI Job to track changes in the DB module to avoid future regressions