### PR TITLE
fix: endpoint URL construction

### DIFF
--- a/packages/client/src/lib.js
+++ b/packages/client/src/lib.js
@@ -133,7 +133,7 @@ class Web3Storage {
     decoders
   } = {}) {
     const targetSize = MAX_CHUNK_SIZE
-    const url = new URL('/car', endpoint)
+    const url = new URL('car', endpoint)
     let headers = Web3Storage.headers(token)
 
     if (name) {
@@ -197,7 +197,7 @@ class Web3Storage {
    * @returns {Promise<Web3Response | null>}
    */
   static async get ({ endpoint, token }, cid) {
-    const url = new URL(`/car/${cid}`, endpoint)
+    const url = new URL(`car/${cid}`, endpoint)
     const res = await fetch(url.toString(), {
       method: 'GET',
       headers: Web3Storage.headers(token)
@@ -222,7 +222,7 @@ class Web3Storage {
    * @returns {Promise<Status | undefined>}
    */
   static async status ({ endpoint, token }, cid) {
-    const url = new URL(`/status/${cid}`, endpoint)
+    const url = new URL(`status/${cid}`, endpoint)
     const res = await fetch(url.toString(), {
       method: 'GET',
       headers: Web3Storage.headers(token)
@@ -251,7 +251,7 @@ class Web3Storage {
    */
     function listPage ({ endpoint, token }, { before, size }) {
       const search = new URLSearchParams({ before, size: size.toString() })
-      const url = new URL(`/user/uploads?${search}`, endpoint)
+      const url = new URL(`user/uploads?${search}`, endpoint)
       return fetch(url.toString(), {
         method: 'GET',
         headers: {


### PR DESCRIPTION
Prefixing with slash will chop off any existing pathname from the base URL. Without the slash it is appended onto the end:

```js
> new URL('/car', 'https://api.web3.storage/_backdoor/').toString()
'https://api.web3.storage/car'
> new URL('car', 'https://api.web3.storage/_backdoor/').toString()
'https://api.web3.storage/_backdoor/car'

// ...the usual case of domain only or domain with trailing slash still works:
> new URL('car', 'https://api.web3.storage').toString()
'https://api.web3.storage/car'
> new URL('car', 'https://api.web3.storage/').toString()
'https://api.web3.storage/car
```