### PR TITLE
fix: pin dag size metric should filter by pinned status

### DIFF
--- a/packages/db/postgres/functions.sql
+++ b/packages/db/postgres/functions.sql
@@ -250,6 +250,7 @@ BEGIN
     select sum(c.dag_size)
     from pin p
     join content c on c.cid = p.content_cid
+    where p.status = ('Pinned')::pin_status_type
   )::TEXT;
 END
 $$;


### PR DESCRIPTION
Porting fauna counterpart with status was missed in migration: https://github.com/web3-storage/web3.storage/blob/db-v2.6.4/packages/db/fauna/resources/Function/sumPinDagSize.js#L31

This was already added to prod DB