### PR TITLE
fix: next and ts linting cleanup

### DIFF
--- a/packages/website/assets/illustrations/spring.js
+++ b/packages/website/assets/illustrations/spring.js
@@ -1,3 +1,4 @@
+// @ts-ignore
 import spring from '../images/spring.png'
 /**
  * @param {any} props

--- a/packages/website/components/account/filesManager/filesManager.tsx
+++ b/packages/website/components/account/filesManager/filesManager.tsx
@@ -1,6 +1,7 @@
 import clsx from 'clsx';
 import filesize from 'filesize';
 import React, { useCallback, useEffect, useState } from 'react';
+// @ts-ignore
 import { useRouter } from 'next/router';
 import { Upload } from 'web3.storage';
 

--- a/packages/website/components/account/filesManager/filesManager.tsx
+++ b/packages/website/components/account/filesManager/filesManager.tsx
@@ -222,7 +222,7 @@ const FilesManager = ({ className }: FilesManagerProps) => {
                 PinStatus.QUEUING
               }
               storageProviders={item.deals.map((deal, indx, deals) => (
-                <span>
+                <span key={deal.dealId}>
                   <a
                     className="underline"
                     href={`https://filfox.info/en/deal/${deal.dealId}`}

--- a/packages/website/components/account/filesManager/filesManager.tsx
+++ b/packages/website/components/account/filesManager/filesManager.tsx
@@ -235,8 +235,8 @@ const FilesManager = ({ className }: FilesManagerProps) => {
                 </span>
               ))}
               size={filesize(item.dagSize)}
-              // TODO: Remove hardcoded highlight when hooked up
-              highlight={{ target: 'name', text: keyword }}
+              // TODO: Remove hardcoded highlight when hooked up, resolve temporary type fix for array of strings
+              highlight={{ target: 'name', text: keyword?.toString() || '' }}
               numberOfPins={item.pins.length}
               isSelected={!!selectedFiles.find(fileSelected => fileSelected === item)}
             />
@@ -250,7 +250,7 @@ const FilesManager = ({ className }: FilesManagerProps) => {
           </button>
           <Pagination
             items={sortedFiles}
-            itemsPerPage={itemsPerPage}
+            itemsPerPage={itemsPerPage || 10}
             visiblePages={1}
             queryParam="page"
             onChange={setPaginatedFiles}

--- a/packages/website/components/breadcrumbs/breadcrumbs.js
+++ b/packages/website/components/breadcrumbs/breadcrumbs.js
@@ -34,7 +34,7 @@ export default function Breadcrumbs({ variant, click, keyboard }) {
       {links.map(item => (
         <div key={item.text} className="breadcrumb-wrapper">
           {item.url ? (
-            <Link href={item.url}>
+            <Link href={item.url} passHref>
               <button
                 className={clsx('breadcrumb', 'breadcrumb-link', variant)}
                 onClick={e => click(e)}

--- a/packages/website/components/card/card.js
+++ b/packages/website/components/card/card.js
@@ -62,7 +62,7 @@ export default function Card({ card, cardsGroup = [], index = 0 }) {
           <div key={category.heading} className="category">
             <div className="category-heading">{category.heading}</div>
             {category.links.map(link => (
-              <Link href={link.url} key={link.text}>
+              <Link href={link.url} key={link.text} passHref>
                 <div
                   className="category-link"
                   onClick={onLinkClick}
@@ -87,7 +87,7 @@ export default function Card({ card, cardsGroup = [], index = 0 }) {
       case 'B':
         return <code className="code-feature" dangerouslySetInnerHTML={{ __html: obj.feature }}></code>;
       case 'C':
-        return <Image src={obj.image} width="64" height="64" />;
+        return <Image src={obj.image} width="64" height="64" alt={obj.image} />;
       case 'D':
         return renderExploreCards(obj);
       default:

--- a/packages/website/components/card/card.js
+++ b/packages/website/components/card/card.js
@@ -87,7 +87,7 @@ export default function Card({ card, cardsGroup = [], index = 0 }) {
       case 'B':
         return <code className="code-feature" dangerouslySetInnerHTML={{ __html: obj.feature }}></code>;
       case 'C':
-        return <Image alt="" src={obj.image} width="64" height="64" />;
+        return <Image loader={({ src }) => src} alt="" src={obj.image} width="64" height="64" />;
       case 'D':
         return renderExploreCards(obj);
       default:

--- a/packages/website/components/footer/footer.js
+++ b/packages/website/components/footer/footer.js
@@ -73,7 +73,7 @@ export default function Footer() {
             <div className="footer_resources">
               <div className="label">{resources.heading}</div>
               {resources.items.map(item => (
-                <Link href={item.url} key={item.text}>
+                <Link href={item.url} key={item.text} passHref>
                   <button className="footer-link" onClick={onLinkClick} onKeyPress={e => handleKeySelect(e, item.url)}>
                     {item.text}
                   </button>
@@ -86,7 +86,7 @@ export default function Footer() {
             <div className="footer_get-started">
               <div className="label">{getStarted.heading}</div>
               {getStarted.items.map(item => (
-                <Link href={item.url} key={item.text}>
+                <Link href={item.url} key={item.text} passHref>
                   <button className="footer-link" onClick={onLinkClick} onKeyPress={e => handleKeySelect(e, item.url)}>
                     {item.text}
                   </button>

--- a/packages/website/components/imageblock/imageblock.js
+++ b/packages/website/components/imageblock/imageblock.js
@@ -11,7 +11,7 @@ export default function ImageBlock({ block }) {
     <>
       {block.src && (
         <div id={block.id} className={clsx('block', 'image-block')}>
-          <Image src={block.src} layout="fill" />
+          <Image src={block.src} layout="fill" alt={block.src} />
 
           <div className={'image-label'}>{block.label}</div>
         </div>

--- a/packages/website/components/imageblock/imageblock.js
+++ b/packages/website/components/imageblock/imageblock.js
@@ -11,7 +11,7 @@ export default function ImageBlock({ block }) {
     <>
       {block.src && (
         <div id={block.id} className={clsx('block', 'image-block')}>
-          <Image alt="" src={block.src} layout="fill" />
+          <Image loader={({ src }) => src} alt="" src={block.src} layout="fill" />
 
           <div className={'image-label'}>{block.label}</div>
         </div>

--- a/packages/website/components/navigation/navigation.js
+++ b/packages/website/components/navigation/navigation.js
@@ -51,17 +51,20 @@ export default function Navigation({ isProductApp }) {
     setMenuOpen(!isMenuOpen);
   };
 
-  const onLinkClick = useCallback(e => {
-    trackCustomLinkClick(events.LINK_CLICK_NAVBAR, e.currentTarget);
-    if (isMenuOpen) {
-      setMenuOpen(false)
-    }
-  }, [isMenuOpen]);
+  const onLinkClick = useCallback(
+    e => {
+      trackCustomLinkClick(events.LINK_CLICK_NAVBAR, e.currentTarget);
+      if (isMenuOpen) {
+        setMenuOpen(false);
+      }
+    },
+    [isMenuOpen]
+  );
 
   const login = useCallback(() => {
     router.push('/login');
     if (isMenuOpen) {
-      setMenuOpen(false)
+      setMenuOpen(false);
     }
   }, [router, isMenuOpen]);
 
@@ -77,38 +80,44 @@ export default function Navigation({ isProductApp }) {
   const getAccountMenu = () => {
     if (account && account.links) {
       if (isProductApp) {
-        const labelText = account.text.toLowerCase()
+        const labelText = account.text.toLowerCase();
         return (
           <div className="nav-account-button">
             <button
-              className={ clsx('nav-item', account.url === router.route ? 'current-page' : '')}
+              className={clsx('nav-item', account.url === router.route ? 'current-page' : '')}
               onClick={onLinkClick}
-              onKeyPress={e => handleKeySelect(e, account.url)}>
+              onKeyPress={e => handleKeySelect(e, account.url)}
+            >
               {account.text}
             </button>
             <div className="nav-account-dropdown">
               <div className="label">{labelText[0].toUpperCase() + labelText.substring(1)}</div>
               {account.links.map(link => (
                 <Link href={link.url === 'request-more-storage' ? mailTo : link.url} key={link.text}>
-                  <button className="nav-dropdown-link" onClick={onLinkClick} onKeyPress={e => handleKeySelect(e, link.url)}>
+                  <button
+                    className="nav-dropdown-link"
+                    onClick={onLinkClick}
+                    onKeyPress={e => handleKeySelect(e, link.url)}
+                  >
                     {link.text}
                   </button>
                 </Link>
               ))}
             </div>
           </div>
-        )
+        );
       }
       return (
         <Link key={account.text} href={account.url}>
           <button
-            className={ clsx('nav-item', account.url === router.route ? 'current-page' : '')}
+            className={clsx('nav-item', account.url === router.route ? 'current-page' : '')}
             onClick={onLinkClick}
-            onKeyPress={e => handleKeySelect(e, account.url)}>
+            onKeyPress={e => handleKeySelect(e, account.url)}
+          >
             {account.text}
           </button>
         </Link>
-      )
+      );
     }
     return null;
   };
@@ -161,9 +170,7 @@ export default function Navigation({ isProductApp }) {
 
   // ================================================ Main Template [Navigation]
   return (
-    <section
-      id="section_navigation"
-      className={clsx('section-navigation', theme, isProductApp ? 'clear-bg' : '')}>
+    <section id="section_navigation" className={clsx('section-navigation', theme, isProductApp ? 'clear-bg' : '')}>
       <div className="grid-noGutter">
         <div className="col">
           <nav id="navigation">
@@ -196,15 +203,16 @@ export default function Navigation({ isProductApp }) {
                 {navItems.map(item => (
                   <Link key={item.text} href={item.url}>
                     <button
-                      className={ clsx('nav-item', item.url === router.route ? 'current-page' : '')}
+                      className={clsx('nav-item', item.url === router.route ? 'current-page' : '')}
                       onClick={onLinkClick}
-                      onKeyPress={e => handleKeySelect(e, item.url)}>
+                      onKeyPress={e => handleKeySelect(e, item.url)}
+                    >
                       {item.text}
                     </button>
                   </Link>
                 ))}
 
-                { isLoggedIn && getAccountMenu() }
+                {isLoggedIn && getAccountMenu()}
 
                 {isLoadingUser
                   ? loadingButton(auth.login, buttonTheme)
@@ -226,7 +234,6 @@ export default function Navigation({ isProductApp }) {
 
             <div className={clsx('nav-mobile-panel', isMenuOpen ? 'open' : '')} aria-hidden={isMenuOpen}>
               <div className="mobile-items-wrapper">
-
                 {navItems.map((item, index) => (
                   <Link href={item.url} key={`mobile-${item.text}`}>
                     <button className="nav-item" onClick={onLinkClick} onKeyPress={onLinkClick}>
@@ -235,22 +242,18 @@ export default function Navigation({ isProductApp }) {
                   </Link>
                 ))}
 
-                { isLoggedIn && account &&
+                {isLoggedIn && account && (
                   <ZeroAccordion multiple={false}>
                     <ZeroAccordionSection disabled={!Array.isArray(account.links)}>
                       <ZeroAccordionSection.Header>
-                        <div className="nav-item-heading">
-                          {account.text}
-                        </div>
+                        <div className="nav-item-heading">{account.text}</div>
                       </ZeroAccordionSection.Header>
 
                       <ZeroAccordionSection.Content>
                         {Array.isArray(account.links) && (
                           <div className="nav-sublinks-wrapper">
                             {account.links.map(link => (
-                              <Link
-                                href={link.url === 'request-more-storage' ? mailTo : link.url}
-                                key={link.text}>
+                              <Link href={link.url === 'request-more-storage' ? mailTo : link.url} key={link.text}>
                                 <button
                                   className="nav-sublink"
                                   onClick={onLinkClick}
@@ -265,7 +268,7 @@ export default function Navigation({ isProductApp }) {
                       </ZeroAccordionSection.Content>
                     </ZeroAccordionSection>
                   </ZeroAccordion>
-                }
+                )}
 
                 {isLoadingUser
                   ? loadingButton(auth.login, 'light')

--- a/packages/website/components/navigation/navigation.js
+++ b/packages/website/components/navigation/navigation.js
@@ -93,7 +93,7 @@ export default function Navigation({ isProductApp }) {
             <div className="nav-account-dropdown">
               <div className="label">{labelText[0].toUpperCase() + labelText.substring(1)}</div>
               {account.links.map(link => (
-                <Link href={link.url === 'request-more-storage' ? mailTo : link.url} key={link.text}>
+                <Link passHref href={link.url === 'request-more-storage' ? mailTo : link.url} key={link.text}>
                   <button
                     className="nav-dropdown-link"
                     onClick={onLinkClick}
@@ -108,7 +108,7 @@ export default function Navigation({ isProductApp }) {
         );
       }
       return (
-        <Link key={account.text} href={account.url}>
+        <Link passHref key={account.text} href={account.url}>
           <button
             className={clsx('nav-item', account.url === router.route ? 'current-page' : '')}
             onClick={onLinkClick}
@@ -182,7 +182,7 @@ export default function Navigation({ isProductApp }) {
               )}
             >
               <div className={clsx('site-logo-container', theme, isMenuOpen ? 'menu-open' : '')}>
-                <Link href="/">
+                <Link passHref href="/">
                   <div
                     title={logoText}
                     className="anchor-wrapper"
@@ -201,7 +201,7 @@ export default function Navigation({ isProductApp }) {
 
               <div className={clsx('nav-items-wrapper', theme)}>
                 {navItems.map(item => (
-                  <Link key={item.text} href={item.url}>
+                  <Link passHref key={item.text} href={item.url}>
                     <button
                       className={clsx('nav-item', item.url === router.route ? 'current-page' : '')}
                       onClick={onLinkClick}
@@ -235,7 +235,7 @@ export default function Navigation({ isProductApp }) {
             <div className={clsx('nav-mobile-panel', isMenuOpen ? 'open' : '')} aria-hidden={isMenuOpen}>
               <div className="mobile-items-wrapper">
                 {navItems.map((item, index) => (
-                  <Link href={item.url} key={`mobile-${item.text}`}>
+                  <Link passHref href={item.url} key={`mobile-${item.text}`}>
                     <button className="nav-item" onClick={onLinkClick} onKeyPress={onLinkClick}>
                       {item.text}
                     </button>
@@ -253,7 +253,11 @@ export default function Navigation({ isProductApp }) {
                         {Array.isArray(account.links) && (
                           <div className="nav-sublinks-wrapper">
                             {account.links.map(link => (
-                              <Link href={link.url === 'request-more-storage' ? mailTo : link.url} key={link.text}>
+                              <Link
+                                passHref
+                                href={link.url === 'request-more-storage' ? mailTo : link.url}
+                                key={link.text}
+                              >
                                 <button
                                   className="nav-sublink"
                                   onClick={onLinkClick}

--- a/packages/website/components/navigation/navigation.js
+++ b/packages/website/components/navigation/navigation.js
@@ -235,7 +235,7 @@ export default function Navigation({ isProductApp }) {
                   </Link>
                 ))}
 
-                { isLoggedIn &&
+                { isLoggedIn && account &&
                   <ZeroAccordion multiple={false}>
                     <ZeroAccordionSection disabled={!Array.isArray(account.links)}>
                       <ZeroAccordionSection.Header>

--- a/packages/website/components/navigation/navigation.js
+++ b/packages/website/components/navigation/navigation.js
@@ -34,7 +34,8 @@ export default function Navigation({ isProductApp }) {
   const [isMenuOpen, setMenuOpen] = useState(false);
   // Navigation Content
   const links = GeneralPageData.navigation.links;
-  const account = links.find(item => item.text.toLowerCase() === 'account');
+  const account = links?.find(item => item.text.toLowerCase() === 'account');
+
   const navItems = links.filter(item => item.text.toLowerCase() !== 'account');
   const auth = GeneralPageData.navigation.auth;
   const logoText = GeneralPageData.site_logo.text;
@@ -74,40 +75,43 @@ export default function Navigation({ isProductApp }) {
 
   // ======================================================= Templates [Buttons]
   const getAccountMenu = () => {
-    if (isProductApp) {
-      const labelText = account.text.toLowerCase()
+    if (account && account.links) {
+      if (isProductApp) {
+        const labelText = account.text.toLowerCase()
+        return (
+          <div className="nav-account-button">
+            <button
+              className={ clsx('nav-item', account.url === router.route ? 'current-page' : '')}
+              onClick={onLinkClick}
+              onKeyPress={e => handleKeySelect(e, account.url)}>
+              {account.text}
+            </button>
+            <div className="nav-account-dropdown">
+              <div className="label">{labelText[0].toUpperCase() + labelText.substring(1)}</div>
+              {account.links.map(link => (
+                <Link href={link.url === 'request-more-storage' ? mailTo : link.url} key={link.text}>
+                  <button className="nav-dropdown-link" onClick={onLinkClick} onKeyPress={e => handleKeySelect(e, link.url)}>
+                    {link.text}
+                  </button>
+                </Link>
+              ))}
+            </div>
+          </div>
+        )
+      }
       return (
-        <div className="nav-account-button">
+        <Link key={account.text} href={account.url}>
           <button
             className={ clsx('nav-item', account.url === router.route ? 'current-page' : '')}
             onClick={onLinkClick}
             onKeyPress={e => handleKeySelect(e, account.url)}>
             {account.text}
           </button>
-          <div className="nav-account-dropdown">
-            <div className="label">{labelText[0].toUpperCase() + labelText.substring(1)}</div>
-            {account.links.map(link => (
-              <Link href={link.url === 'request-more-storage' ? mailTo : link.url} key={link.text}>
-                <button className="nav-dropdown-link" onClick={onLinkClick} onKeyPress={e => handleKeySelect(e, link.url)}>
-                  {link.text}
-                </button>
-              </Link>
-            ))}
-          </div>
-        </div>
+        </Link>
       )
     }
-    return (
-      <Link key={account.text} href={account.url}>
-        <button
-          className={ clsx('nav-item', account.url === router.route ? 'current-page' : '')}
-          onClick={onLinkClick}
-          onKeyPress={e => handleKeySelect(e, account.url)}>
-          {account.text}
-        </button>
-      </Link>
-    )
-  }
+    return null;
+  };
 
   const logoutButton = (button, forceTheme) => {
     const variant = forceTheme || theme;

--- a/packages/website/components/tokens/tokensManager/tokensManager.js
+++ b/packages/website/components/tokens/tokensManager/tokensManager.js
@@ -118,7 +118,7 @@ const TokensManager = () => {
       <div className="tokens-manager-footer">
         <Pagination
           items={sortedTokens}
-          itemsPerPage={itemsPerPage}
+          itemsPerPage={itemsPerPage || 10}
           visiblePages={2}
           queryParam="page"
           onChange={setPaginatedTokens}

--- a/packages/website/components/tokens/tokensManager/tokensManager.js
+++ b/packages/website/components/tokens/tokensManager/tokensManager.js
@@ -92,7 +92,7 @@ const TokensManager = () => {
           <Loading className={'tokens-manager-loading-spinner'} />
         ) : !tokens.length ? (
           <span className="tokens-manager-upload-cta">
-            You don't have any API Tokens created yet.{'\u00A0'}
+            You don&apos;t have any API Tokens created yet.{'\u00A0'}
             <Button
               className={clsx(isCreating && 'isDisabled')}
               href="/tokens?create=true"

--- a/packages/website/modules/zero/components/filterable/filterable.js
+++ b/packages/website/modules/zero/components/filterable/filterable.js
@@ -14,6 +14,7 @@ import SearchBar from 'ZeroComponents/searchbar/searchbar'
  * @prop {string} [placeholder]
  * @prop {React.ReactNode} [icon]
  * @prop {function} [onChange]
+ * @prop {function} [onValueChange]
  */
 
 /**
@@ -40,7 +41,7 @@ const Filterable = ({
 
   useEffect(() => {
     if(!currentValue) return onChange && onChange(items?.slice(0))
-    const filteredItems = items.slice(0).filter(item => filterKeys.filter(filterKey => String(item[filterKey] || item).toLowerCase().includes(currentValue.toLowerCase())).length > 0)
+    const filteredItems = items?.slice(0).filter(item => filterKeys.filter(filterKey => String(item[filterKey] || item).toLowerCase().includes(currentValue.toLowerCase())).length > 0)
     onChange && onChange(filteredItems)
   }, [items, currentValue, onChange])
 

--- a/packages/website/next-env.d.ts
+++ b/packages/website/next-env.d.ts
@@ -1,4 +1,5 @@
 /// <reference types="next" />
+/// <reference types="next/types/global" />
 /// <reference types="next/image-types/global" />
 
 // NOTE: This file should not be edited

--- a/packages/website/next.config.js
+++ b/packages/website/next.config.js
@@ -9,7 +9,7 @@ const nextConfig = {
   trailingSlash: true,
   reactStrictMode: true,
   images: {
-    loader: "default",
+    loader: 'custom',
   },
   webpack: function(config, options) {
     config.resolve.alias = {

--- a/packages/website/next.config.js
+++ b/packages/website/next.config.js
@@ -8,10 +8,6 @@ const dirName = path.resolve(__dirname)
 const nextConfig = {
   trailingSlash: true,
   reactStrictMode: true,
-  images: {
-    loader: 'imgix',
-    path: '/',
-  },
   webpack: function(config, options) {
     config.resolve.alias = {
       ...config.resolve.alias,

--- a/packages/website/next.config.js
+++ b/packages/website/next.config.js
@@ -8,6 +8,9 @@ const dirName = path.resolve(__dirname)
 const nextConfig = {
   trailingSlash: true,
   reactStrictMode: true,
+  images: {
+    loader: "default",
+  },
   webpack: function(config, options) {
     config.resolve.alias = {
       ...config.resolve.alias,

--- a/packages/website/next.config.js
+++ b/packages/website/next.config.js
@@ -10,9 +10,8 @@ const nextConfig = {
   reactStrictMode: true,
   images: {
     loader: 'imgix',
-    path: '',
+    path: '/',
   },
-
   webpack: function(config, options) {
     config.resolve.alias = {
       ...config.resolve.alias,

--- a/packages/website/pages/404.js
+++ b/packages/website/pages/404.js
@@ -3,13 +3,14 @@ import GeneralPageData from '../content/pages/general.json';
 import Navigation from '../components/navigation/navigation.js';
 import Footer from '../components/footer/footer.js';
 import BlockBuilder from '../components/blockbuilder/blockbuilder.js';
+// @ts-ignore
 
 // ===================================================================== Exports
 const blocks = GeneralPageData.error_404.sections;
 
 const Custom404 = () => (
   <main className="page-404">
-    <Navigation />
+    <Navigation isProductApp={false}/>
 
     <BlockBuilder id="error_section-1" subsections={blocks} />
 

--- a/packages/website/pages/404.js
+++ b/packages/website/pages/404.js
@@ -10,7 +10,7 @@ const blocks = GeneralPageData.error_404.sections;
 
 const Custom404 = () => (
   <main className="page-404">
-    <Navigation isProductApp={false}/>
+    <Navigation isProductApp={false} />
 
     <BlockBuilder id="error_section-1" subsections={blocks} />
 

--- a/packages/website/pages/_app.tsx
+++ b/packages/website/pages/_app.tsx
@@ -19,15 +19,12 @@ const App = ({ Component, pageProps }: any) => {
   const marketingRoutes = ['/', '/tiers', '/about', '/faq', '/terms'];
   const productApp = productRoutes.includes(pathname);
 
-  
   return (
     <AppProviders authorizationProps={{ ...pageProps }}>
       <Metadata {...pageProps} />
       <RestrictedRoute {...pageProps}>
-        <div
-          id="master-container"
-          className={clsx(productApp ? 'product-app' : 'marketing-site')}>
-          {productApp && <Corkscrew className="corkscrew-background"/>}
+        <div id="master-container" className={clsx(productApp ? 'product-app' : 'marketing-site')}>
+          {productApp && <Corkscrew className="corkscrew-background" />}
           <MessageBanner />
           <Navigation isProductApp={productApp} />
           <Component {...pageProps} />

--- a/packages/website/pages/_app.tsx
+++ b/packages/website/pages/_app.tsx
@@ -16,19 +16,20 @@ import Footer from '../components/footer/footer.js';
 const App = ({ Component, pageProps }: any) => {
   const { pathname } = useRouter();
   const productRoutes = ['/login', '/account', '/tokens'];
+  const marketingRoutes = ['/', '/tiers', '/about', '/faq', '/terms'];
   const productApp = productRoutes.includes(pathname);
 
+  
   return (
     <AppProviders authorizationProps={{ ...pageProps }}>
       <Metadata {...pageProps} />
-      {productApp && <CorkscrewBackground />}
       <RestrictedRoute {...pageProps}>
         <div
           id="master-container"
-          className={clsx(notMarketingSite ? 'product-app' : 'marketing-site')}>
-          {notMarketingSite && <Corkscrew className="corkscrew-background"/>}
+          className={clsx(productApp ? 'product-app' : 'marketing-site')}>
+          {productApp && <Corkscrew className="corkscrew-background"/>}
           <MessageBanner />
-          <Navigation isProductApp={notMarketingSite} />
+          <Navigation isProductApp={productApp} />
           <Component {...pageProps} />
           <Footer />
         </div>

--- a/packages/website/pages/_app.tsx
+++ b/packages/website/pages/_app.tsx
@@ -16,7 +16,7 @@ import Footer from '../components/footer/footer.js';
 const App = ({ Component, pageProps }: any) => {
   const { pathname } = useRouter();
   const productRoutes = ['/login', '/account', '/tokens'];
-  const marketingRoutes = ['/', '/tiers', '/about', '/faq', '/terms'];
+  // const marketingRoutes = ['/', '/tiers', '/about', '/faq', '/terms'];
   const productApp = productRoutes.includes(pathname);
 
   return (


### PR DESCRIPTION
_(This PR relates to the new site in development in `feat/new-brand-frontend`)_

Adding `next` and `next/core-web-vitals` to the `.eslintrc.js` should identify all the issues that will make the site compatible with `next build` and `next export`. 

Some of those issues are resolved in this PR, as are a lot of the errors that were being thrown from `tsc`. 

`eslint` however (`eslint '{pages,components,hooks,content,store}/**/*.{js,ts,tsx}'` still throws a number of errors that I wanted you to take a look at (3 errors right now that cause linting to exit). These are the same errors that appear when running `npx next build`, so this is probably what's preventing the static site output as well.

