### PR TITLE
fix: api cluster add car explicitly

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19363,7 +19363,7 @@
     },
     "packages/api": {
       "name": "@web3-storage/api",
-      "version": "5.0.5",
+      "version": "5.0.6",
       "license": "(Apache-2.0 AND MIT)",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.28.0",
@@ -19418,7 +19418,7 @@
     },
     "packages/client": {
       "name": "web3.storage",
-      "version": "3.5.2",
+      "version": "3.5.3",
       "license": "(Apache-2.0 AND MIT)",
       "dependencies": {
         "@ipld/car": "^3.1.4",
@@ -20010,10 +20010,10 @@
     },
     "packages/w3": {
       "name": "@web3-storage/w3",
-      "version": "2.4.1",
+      "version": "2.4.2",
       "license": "ISC",
       "dependencies": {
-        "@ipld/car": "^3.1.4",
+        "@ipld/car": "^3.1.16",
         "conf": "^10.0.1",
         "enquirer": "^2.3.6",
         "hard-rejection": "^2.1.0",
@@ -20457,7 +20457,7 @@
     },
     "packages/website": {
       "name": "@web3-storage/website",
-      "version": "1.9.0",
+      "version": "1.9.1",
       "dependencies": {
         "@magic-ext/oauth": "^0.7.0",
         "@tailwindcss/typography": "^0.4.1",
@@ -23701,7 +23701,7 @@
     "@web3-storage/w3": {
       "version": "file:packages/w3",
       "requires": {
-        "@ipld/car": "^3.1.4",
+        "@ipld/car": "^3.1.16",
         "conf": "^10.0.1",
         "enquirer": "^2.3.6",
         "execa": "^5.1.1",

--- a/packages/api/src/car.js
+++ b/packages/api/src/car.js
@@ -228,7 +228,7 @@ async function addToCluster (car, env) {
   // Note: We can't make use of `bytes` or `size` properties on the response from cluster.add
   // `bytes` is the sum of block sizes in bytes. Where the CAR is a partial, it'll only be a shard of the total dag size.
   // `size` is UnixFS FileSize which is 0 for directories, and is not set for raw encoded files, only dag-pb ones.
-  const { cid } = await env.cluster.add(car, {
+  const { cid } = await env.cluster.addCAR(car, {
     metadata: { size: car.size.toString() },
     // When >2.5MB, use local add, because waiting for blocks to be sent to
     // other cluster nodes can take a long time. Replication to other nodes


### PR DESCRIPTION
When updating cluster client in https://github.com/web3-storage/web3.storage/pull/855 I missed the breaking change from https://github.com/nftstorage/ipfs-cluster/pull/14