### PR TITLE
fix: list uploads fetch deals for correct cid

### DIFF
--- a/packages/db/index.js
+++ b/packages/db/index.js
@@ -218,12 +218,12 @@ export class DBClient {
     }
 
     // Get deals
-    const cids = uploads?.map((u) => u.content_cid)
+    const cids = uploads?.map((u) => u.content.cid)
     const deals = await this.getDealsForCids(cids)
 
     return uploads?.map((u) => ({
       ...normalizeUpload(u),
-      deals: deals[u.content_cid] || []
+      deals: deals[u.content.cid] || []
     }))
   }
 


### PR DESCRIPTION
The status API was working fine to get the deals, but the same was not true for the list of uploads. When the query was simplified, the `content_cid` was removed from the query and we can rely on the content relation to ask the deals for the correct cid