### PR TITLE
fix: add pre-bundled ESM build to package exports

### DIFF
--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -72,22 +72,26 @@
   "types": "./dist/src/lib.d.ts",
   "module": "./src/lib.js",
   "main": "./dist/src/lib.cjs",
-  "exports": {
-    ".": {
-      "browser": "./src/lib.js",
-      "require": "./dist/src/lib.cjs",
-      "node": "./src/lib.js"
-    },
-    "./src/platform.js": {
-      "browser": "./src/platform.web.js",
-      "require": "./dist/src/platform.cjs",
-      "node": "./src/platform.js"
-    },
-    "./name": {
-      "browser": "./src/name.js",
-      "require": "./dist/src/name.cjs",
-      "node": "./src/name.js"
-    }
+  "exports": { 
+    ".": { 
+      "browser": "./src/lib.js", 
+      "require": "./dist/src/lib.cjs", 
+      "node": "./src/lib.js" 
+    }, 
+    "./src/platform.js": { 
+      "browser": "./src/platform.web.js", 
+      "require": "./dist/src/platform.cjs", 
+      "node": "./src/platform.js" 
+    }, 
+    "./name": { 
+      "browser": "./src/name.js", 
+      "require": "./dist/src/name.cjs", 
+      "node": "./src/name.js" }, 
+    "./dist/bundle.esm.min.js": { 
+      "browser": "./dist/bundle.esm.min.js", 
+      "require": "./dist/bundle.esm.min.js", 
+      "node": "./dist/bundle.esm.min.js" 
+      }
   },
   "browser": {
     "./src/platform.js": "./src/platform.web.js"

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -72,20 +72,20 @@
   "types": "./dist/src/lib.d.ts",
   "module": "./src/lib.js",
   "main": "./dist/src/lib.cjs",
-  "exports": { 
-    ".": { 
-      "browser": "./src/lib.js", 
-      "require": "./dist/src/lib.cjs", 
-      "node": "./src/lib.js" 
+  "exports": {
+    ".": {
+      "browser": "./src/lib.js",
+      "require": "./dist/src/lib.cjs",
+      "node": "./src/lib.js"
     }, 
-    "./src/platform.js": { 
-      "browser": "./src/platform.web.js", 
-      "require": "./dist/src/platform.cjs", 
-      "node": "./src/platform.js" 
-    }, 
-    "./name": { 
-      "browser": "./src/name.js", 
-      "require": "./dist/src/name.cjs", 
+    "./src/platform.js": {
+      "browser": "./src/platform.web.js",
+      "require": "./dist/src/platform.cjs",
+      "node": "./src/platform.js"
+    },
+    "./name": {
+      "browser": "./src/name.js",
+      "require": "./dist/src/name.cjs",
       "node": "./src/name.js"
     }, 
     "./dist/bundle.esm.min.js": { 

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -86,12 +86,13 @@
     "./name": { 
       "browser": "./src/name.js", 
       "require": "./dist/src/name.cjs", 
-      "node": "./src/name.js" }, 
+      "node": "./src/name.js"
+    }, 
     "./dist/bundle.esm.min.js": { 
       "browser": "./dist/bundle.esm.min.js", 
       "require": "./dist/bundle.esm.min.js", 
       "node": "./dist/bundle.esm.min.js" 
-      }
+    }
   },
   "browser": {
     "./src/platform.js": "./src/platform.web.js"

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -77,7 +77,7 @@
       "browser": "./src/lib.js",
       "require": "./dist/src/lib.cjs",
       "node": "./src/lib.js"
-    }, 
+    },
     "./src/platform.js": {
       "browser": "./src/platform.web.js",
       "require": "./dist/src/platform.cjs",


### PR DESCRIPTION
This adds the `./dist/bundle.esm.min.js` file to the `exports` field in `package.json`, as suggested by @jilt in [this comment](https://github.com/web3-storage/web3.storage/issues/549#issuecomment-1015236158) on #549. closes #549.

Should hopefully fix issues with compiling the pre-bundled ESM build for production webpack builds.

@jilt, would you mind testing this PR to see if it works with your setup? Thanks!