### PR TITLE
chore: remove migration tracking table

### DIFF
--- a/packages/db/postgres/tables.sql
+++ b/packages/db/postgres/tables.sql
@@ -226,17 +226,6 @@ CREATE TABLE IF NOT EXISTS psa_pin_request
   updated_at      TIMESTAMP WITH TIME ZONE DEFAULT timezone('utc'::text, now()) NOT NULL
 );
 
--- A migration tracker.
-CREATE TABLE IF NOT EXISTS migration_tracker
-(
-  id              BIGSERIAL PRIMARY KEY,
-  cid             TEXT                                                          NOT NULL,
-  duration        BIGINT,
-  dump_started_at TIMESTAMP WITH TIME ZONE,
-  dump_ended_at   TIMESTAMP WITH TIME ZONE NOT NULL,
-  inserted_at     TIMESTAMP WITH TIME ZONE DEFAULT timezone('utc'::text, now()) NOT NULL
-);
-
 CREATE TABLE IF NOT EXISTS name
 (
     -- base36 "libp2p-key" encoding of the public key


### PR DESCRIPTION
Remove temporary table used for DB migration from Fauna to Postgres