### PR TITLE
feat: enable sentry to record X-Client request header

### DIFF
--- a/packages/api/src/env.js
+++ b/packages/api/src/env.js
@@ -30,7 +30,7 @@ export function envAll (_, env, event) {
   env.sentry = (env.SENTRY_DSN || typeof SENTRY_DSN !== 'undefined') && new Toucan({
     dsn: env.SENTRY_DSN || SENTRY_DSN,
     context: event,
-    allowedHeaders: ['user-agent'],
+    allowedHeaders: ['user-agent', 'x-client'],
     allowedSearchParams: /(.*)/,
     debug: false,
     rewriteFrames: {

--- a/packages/client/src/lib.js
+++ b/packages/client/src/lib.js
@@ -83,7 +83,7 @@ class Web3Storage {
     if (!token) throw new Error('missing token')
     return {
       Authorization: `Bearer ${token}`,
-      'X-Client': 'web3.storage'
+      'X-Client': 'web3.storage/js'
     }
   }
 


### PR DESCRIPTION
So we can see in error reports if the JS client is being used.

Also alters the `X-Client` value and adds the suffix `/js` as we also have a golang client.

see also https://github.com/web3-storage/go-w3s-client/pull/7