### PR TITLE
fix: postgres set max parallel workers per gather to 4

### DIFF
--- a/packages/db/postgres/config.sql
+++ b/packages/db/postgres/config.sql
@@ -1,0 +1,1 @@
+SET max_parallel_workers_per_gather TO 4;

--- a/packages/db/scripts/cmds/db-sql.js
+++ b/packages/db/scripts/cmds/db-sql.js
@@ -19,6 +19,10 @@ const { Client } = pg
  */
 export async function dbSqlCmd ({ reset, cargo, testing } = {}) {
   // read all the SQL files
+  const configSql = fs.readFileSync(path.join(__dirname, '../../postgres/config.sql'), {
+    encoding: 'utf-8'
+  })
+
   const tablesSql = fs.readFileSync(path.join(__dirname, '../../postgres/tables.sql'), {
     encoding: 'utf-8'
   })
@@ -57,6 +61,7 @@ export async function dbSqlCmd ({ reset, cargo, testing } = {}) {
     await client.query(resetSql)
   }
 
+  await client.query(configSql)
   await client.query(tablesSql)
 
   if (cargo) {

--- a/packages/infra/heroku/init.sh
+++ b/packages/infra/heroku/init.sh
@@ -17,11 +17,13 @@ heroku addons:create heroku-postgresql:premium-4 --app=web3-storage-prod --name=
 
 # Add schema
 heroku pg:psql web3-storage-staging-0 --app=web3-storage-staging
+# ...run schema SQL from /packages/db/config.sql
 # ...run schema SQL from /packages/db/tables.sql
 # ...run schema SQL from /packages/db/fdw.sql with credentials replaced
 # ...run schema SQL from /packages/db/cargo.sql
 # ...run schema SQL from /packages/db/functions.sql
 heroku pg:psql web3-storage-prod-0 --app=web3-storage-prod
+# ...run schema SQL from /packages/db/config.sql
 # ...run schema SQL from /packages/db/tables.sql
 # ...run schema SQL from /packages/db/fdw.sql with credentials replaced
 # ...run schema SQL from /packages/db/cargo.sql


### PR DESCRIPTION
We changed the max parallel workers per gather to 4 in production when we moved to Postgres. Let's keep track of it in the infra setup scripts