### PR TITLE
fix: max pin requests per run in cron and pinpin

### DIFF
--- a/packages/cron/src/jobs/pins.js
+++ b/packages/cron/src/jobs/pins.js
@@ -3,7 +3,7 @@ import { toPinStatusEnum } from '@web3-storage/api/src/utils/pin.js'
 import retry from 'p-retry'
 import { piggyback } from 'piggybacker'
 
-const MAX_PIN_REQUESTS_PER_RUN = 600
+const MAX_PIN_REQUESTS_PER_RUN = 400
 const log = debug('pins:updatePinStatuses')
 
 /**

--- a/packages/pinpin/src/index.js
+++ b/packages/pinpin/src/index.js
@@ -9,7 +9,7 @@ import debug from 'debug'
 import retry from 'p-retry'
 
 // Note: any other batch size and the request to fetch the PinRequests fails!
-const MAX_PIN_REQUESTS_PER_RUN = 600
+const MAX_PIN_REQUESTS_PER_RUN = 400
 const log = debug('pinpin')
 
 /**


### PR DESCRIPTION
When calling delete  on https://github.com/web3-storage/web3.storage/blob/main/packages/db/postgres/client.js#L533 to delete pinRequests + PinSyncRequests on cron jobs the requests could fail given the Postgrest URL was too big. After some tests, 400 Pins seemed the most reasonable number to use.