### PR TITLE
fix: encode created date in Link header

### DIFF
--- a/packages/api/src/user.js
+++ b/packages/api/src/user.js
@@ -193,7 +193,7 @@ export async function userUploadsGet (request, env) {
 
   const oldest = uploads[uploads.length - 1]
   const headers = uploads.length === size
-    ? { Link: `<${requestUrl.pathname}?size=${size}&before=${oldest.created}>; rel="next"` }
+    ? { Link: `<${requestUrl.pathname}?size=${size}&before=${encodeURIComponent(oldest.created)}>; rel="next"` }
     : undefined
   return new JSONResponse(uploads, { headers })
 }

--- a/packages/api/test/user.spec.js
+++ b/packages/api/test/user.spec.js
@@ -277,7 +277,7 @@ describe('GET /user/uploads', () => {
     ]
     const link = res.headers.get('Link')
     assert(link, 'has a Link header for the next page')
-    assert.strictEqual(link, `</user/uploads?size=${size}&before=${expected[0].created}>; rel="next"`)
+    assert.strictEqual(link, `</user/uploads?size=${size}&before=${encodeURIComponent(expected[0].created)}>; rel="next"`)
     const uploads = await res.json()
     assert.deepStrictEqual(uploads, expected)
   })

--- a/packages/client/test/mocks/api/get_user#uploads.js
+++ b/packages/client/test/mocks/api/get_user#uploads.js
@@ -11,7 +11,7 @@ module.exports = (opts) => {
     }
     const body = JSON.parse(JSON.stringify(res)).filter(u => u.created < before).slice(0, size)
     const responseHeaders = body.length === 100
-      ? { Link: `</user/uploads/?size=${size}&before=${body[body.length - 1].created}>; rel="next"` }
+      ? { Link: `</user/uploads/?size=${size}&before=${encodeURIComponent(body[body.length - 1].created)}>; rel="next"` }
       : {}
     return {
       statusCode: 200,


### PR DESCRIPTION
If this value is not encoded, the "+" is interpreted as a space, and it produces an invalid date string, causing the service to respond with "invalid before date".

```js
new URL('https://api.web3.storage/user/uploads?size=25&before=2021-11-25T22:57:31.887+00:00').searchParams.get('before')
"2021-11-25T22:57:31.887 00:00"

new Date('2021-11-25T22:57:31.887 00:00')
Invalid Date
```

The issue is not seen in tests because we happen to not use `+00:00` (we use `Z` instead) but this is a valid date string currently returned by our service:

<img width="741" alt="Screenshot 2021-11-30 at 13 04 22" src="https://user-images.githubusercontent.com/152863/144052676-02773f37-ccc6-4dc8-b166-8a6ad210bcf2.png">
