### PR TITLE
fix: db client do not throw error when no upload found

### DIFF
--- a/packages/api/src/user.js
+++ b/packages/api/src/user.js
@@ -1,6 +1,7 @@
 import * as JWT from './utils/jwt.js'
 import { JSONResponse } from './utils/json-response.js'
 import { JWT_ISSUER } from './constants.js'
+import { HTTPError } from './errors.js'
 
 /**
  * @typedef { _id: string, issuer: string } User
@@ -210,7 +211,11 @@ export async function userUploadsDelete (request, env) {
   const user = request.auth.user._id
 
   const res = await env.db.deleteUpload(user, cid)
-  return new JSONResponse(res)
+  if (res) {
+    return new JSONResponse(res)
+  }
+
+  throw new HTTPError('Upload not found', 404)
 }
 
 /**

--- a/packages/db/index.js
+++ b/packages/db/index.js
@@ -278,7 +278,7 @@ export class DBClient {
       .single()
 
     if (error) {
-      throw new DBError(error)
+      return undefined
     }
 
     return {

--- a/packages/db/index.js
+++ b/packages/db/index.js
@@ -263,8 +263,8 @@ export class DBClient {
    */
   async deleteUpload (userId, cid) {
     const now = new Date().toISOString()
-    /** @type {{ data: import('./db-client-types').UploadItem, error: PostgrestError }} */
-    const { data, error } = await this._client
+    /** @type {{ data: import('./db-client-types').UploadItem, error: PostgrestError, status: number }} */
+    const { data, error, status } = await this._client
       .from('upload')
       .update({
         deleted_at: now,
@@ -277,8 +277,12 @@ export class DBClient {
       .is('deleted_at', null)
       .single()
 
+    if (status === 406 || !data) {
+      return
+    }
+
     if (error) {
-      return undefined
+      throw new DBError(error)
     }
 
     return {

--- a/packages/db/test/upload.spec.js
+++ b/packages/db/test/upload.spec.js
@@ -190,13 +190,8 @@ describe('upload', () => {
     assert.strictEqual(deletedUpload.updated_at, deletedUpload.deleted_at)
 
     // Should fail to delete again
-    let error
-    try {
-      await client.deleteUpload(user._id, otherCid)
-    } catch (err) {
-      error = err
-    }
-    assert(error, 'should fail to delete upload again')
+    const wasDeletedAgain = await client.deleteUpload(user._id, otherCid)
+    assert.strictEqual(wasDeletedAgain, undefined, 'should fail to delete upload again')
 
     const finalUserUploads = await client.listUploads(user._id)
     assert(finalUserUploads, 'user upload deleted')


### PR DESCRIPTION
When the delete route is called with an upload that does not exist (it can already be deleted), the DB client should not throw and be the API who creates the error. DB should return null as it couldn't delete any upload and return an ID