### PR TITLE
docs: add note about reserved Remote upload type

### DIFF
--- a/packages/db/postgres/tables.sql
+++ b/packages/db/postgres/tables.sql
@@ -98,6 +98,8 @@ BEGIN
       'Blob',
       -- A multi file upload using a multipart request.
       'Multipart'
+      -- Note: "Remote" is reserved by dagcargo to identify PSA pin request
+      -- "uploads" and cannot be used here!
     );
   END IF;
 END$$;


### PR DESCRIPTION
In NFT.Storage pin requests are added to the upload table with type "Remote". In dagcargo, PSA pin requests from Web3.Storage are combined with uploads (as they are in NFT.Storage) and are artificially given a type "Remote". Hence specifically adding a "Remote" type here would be problematic.