### PR TITLE
fix: support upload list page size up to 1000

### DIFF
--- a/packages/api/README.md
+++ b/packages/api/README.md
@@ -121,7 +121,7 @@ You can also provide a name for the file using the header `X-NAME`, but be sure 
 Get a list of user uploads. _Authenticated_
 
 ```console
-curl -H 'Authorization: Bearer YOUR_API_KEY' 'http://127.0.0.1:8787/status/bafybeidwfngv7n5y7ydbzotrwl3gohgr2lv2g7vn6xggwcjzrf5emknrki' -s | jq
+curl -H 'Authorization: Bearer YOUR_API_KEY' 'http://127.0.0.1:8787/user/uploads' -s | jq
 {
   "cid": "bafybeidwfngv7n5y7ydbzotrwl3gohgr2lv2g7vn6xggwcjzrf5emknrki",
   "created": "2021-07-29T09:08:28.295905Z",
@@ -134,7 +134,14 @@ curl -H 'Authorization: Bearer YOUR_API_KEY' 'http://127.0.0.1:8787/status/bafyb
       "peerName": "web3-storage-sv15",
       "region": "US-CA"
     }
-  ]
+  ],
+  "deals": []
+```
+
+By default, 25 uploads are requested, but more can be requested up to a maximum of 1000. A `size` parameter should be used as follows:
+
+```console
+curl -H 'Authorization: Bearer YOUR_API_KEY' 'http://127.0.0.1:8787/user/uploads?size=1000'
 ```
 
 ### 🤲 `GET /car/:cid`

--- a/packages/api/src/user.js
+++ b/packages/api/src/user.js
@@ -166,7 +166,7 @@ export async function userUploadsGet (request, env) {
   let size = 25
   if (searchParams.has('size')) {
     const parsedSize = parseInt(searchParams.get('size'))
-    if (isNaN(parsedSize) || parsedSize <= 0 || parsedSize > 100) {
+    if (isNaN(parsedSize) || parsedSize <= 0 || parsedSize > 1000) {
       throw Object.assign(new Error('invalid page size'), { status: 400 })
     }
     size = parsedSize


### PR DESCRIPTION
Also fixes the API docs. The docs.web3.storage mentions the url search parameter to be `limit`, which was also the root reason for this problem. The option was already `size` previously when using fauna https://github.com/web3-storage/web3.storage/blob/api-v3.0.0/packages/api/src/user.js#L259 in the older version.

Needs:
- [x] update docs.web3.storage https://github.com/web3-storage/docs/pull/210

Closes #598 