### PR TITLE
fix: Issue 581 Webpack 4 build error

### DIFF
--- a/packages/client/src/lib.js
+++ b/packages/client/src/lib.js
@@ -266,7 +266,7 @@ class Web3Storage {
       if (!res.ok) {
         /* c8 ignore next 2 */
         const errorMessage = await res.json()
-        throw new Error(`${res.status} ${res.statusText} ${'- ' + errorMessage?.message || ''}`)
+        throw new Error(`${res.status} ${res.statusText} ${errorMessage ? '- ' + errorMessage.message : ''}`)
       }
       const page = await res.json()
       for (const upload of page) {


### PR DESCRIPTION
Fixes #581 
This pr reworks the problematic error message to not use the coalesce operator to resolve webpack4 issues.
In the future might look at the current rollup config and transpile to es5 or another valid syntax and export for older build setups. This however is a quick and easy solution for this specific build issue.

I verified this by creating a webpack 4 config and found the issue and resolved locally. This isn't the most foolproof way, but whenever I fixed it this way, create-react-app using webpack 4 successfully compiled, and angular 13 does not have this issue, it used webpack 5 now.