### PR TITLE
perf: update pin composite index and adds inserted at index to content

### DIFF
--- a/packages/db/postgres/tables.sql
+++ b/packages/db/postgres/tables.sql
@@ -132,8 +132,7 @@ CREATE INDEX IF NOT EXISTS pin_content_cid_idx ON pin (content_cid);
 CREATE INDEX IF NOT EXISTS pin_location_id_idx ON pin (pin_location_id);
 CREATE INDEX IF NOT EXISTS pin_updated_at_idx ON pin (updated_at);
 CREATE INDEX IF NOT EXISTS pin_status_idx ON pin (status);
-CREATE INDEX IF NOT EXISTS pin_composite_pinned_at_idx ON pin (content_cid, updated_at) WHERE status = 'Pinned';
-
+CREATE INDEX IF NOT EXISTS pin_composite_updated_at_and_content_cid_idx ON pin (updated_at, content_cid);
 
 -- An upload created by a user.
 CREATE TABLE IF NOT EXISTS upload

--- a/packages/db/postgres/tables.sql
+++ b/packages/db/postgres/tables.sql
@@ -45,6 +45,7 @@ CREATE TABLE IF NOT EXISTS content
   updated_at      TIMESTAMP WITH TIME ZONE DEFAULT timezone('utc'::text, now()) NOT NULL
 );
 
+CREATE INDEX IF NOT EXISTS content_inserted_at_idx ON content (inserted_at);
 CREATE INDEX IF NOT EXISTS content_updated_at_idx ON content (updated_at);
 -- TODO: Sync with @ribasushi as we can start using this as the primary key
 CREATE UNIQUE INDEX content_cid_with_size_idx ON content (cid) INCLUDE (dag_size);
@@ -128,7 +129,6 @@ CREATE TABLE IF NOT EXISTS pin
   UNIQUE (content_cid, pin_location_id)
 );
 
-CREATE INDEX IF NOT EXISTS pin_content_cid_idx ON pin (content_cid);
 CREATE INDEX IF NOT EXISTS pin_location_id_idx ON pin (pin_location_id);
 CREATE INDEX IF NOT EXISTS pin_updated_at_idx ON pin (updated_at);
 CREATE INDEX IF NOT EXISTS pin_status_idx ON pin (status);


### PR DESCRIPTION
This PR updates pin composite index for performance reasons on dag cargo queries, as well as adds an index for `inserted_at` which is used as part of the update dag size job in https://github.com/web3-storage/web3.storage/blob/main/packages/cron/src/jobs/dagcargo.js#L3-L31