### PR TITLE
fix: pin status metrics returns data object

### DIFF
--- a/packages/api/test/mocks/pgrest/post_rpc#pin_from_status_total.js
+++ b/packages/api/test/mocks/pgrest/post_rpc#pin_from_status_total.js
@@ -4,6 +4,8 @@
 module.exports = () => {
   return {
     statusCode: 200,
-    body: '30000'
+    body: [{
+      pin_from_status_total: '30000'
+    }]
   }
 }

--- a/packages/db/postgres/metrics.js
+++ b/packages/db/postgres/metrics.js
@@ -76,13 +76,13 @@ const pinStatusMapping = {
 
 export async function getPinStatusMetrics (client, key) {
   const pinStatus = pinStatusMapping[key]
-  const { count, error } = await client.rpc('pin_from_status_total', { query_status: pinStatus })
+  const { data, error } = await client.rpc('pin_from_status_total', { query_status: pinStatus })
 
   if (error) {
     throw new DBError(error)
   }
 
   return {
-    total: count
+    total: data[0].pin_from_status_total
   }
 }


### PR DESCRIPTION
We kept count as returned from supabase client, but when getting it as an rpc call it returns it as data. Fix from bug introduced on https://github.com/web3-storage/web3.storage/pull/625