### PR TITLE
fix: only disallow delete if dag size is unknown

### DIFF
--- a/packages/website/pages/files.js
+++ b/packages/website/pages/files.js
@@ -232,7 +232,7 @@ const UploadItem = ({ upload, index, toggle, selectedFiles, showCopiedMessage })
   return (
     <tr>
       <td className="w-8">
-        <Checkbox className="mr-2" checked={checked} disabled={!upload.dagSize} disabledText='You may only delete after the upload is complete' onChange={() => toggle(upload.cid)}/>
+        <Checkbox className="mr-2" checked={checked} disabled={upload.dagSize == null} disabledText='You may only delete after the upload is complete' onChange={() => toggle(upload.cid)}/>
       </td>
       <TableElement {...sharedArgs}>
         <span title={upload.created} className="break-normal">{formatTimestamp(upload.created)}</span>


### PR DESCRIPTION
Someone has uploaded a CAR file with a single block of zero bytes: bafkreihdwdcefgh4dqkjv67uzcmw7ojee6xedzdetojuzjevtenxquvyku