### PR TITLE
fix: do not prefer node.js builtins

### DIFF
--- a/packages/client/rollup.esm.config.js
+++ b/packages/client/rollup.esm.config.js
@@ -18,6 +18,7 @@ export default {
   plugins: [
     commonjs(),
     resolve({
+      preferBuiltins: false,
       browser: true
     }),
     json()


### PR DESCRIPTION
Without this option, we get `import require$$0 from"buffer";` (+more) in the bundle, which cannot be resolved when used in the browser (what it is for).

<img width="882" alt="Screenshot 2021-12-03 at 15 44 48" src="https://user-images.githubusercontent.com/152863/144632220-c3529672-3ea3-4a14-92e4-4595df079fb0.png">


