### PR TITLE
fix: performance metrics queries

### DIFF
--- a/packages/api/test/mocks/pgrest/post_rpc#pin_from_status_total.js
+++ b/packages/api/test/mocks/pgrest/post_rpc#pin_from_status_total.js
@@ -1,0 +1,9 @@
+/**
+ * https://github.com/sinedied/smoke#javascript-mocks
+ */
+module.exports = () => {
+  return {
+    statusCode: 200,
+    body: '30000'
+  }
+}

--- a/packages/db/postgres/functions.sql
+++ b/packages/db/postgres/functions.sql
@@ -216,6 +216,19 @@ SELECT (ak.id)::TEXT AS id,
  WHERE ak.user_id = query_user_id AND ak.deleted_at IS NULL
 $$;
 
+CREATE OR REPLACE FUNCTION pin_from_status_total(query_status TEXT) RETURNS TEXT
+  LANGUAGE plpgsql
+AS
+$$
+BEGIN
+  return(
+    select count(*)
+    from pin
+    where status = (query_status)::pin_status_type
+  )::TEXT;
+END
+$$;
+
 CREATE OR REPLACE FUNCTION content_dag_size_total() RETURNS TEXT
   LANGUAGE plpgsql
 AS

--- a/packages/db/postgres/metrics.js
+++ b/packages/db/postgres/metrics.js
@@ -76,11 +76,7 @@ const pinStatusMapping = {
 
 export async function getPinStatusMetrics (client, key) {
   const pinStatus = pinStatusMapping[key]
-  const { count, error } = await client
-    .from('pin')
-    .select('*', { head: true, count: 'exact' })
-    .filter('status', 'eq', pinStatus)
-    .range(0, 1)
+  const { count, error } = await client.rpc('pin_from_status_total', { query_status: pinStatus })
 
   if (error) {
     throw new DBError(error)

--- a/packages/db/postgres/tables.sql
+++ b/packages/db/postgres/tables.sql
@@ -46,6 +46,7 @@ CREATE TABLE IF NOT EXISTS content
 );
 
 CREATE INDEX IF NOT EXISTS content_updated_at_idx ON content (updated_at);
+CREATE UNIQUE INDEX content_cid_with_size_idx ON content (cid) INCLUDE (dag_size);
 
 -- IPFS Cluster tracker status values.
 -- https://github.com/ipfs/ipfs-cluster/blob/54c3608899754412861e69ee81ca8f676f7e294b/api/types.go#L52-L83

--- a/packages/db/postgres/tables.sql
+++ b/packages/db/postgres/tables.sql
@@ -46,6 +46,7 @@ CREATE TABLE IF NOT EXISTS content
 );
 
 CREATE INDEX IF NOT EXISTS content_updated_at_idx ON content (updated_at);
+-- TODO: Sync with @ribasushi as we can start using this as the primary key
 CREATE UNIQUE INDEX content_cid_with_size_idx ON content (cid) INCLUDE (dag_size);
 
 -- IPFS Cluster tracker status values.


### PR DESCRIPTION
Improves metrics related queries to get the API endpoint working:

- supabase count was not properly doing the count, but getting all the rows instead, which was too slow.
- added an unique index to cid including `dag_size` to speed up `pin_dag_size_total` rpc function.

All thanks to @ribasushi 

New function already created into production DB