### PR TITLE
fix: tolerant of failure for deals

### DIFF
--- a/packages/db/index.js
+++ b/packages/db/index.js
@@ -548,7 +548,9 @@ export class DBClient {
   }
 
   /**
-   * Get deals for multiple cids
+   * Get deals for multiple cids. This function is error tolerant as it uses
+   * the dagcargo FDW. It will return an empty object if any error is
+   * encountered fetching the data.
    *
    * @param {string[]} cids
    * @return {Promise<Record<string, import('./db-client-types').Deal[]>>}
@@ -561,7 +563,7 @@ export class DBClient {
       })
 
     if (error) {
-      throw new DBError(error)
+      return {}
     }
 
     const result = {}


### PR DESCRIPTION
Remaining bits of removing the materialized view. Makes the status/list uploads calls tolerant to failures from cargo

Needs:
- [x] https://github.com/web3-storage/web3.storage/pull/765