### PR TITLE
Fix the react-scripts-v5 compatible issue.

### DIFF
--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -42,7 +42,7 @@
     "ipns": "^0.15.0",
     "libp2p-crypto": "^0.20.0",
     "p-retry": "^4.5.0",
-    "parse-link-header": "^1.0.1",
+    "parse-link-header": "^2.0.0",
     "streaming-iterables": "^6.0.0",
     "uint8arrays": "^3.0.0"
   },
@@ -52,7 +52,7 @@
     "@rollup/plugin-json": "^4.1.0",
     "@rollup/plugin-node-resolve": "^13.0.0",
     "@types/mocha": "8.2.2",
-    "@types/parse-link-header": "^1.0.0",
+    "@types/parse-link-header": "^1.0.1",
     "bundlesize": "^0.18.1",
     "cors": "^2.8.5",
     "del-cli": "^4.0.0",


### PR DESCRIPTION
Bump the versions of `parse-link-header` dependencies to fix the below build (e.g. `yarn build`) issue in react-scripts v5.

```
Module not found: Error: Can't resolve 'querystring' in '/web3-storage/node_modules/parse-link-header'
BREAKING CHANGE: webpack < 5 used to include polyfills for node.js core modules by default.
This is no longer the case. Verify if you need this module and configure a polyfill for it.

If you want to include a polyfill, you need to:
        - add a fallback 'resolve.fallback: { "querystring": require.resolve("querystring-es3") }'
        - install 'querystring-es3'
If you don't want to include a polyfill, you can use an empty module like this:
        resolve.fallback: { "querystring": false }
```

**NOTE**: If the user bumped the react-scripts from v4 to v5, then they can just use `import { Web3Storage } from 'web3.storage'` to import the web3.storage rather than `import { Web3Storage } from 'web3.storage/dist/bundle.esm.min.js'`