### PR TITLE
fix: dag size for big dags with non pb root

### DIFF
--- a/.github/workflows/cron-dagcargo-sizes.yml
+++ b/.github/workflows/cron-dagcargo-sizes.yml
@@ -1,0 +1,28 @@
+name: Cron dagcargo Populate Content DAG Sizes
+
+on:
+  schedule:
+    - cron: '38 * * * *'
+  workflow_dispatch:
+
+jobs:
+  update:
+    name: Populate Missing Content DAG Sizes
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        env: ['staging', 'production']
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: 16
+      - uses: bahmutov/npm-install@v1
+      - name: Run job
+        env:
+          DEBUG: '*'
+          ENV: ${{ matrix.env }}
+          STAGING_PG_CONNECTION: ${{ secrets.STAGING_PG_CONNECTION }}
+          PROD_PG_CONNECTION: ${{ secrets.PROD_PG_CONNECTION }}
+        run: npm run start:dagcargo:sizes -w packages/cron

--- a/.github/workflows/cron-pins.yml
+++ b/.github/workflows/cron-pins.yml
@@ -28,14 +28,10 @@ jobs:
         env:
           DEBUG: '*'
           ENV: ${{ matrix.env }}
-          DATABASE: ${{ secrets.PROD_DATABASE }}
-          STAGING_DATABASE: ${{ secrets.STAGING_DATABASE }}
           PG_REST_JWT: ${{ secrets.PROD_PG_REST_JWT }}
           STAGING_PG_REST_JWT: ${{ secrets.STAGING_PG_REST_JWT }}
           PG_REST_URL: ${{ secrets.PROD_PG_REST_URL }}
           STAGING_PG_REST_URL: ${{ secrets.STAGING_PG_REST_URL }}
-          FAUNA_KEY: ${{ secrets.PROD_FAUNA_KEY }}
-          STAGING_FAUNA_KEY: ${{ secrets.STAGING_FAUNA_KEY }}
           CLUSTER_API_URL: ${{ secrets.CLUSTER_API_URL }}
           CLUSTER_BASIC_AUTH_TOKEN: ${{ secrets.CLUSTER_BASIC_AUTH_TOKEN }}
           CLUSTER_IPFS_PROXY_API_URL: ${{ secrets.CLUSTER_IPFS_PROXY_API_URL }}

--- a/packages/cron/README.md
+++ b/packages/cron/README.md
@@ -15,7 +15,6 @@ To run this locally you will need the following in your `packages/cron/.env` fil
 
 ```ini
 ENV=dev
-DATABASE=postgres
 
 # PostgREST API URL
 DEV_PG_REST_URL=http://localhost:3000
@@ -29,9 +28,6 @@ DEV_PG_CONNECTION=postgres://postgres:postgres@127.0.0.1:5432/postgres
 # Cluster
 CLUSTER_API_URL=http://127.0.0.1:9094/
 CLUSTER_IPFS_PROXY_API_URL=http://127.0.0.1:9095/api/v0/
-
-# Fauna
-DEV_FAUNA_KEY="<your key here>"
 ```
 
 You also need to have:

--- a/packages/cron/package.json
+++ b/packages/cron/package.json
@@ -9,6 +9,7 @@
     "start": "run-s start:*",
     "start:metrics": "node src/bin/metrics.js",
     "start:pins": "node src/bin/pins.js",
+    "start:dagcargo:sizes": "NODE_TLS_REJECT_UNAUTHORIZED=0 node src/bin/dagcargo-sizes.js",
     "test": "npm-run-all -p -r mock:cluster mock:pgrest test:e2e",
     "test:e2e": "mocha test/*.spec.js --exit",
     "mock:cluster": "smoke -p 9094 test/mocks/cluster",

--- a/packages/cron/src/bin/dagcargo-sizes.js
+++ b/packages/cron/src/bin/dagcargo-sizes.js
@@ -1,0 +1,22 @@
+#!/usr/bin/env node
+
+import dotenv from 'dotenv'
+import { updateDagSizes } from '../jobs/dagcargo.js'
+import { getPg } from '../lib/utils.js'
+
+const oneMonthAgo = () => new Date().setMonth(new Date().getMonth() - 1)
+
+async function main () {
+  const pg = getPg(process.env)
+  await pg.connect()
+
+  try {
+    const after = new Date(process.env.AFTER || oneMonthAgo())
+    await updateDagSizes({ pg, after })
+  } finally {
+    await pg.end()
+  }
+}
+
+dotenv.config()
+main()

--- a/packages/cron/src/jobs/dagcargo.js
+++ b/packages/cron/src/jobs/dagcargo.js
@@ -1,0 +1,78 @@
+import debug from 'debug'
+
+const COUNT_CONTENT_WITHOUT_SIZE = `
+SELECT COUNT(*)
+  FROM public.content
+ WHERE (dag_size IS NULL OR dag_size = 0)
+   AND inserted_at > $1
+`
+
+const FIND_CONTENT_WITHOUT_SIZE = `
+SELECT cid
+  FROM public.content
+ WHERE (dag_size IS NULL OR dag_size = 0)
+   AND inserted_at > $1
+OFFSET $2
+ LIMIT $3
+`
+
+const FIND_DAG_SIZES = `
+SELECT cid_v1,
+       size_actual
+  FROM cargo.dags
+ WHERE size_actual IS NOT NULL
+   AND cid_v1 = ANY ($1)
+`
+
+const UPDATE_CONTENT_DAG_SIZE = `
+UPDATE public.content
+   SET dag_size = $1,
+       updated_at = timezone('utc'::TEXT, NOW())
+ WHERE cid = $2
+`
+
+/**
+ * Sets dag_size for content that does not yet have a size.
+ *
+ * @param {{ pg: import('pg').Client, after: Date }} config
+ */
+export async function updateDagSizes ({ pg, after }) {
+  const log = debug('dagcargo:updateDagSizes')
+  if (!log.enabled) {
+    console.log('ℹ️ Enable logging by setting DEBUG=dagcargo:updateDagSizes')
+  }
+
+  log(`🎯 Updating DAG sizes for content inserted after ${after.toISOString()}`)
+
+  const countRes = await pg.query(COUNT_CONTENT_WITHOUT_SIZE, [
+    after.toISOString()
+  ])
+  const total = countRes.rows[0].count
+  log(`ℹ️ ${total} records without dag_size`)
+
+  let offset = 0
+  const limit = 1000
+  while (true) {
+    const { rows: contents } = await pg.query(FIND_CONTENT_WITHOUT_SIZE, [
+      after.toISOString(),
+      offset,
+      limit
+    ])
+    if (!contents.length) break
+
+    const cids = contents.map((c) => c.cid)
+    const { rows: sizes } = await pg.query(FIND_DAG_SIZES, [cids])
+
+    /* eslint-disable camelcase */
+    for (const { cid_v1, size_actual } of sizes) {
+      log(`💪 ${cid_v1} ${size_actual} bytes`)
+      await pg.query(UPDATE_CONTENT_DAG_SIZE, [size_actual, cid_v1])
+    }
+    /* eslint-enable camelcase */
+
+    log(`ℹ️ ${offset + contents.length} of ${total} processed in total`)
+    offset += limit
+  }
+
+  log('✅ Done')
+}

--- a/packages/cron/src/lib/utils.js
+++ b/packages/cron/src/lib/utils.js
@@ -30,35 +30,10 @@ export function getClusterIPFSProxy (env) {
 }
 
 /**
- * Create a new Fauna DB client instance from the passed environment variables.
+ * Create a new DB client instance from the passed environment variables.
  * @param {Record<string, string|undefined>} env
  */
 export function getDBClient (env) {
-  if (env.DATABASE === 'postgres') {
-    return getDBPostgresClient(env)
-  }
-
-  return getDBFaunaClient(env)
-}
-
-function getDBFaunaClient (env) {
-  let token
-  if (env.ENV === 'production') {
-    if (!env.FAUNA_KEY) throw new Error('missing FAUNA_KEY environment var')
-    token = env.FAUNA_KEY
-  } else if (env.ENV === 'staging') {
-    if (!env.STAGING_FAUNA_KEY) throw new Error('missing STAGING_FAUNA_KEY environment var')
-    token = env.STAGING_FAUNA_KEY
-  } else if (env.ENV === 'dev') {
-    if (!env.DEV_FAUNA_KEY) throw new Error('missing DEV_FAUNA_KEY environment var')
-    token = env.DEV_FAUNA_KEY
-  } else {
-    throw new Error(`unsupported environment ${env.ENV}`)
-  }
-  return new DBClient({ token })
-}
-
-function getDBPostgresClient (env) {
   let token, endpoint
   if (env.ENV === 'production') {
     if (!env.PG_REST_JWT) throw new Error('missing PG_REST_JWT environment var')


### PR DESCRIPTION
This PR fixes wrong computation of dag size with non pb roots.

It adds a cron job to check them in dagcargo in the same way nft.storage operates.

Please note that some older Fauna related code was removed within the cron package. Namely, the ENV vars to use different DBs and its client function.

Closes #759 