### PR TITLE
fix: use single sentry project

### DIFF
--- a/.github/workflows/api.yml
+++ b/.github/workflows/api.yml
@@ -45,9 +45,8 @@ jobs:
         # workaround for https://github.com/cloudflare/wrangler-action/issues/59 to use node 16
         uses: web3-storage/wrangler-action@node16
         env:
-          SENTRY_TOKEN: ${{ secrets.STAGING_SENTRY_TOKEN}}
-          SENTRY_PROJECT: ${{ secrets.STAGING_SENTRY_PROJECT}}
-          SENTRY_UPLOAD: ${{ secrets.STAGING_SENTRY_UPLOAD}}
+          SENTRY_TOKEN: ${{ secrets.SENTRY_TOKEN}}
+          SENTRY_UPLOAD: ${{ secrets.SENTRY_UPLOAD}}
         with:
           apiToken: ${{ secrets.CF_API_TOKEN }}
           workingDirectory: 'packages/api'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -127,9 +127,8 @@ jobs:
         # workaround for https://github.com/cloudflare/wrangler-action/issues/59 to use node 16
         uses: web3-storage/wrangler-action@node16
         env:
-          SENTRY_TOKEN: ${{ secrets.PROD_SENTRY_TOKEN}}
-          SENTRY_PROJECT: ${{ secrets.PROD_SENTRY_PROJECT}}
-          SENTRY_UPLOAD: ${{ secrets.PROD_SENTRY_UPLOAD}}
+          SENTRY_TOKEN: ${{ secrets.SENTRY_TOKEN}}
+          SENTRY_UPLOAD: ${{ secrets.SENTRY_UPLOAD}}
         with:
           apiToken: ${{ secrets.CF_API_TOKEN }}
           workingDirectory: 'packages/api'

--- a/packages/api/webpack.config.js
+++ b/packages/api/webpack.config.js
@@ -61,7 +61,7 @@ export default {
         include: './dist',
         urlPrefix: '/',
         org: 'protocol-labs-it',
-        project: process.env.SENTRY_PROJECT,
+        project: 'web3-api',
         authToken: process.env.SENTRY_TOKEN
       }),
     process.env.SENTRY_UPLOAD === 'true' &&


### PR DESCRIPTION
We can use one project for all environments, given sentry can already know the environment running and we can also filter within it.

Needs:

- [x] Add SENTRY_TOKEN and SENTRY_UPLOAD secrets
- [x] Project rename in sentry https://sentry.io/settings/protocol-labs-it/projects/api-prod/ to `web3-api`

After merge:

- [ ] Remove STAGING_SENTRY_TOKEN, STAGING_SENTRY_UPLOAD, PROD_SENTRY_TOKEN and PROD_SENTRY_UPLOAD secrets, PROD_SENTRY_PROJECT and STAGING_SENTRY_PROJECT
- [ ] Remove sentry staging project

Closes #760 