### PR TITLE
fix: deal normalize should filter out unexpected deal status

### DIFF
--- a/packages/api/test/mocks/pgrest/post_rpc#find_deals_by_content_cids.js
+++ b/packages/api/test/mocks/pgrest/post_rpc#find_deals_by_content_cids.js
@@ -13,7 +13,7 @@ module.exports = ({ body }) => {
         pieceCid: 'baga',
         dataCid: 'bafybeifnfkzjeohjf2dch2iqqpef3bfjylwxlcjws2msvdfyze5bvdprfm',
         dataModelSelector: 'Links/0/Links',
-        activation: '<iso timestamp>',
+        dealActivation: '<iso timestamp>',
         created: '2021-07-14T19:27:14.934572Z',
         updated: '2021-07-14T19:27:14.934572Z'
       },
@@ -24,7 +24,7 @@ module.exports = ({ body }) => {
         pieceCid: 'baga',
         dataCid: 'bafybeifnfkzjeohjf2dch2iqqpef3bfjylwxlcjws2msvdfyze5bvdprfm',
         dataModelSelector: 'Links/0/Links',
-        activation: '<iso timestamp>',
+        dealActivation: '<iso timestamp>',
         created: '2021-07-14T19:27:14.934572Z',
         updated: '2021-07-14T19:27:14.934572Z'
       }

--- a/packages/api/test/mocks/pgrest/post_rpc#find_deals_by_content_cids.js
+++ b/packages/api/test/mocks/pgrest/post_rpc#find_deals_by_content_cids.js
@@ -5,17 +5,30 @@
 module.exports = ({ body }) => {
   // main cid
   if (body.cids.includes('bafybeifnfkzjeohjf2dch2iqqpef3bfjylwxlcjws2msvdfyze5bvdprfm')) {
-    return [{
-      dealId: 12345,
-      storageProvider: 'f99',
-      status: 'Active',
-      pieceCid: 'baga',
-      dataCid: 'bafybeifnfkzjeohjf2dch2iqqpef3bfjylwxlcjws2msvdfyze5bvdprfm',
-      dataModelSelector: 'Links/0/Links',
-      activation: '<iso timestamp>',
-      created: '2021-07-14T19:27:14.934572Z',
-      updated: '2021-07-14T19:27:14.934572Z'
-    }]
+    return [
+      {
+        dealId: 12345,
+        storageProvider: 'f99',
+        status: 'Active',
+        pieceCid: 'baga',
+        dataCid: 'bafybeifnfkzjeohjf2dch2iqqpef3bfjylwxlcjws2msvdfyze5bvdprfm',
+        dataModelSelector: 'Links/0/Links',
+        activation: '<iso timestamp>',
+        created: '2021-07-14T19:27:14.934572Z',
+        updated: '2021-07-14T19:27:14.934572Z'
+      },
+      {
+        dealId: 123456,
+        storageProvider: 'f98',
+        status: 'Terminated',
+        pieceCid: 'baga',
+        dataCid: 'bafybeifnfkzjeohjf2dch2iqqpef3bfjylwxlcjws2msvdfyze5bvdprfm',
+        dataModelSelector: 'Links/0/Links',
+        activation: '<iso timestamp>',
+        created: '2021-07-14T19:27:14.934572Z',
+        updated: '2021-07-14T19:27:14.934572Z'
+      }
+    ]
   } else if (body.cids.includes('bafybeica6klnrhlrbx6z24icefykpbwyypouglnypvnwb5esdm6yzcie3q')) {
     return [{
       status: 'Queued',

--- a/packages/db/index.js
+++ b/packages/db/index.js
@@ -1,6 +1,6 @@
 import { PostgrestClient } from '@supabase/postgrest-js'
 
-import { normalizeUpload, normalizeContent, normalizePins } from './utils.js'
+import { normalizeUpload, normalizeContent, normalizePins, normalizeDeals } from './utils.js'
 import { DBError } from './errors.js'
 import {
   getUserMetrics,
@@ -568,7 +568,7 @@ export class DBClient {
 
     // TODO: normalize deal by removing deal prefix on dealActivation and dealExpiration
     const result = {}
-    for (const d of data) {
+    for (const d of normalizeDeals(data)) {
       const cid = d.dataCid
       if (!Array.isArray(result[cid])) {
         result[cid] = [d]

--- a/packages/db/index.js
+++ b/packages/db/index.js
@@ -566,7 +566,6 @@ export class DBClient {
       throw new DBError(error)
     }
 
-    // TODO: normalize deal by removing deal prefix on dealActivation and dealExpiration
     const result = {}
     for (const d of normalizeDeals(data)) {
       const cid = d.dataCid

--- a/packages/db/utils.js
+++ b/packages/db/utils.js
@@ -35,15 +35,16 @@ export function normalizeContent (content) {
  * @return {Array<import('../db-client-types').PinItemOutput>}
  */
 export function normalizePins (pins) {
-  return pins.map(pin => ({
-    _id: pin._id,
-    status: pin.status,
-    created: pin.created,
-    updated: pin.updated,
-    peerId: pin.location.peerId,
-    peerName: pin.location.peerName,
-    region: pin.location.region
-  })).filter(pin => PIN_STATUS.has(pin.status))
+  return pins.filter(pin => PIN_STATUS.has(pin.status))
+    .map(pin => ({
+      _id: pin._id,
+      status: pin.status,
+      created: pin.created,
+      updated: pin.updated,
+      peerId: pin.location.peerId,
+      peerName: pin.location.peerName,
+      region: pin.location.region
+    }))
 }
 
 /**

--- a/packages/db/utils.js
+++ b/packages/db/utils.js
@@ -51,6 +51,18 @@ export function normalizePins (pins) {
  */
 export function normalizeDeals (deals) {
   return deals.filter(deal => DEAL_STATUS.has(deal.status))
+    .map(deal => ({
+      dealId: deal.dealId,
+      storageProvider: deal.storageProvider,
+      status: deal.status,
+      pieceCid: deal.pieceCid,
+      dataCid: deal.dataCid,
+      dataModelSelector: deal.dataModelSelector,
+      activation: deal.dealActivation,
+      expiration: deal.dealExpiration,
+      created: deal.created,
+      updated: deal.updated
+    }))
 }
 
 const PIN_STATUS = new Set([

--- a/packages/db/utils.js
+++ b/packages/db/utils.js
@@ -46,8 +46,21 @@ export function normalizePins (pins) {
   })).filter(pin => PIN_STATUS.has(pin.status))
 }
 
+/**
+ * Normalize deal items.
+ */
+export function normalizeDeals (deals) {
+  return deals.filter(deal => DEAL_STATUS.has(deal.status))
+}
+
 const PIN_STATUS = new Set([
   'Pinned',
   'Pinning',
   'PinQueued'
+])
+
+const DEAL_STATUS = new Set([
+  'Queued',
+  'Published',
+  'Active'
 ])


### PR DESCRIPTION
Per https://github.com/web3-storage/web3.storage/pull/677#pullrequestreview-813653126 filters out deals with other status.

Also normalizes activation and termination per:
- https://github.com/web3-storage/web3.storage/blob/cd04716844a646d986f53aeae7c73840a008aad3/packages/api/src/status.js#L40