### PR TITLE
fix: backup unique constraint

### DIFF
--- a/packages/db/postgres/functions.sql
+++ b/packages/db/postgres/functions.sql
@@ -138,7 +138,7 @@ BEGIN
     values (inserted_upload_id,
             backup_url,
             (data ->> 'inserted_at')::timestamptz)
-    ON CONFLICT ( url ) DO NOTHING;
+    ON CONFLICT ( upload_id, url ) DO NOTHING;
   end loop;
 
   return (inserted_upload_id)::TEXT;

--- a/packages/db/postgres/tables.sql
+++ b/packages/db/postgres/tables.sql
@@ -169,8 +169,9 @@ CREATE TABLE IF NOT EXISTS backup
   -- Upload that resulted in this backup.
   upload_id       BIGINT                                                        NOT NULL REFERENCES upload (id) ON DELETE CASCADE,
   -- Backup url location.
-  url             TEXT                                                          NOT NULL UNIQUE,
-  inserted_at     TIMESTAMP WITH TIME ZONE DEFAULT timezone('utc'::text, now()) NOT NULL
+  url             TEXT                                                          NOT NULL,
+  inserted_at     TIMESTAMP WITH TIME ZONE DEFAULT timezone('utc'::text, now()) NOT NULL,
+  UNIQUE (upload_id, url)
 );
 
 CREATE INDEX IF NOT EXISTS backup_upload_id_idx ON backup (upload_id);


### PR DESCRIPTION
This PR relaxes the uniqueness constraint on the `backup` table to include the `upload_id`.

The constraint was previously on the `url` field so that multiple uploads of the same CAR file by the same user don't result in multiple rows in the table.

With the upcoming historical data backups we'll be saving _complete_ CAR files to `<bucket_host>/complete/<CID>.car`. We want to create backup records that point to that URL but the CID may have been uploaded by multiple users.

Relaxing the constraint to include the `upload_id` ensures multiple uploads can point to the same _complete_ backup URL whilst retaining the original intention of uniqueness on `url`.

I will run the following SQL to migrate staging and production:

```sql
CREATE UNIQUE INDEX CONCURRENTLY backup_upload_id_url_key ON backup (upload_id,url);
ALTER TABLE backup DROP CONSTRAINT IF EXISTS backup_url_key;
ALTER TABLE backup ADD CONSTRAINT backup_upload_id_url_key UNIQUE USING INDEX backup_upload_id_url_key;
```