### PR TITLE
feat: websockets support for w3name

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27125,7 +27125,7 @@
         "mocha": "^9.2.0",
         "multiformats": "^9.5.8",
         "npm-run-all": "^4.1.5",
-        "p-defer": "*",
+        "p-defer": "^4.0.0",
         "p-retry": "^4.6.1",
         "process": "^0.11.10",
         "protobufjs": "^6.11.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -5676,6 +5676,19 @@
         "node": ">=0.2.0"
       }
     },
+    "node_modules/bufferutil": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/bufferutil/-/bufferutil-4.0.6.tgz",
+      "integrity": "sha512-jduaYOYtnio4aIAyc6UbvPCVcgq7nYpVnucyxr6eCYg/Woad9Hf/oxxBRDnGGjPfjUm6j5O/uBWhIu4iLebFaw==",
+      "devOptional": true,
+      "hasInstallScript": true,
+      "dependencies": {
+        "node-gyp-build": "^4.3.0"
+      },
+      "engines": {
+        "node": ">=6.14.2"
+      }
+    },
     "node_modules/builtin-modules": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-3.2.0.tgz",
@@ -7349,6 +7362,16 @@
       "integrity": "sha512-PjiQ659aQ+fUTQqSrd1XEDnOr52jh30RBurfzkscaE2tPaFsDH5wOAHJiw8XAHphRknCwMUE9KRayc4K/NbO8A==",
       "license": "MIT"
     },
+    "node_modules/d": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/d/-/d-1.0.1.tgz",
+      "integrity": "sha512-m62ShEObQ39CfralilEQRjH6oAMtNCV1xJyEx5LpRYUVN+EviphDgUc/F3hnYbADmkiNs67Y+3ylmlG7Lnu+FA==",
+      "dev": true,
+      "dependencies": {
+        "es5-ext": "^0.10.50",
+        "type": "^1.0.1"
+      }
+    },
     "node_modules/d3-format": {
       "version": "3.0.1",
       "license": "ISC",
@@ -8251,12 +8274,34 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/es5-ext": {
+      "version": "0.10.53",
+      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.53.tgz",
+      "integrity": "sha512-Xs2Stw6NiNHWypzRTY1MtaG/uJlwCk8kH81920ma8mvN8Xq1gsfhZvpkImLQArw8AHnv8MT2I45J3c0R8slE+Q==",
+      "dev": true,
+      "dependencies": {
+        "es6-iterator": "~2.0.3",
+        "es6-symbol": "~3.1.3",
+        "next-tick": "~1.0.0"
+      }
+    },
     "node_modules/es6-error": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/es6-error/-/es6-error-4.1.1.tgz",
       "integrity": "sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/es6-iterator": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.3.tgz",
+      "integrity": "sha1-p96IkUGgWpSwhUQDstCg+/qY87c=",
+      "dev": true,
+      "dependencies": {
+        "d": "1",
+        "es5-ext": "^0.10.35",
+        "es6-symbol": "^3.1.1"
+      }
     },
     "node_modules/es6-object-assign": {
       "version": "1.1.0",
@@ -8270,6 +8315,16 @@
       "integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/es6-symbol": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.3.tgz",
+      "integrity": "sha512-NJ6Yn3FuDinBaBRWl/q5X/s4koRHBrgKAu+yGI6JCBeiu3qrcbJhwT2GeR/EXVfylRk8dpQVJoLEFhK+Mu31NA==",
+      "dev": true,
+      "dependencies": {
+        "d": "^1.0.1",
+        "ext": "^1.1.2"
+      }
     },
     "node_modules/esbuild": {
       "version": "0.13.14",
@@ -9355,6 +9410,21 @@
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
       "license": "MIT"
+    },
+    "node_modules/ext": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/ext/-/ext-1.6.0.tgz",
+      "integrity": "sha512-sdBImtzkq2HpkdRLtlLWDa6w4DX22ijZLKx8BMPUuKe1c5lbN6xwQDQCxSfxBQnHZ13ls/FH0MQZx/q/gr6FQg==",
+      "dev": true,
+      "dependencies": {
+        "type": "^2.5.0"
+      }
+    },
+    "node_modules/ext/node_modules/type": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/type/-/type-2.5.0.tgz",
+      "integrity": "sha512-180WMDQaIMm3+7hGXWf12GtdniDEy7nYcyFMKJn/eZz/6tSLXrUN9V0wKSbMjej0I1WHWbpREDEKHtqPQa9NNw==",
+      "dev": true
     },
     "node_modules/extend": {
       "version": "3.0.2",
@@ -14406,6 +14476,12 @@
       "peerDependencies": {
         "next": "*"
       }
+    },
+    "node_modules/next-tick": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz",
+      "integrity": "sha1-yobR/ogoFpsBICCOPchCS524NCw=",
+      "dev": true
     },
     "node_modules/next/node_modules/@babel/runtime": {
       "version": "7.15.3",
@@ -20661,6 +20737,12 @@
       "integrity": "sha512-RKJBIj8lySrShN4w6i/BonWp2Z/uxwC3h4y7xsRrpP59ZboCd0GpEVsOnMDYLMmKBpYhb5TgHzZXy7wTfYFBRw==",
       "license": "Unlicense"
     },
+    "node_modules/type": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/type/-/type-1.2.0.tgz",
+      "integrity": "sha512-+5nt5AAniqsCnu2cEQQdpzCAh33kVx8n0VoFidKpB1dVVLAN/F+bgVOqOJqOnEnrhp222clB5p3vUlD+1QAnfg==",
+      "dev": true
+    },
     "node_modules/type-check": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
@@ -21076,6 +21158,19 @@
         "react": "^16.8.0 || ^17.0.0"
       }
     },
+    "node_modules/utf-8-validate": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-5.0.8.tgz",
+      "integrity": "sha512-k4dW/Qja1BYDl2qD4tOMB9PFVha/UJtxTc1cXYOe3WwA/2m0Yn4qB7wLMpJyLJ/7DR0XnTut3HsCSzDT4ZvKgA==",
+      "devOptional": true,
+      "hasInstallScript": true,
+      "dependencies": {
+        "node-gyp-build": "^4.3.0"
+      },
+      "engines": {
+        "node": ">=6.14.2"
+      }
+    },
     "node_modules/util": {
       "version": "0.12.4",
       "resolved": "https://registry.npmjs.org/util/-/util-0.12.4.tgz",
@@ -21413,6 +21508,23 @@
         "node": ">=10.13.0"
       }
     },
+    "node_modules/websocket": {
+      "version": "1.0.34",
+      "resolved": "https://registry.npmjs.org/websocket/-/websocket-1.0.34.tgz",
+      "integrity": "sha512-PRDso2sGwF6kM75QykIesBijKSVceR6jL2G8NGYyq2XrItNC2P5/qL5XeR056GhA+Ly7JMFvJb9I312mJfmqnQ==",
+      "dev": true,
+      "dependencies": {
+        "bufferutil": "^4.0.1",
+        "debug": "^2.2.0",
+        "es5-ext": "^0.10.50",
+        "typedarray-to-buffer": "^3.1.5",
+        "utf-8-validate": "^5.0.2",
+        "yaeti": "^0.0.6"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
     "node_modules/websocket-stream": {
       "version": "5.5.2",
       "license": "BSD-2-Clause",
@@ -21486,6 +21598,21 @@
         "safe-buffer": "~5.1.0",
         "ultron": "~1.1.0"
       }
+    },
+    "node_modules/websocket/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "dev": true,
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/websocket/node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+      "dev": true
     },
     "node_modules/whatwg-url": {
       "version": "5.0.0",
@@ -21696,6 +21823,15 @@
       "version": "3.2.2",
       "license": "ISC",
       "peer": true
+    },
+    "node_modules/yaeti": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/yaeti/-/yaeti-0.0.6.tgz",
+      "integrity": "sha1-8m9ITXJoTPQr7ft2lwqhYI+/lXc=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.32"
+      }
     },
     "node_modules/yallist": {
       "version": "4.0.0",
@@ -21922,12 +22058,14 @@
         "miniflare": "^2.2.0",
         "mocha": "^9.2.0",
         "npm-run-all": "^4.1.5",
+        "p-defer": "^4.0.0",
         "process": "^0.11.10",
         "sade": "^1.8.1",
         "smoke": "^3.1.1",
         "stream": "^0.0.2",
         "stream-browserify": "^3.0.0",
-        "toucan-js": "^2.4.1"
+        "toucan-js": "^2.4.1",
+        "websocket": "^1.0.34"
       }
     },
     "packages/api/node_modules/@magic-ext/oauth": {
@@ -22380,6 +22518,18 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "dev": true
+    },
+    "packages/api/node_modules/p-defer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/p-defer/-/p-defer-4.0.0.tgz",
+      "integrity": "sha512-Vb3QRvQ0Y5XnF40ZUWW7JfLogicVh/EnA5gBIvKDJoYpeI82+1E3AlB9yOcKFS0AhHrWVnAQO39fbR0G99IVEQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "packages/api/node_modules/p-limit": {
       "version": "3.1.0",
@@ -26975,6 +27125,7 @@
         "mocha": "^9.2.0",
         "multiformats": "^9.5.8",
         "npm-run-all": "^4.1.5",
+        "p-defer": "*",
         "p-retry": "^4.6.1",
         "process": "^0.11.10",
         "protobufjs": "^6.11.2",
@@ -26984,7 +27135,8 @@
         "stream-browserify": "^3.0.0",
         "toucan-js": "^2.4.1",
         "tweetnacl": "^1.0.3",
-        "uint8arrays": "^3.0.0"
+        "uint8arrays": "^3.0.0",
+        "websocket": "^1.0.34"
       },
       "dependencies": {
         "@magic-ext/oauth": {
@@ -27279,6 +27431,12 @@
             }
           }
         },
+        "p-defer": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/p-defer/-/p-defer-4.0.0.tgz",
+          "integrity": "sha512-Vb3QRvQ0Y5XnF40ZUWW7JfLogicVh/EnA5gBIvKDJoYpeI82+1E3AlB9yOcKFS0AhHrWVnAQO39fbR0G99IVEQ==",
+          "dev": true
+        },
         "p-limit": {
           "version": "3.1.0",
           "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
@@ -27359,7 +27517,7 @@
         "execa": "^5.1.1",
         "limiter": "2.0.1",
         "mocha": "^8.3.2",
-        "multiformats": "*",
+        "multiformats": "^9.6.2",
         "node-fetch": "^2.6.1",
         "npm-run-all": "^4.1.5",
         "p-retry": "^4.6.1",
@@ -29294,6 +29452,15 @@
       "version": "0.1.1",
       "peer": true
     },
+    "bufferutil": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/bufferutil/-/bufferutil-4.0.6.tgz",
+      "integrity": "sha512-jduaYOYtnio4aIAyc6UbvPCVcgq7nYpVnucyxr6eCYg/Woad9Hf/oxxBRDnGGjPfjUm6j5O/uBWhIu4iLebFaw==",
+      "devOptional": true,
+      "requires": {
+        "node-gyp-build": "^4.3.0"
+      }
+    },
     "builtin-modules": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-3.2.0.tgz",
@@ -30503,6 +30670,16 @@
       "resolved": "https://registry.npmjs.org/csv-stringify/-/csv-stringify-5.6.5.tgz",
       "integrity": "sha512-PjiQ659aQ+fUTQqSrd1XEDnOr52jh30RBurfzkscaE2tPaFsDH5wOAHJiw8XAHphRknCwMUE9KRayc4K/NbO8A=="
     },
+    "d": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/d/-/d-1.0.1.tgz",
+      "integrity": "sha512-m62ShEObQ39CfralilEQRjH6oAMtNCV1xJyEx5LpRYUVN+EviphDgUc/F3hnYbADmkiNs67Y+3ylmlG7Lnu+FA==",
+      "dev": true,
+      "requires": {
+        "es5-ext": "^0.10.50",
+        "type": "^1.0.1"
+      }
+    },
     "d3-format": {
       "version": "3.0.1"
     },
@@ -31160,11 +31337,33 @@
         "is-symbol": "^1.0.2"
       }
     },
+    "es5-ext": {
+      "version": "0.10.53",
+      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.53.tgz",
+      "integrity": "sha512-Xs2Stw6NiNHWypzRTY1MtaG/uJlwCk8kH81920ma8mvN8Xq1gsfhZvpkImLQArw8AHnv8MT2I45J3c0R8slE+Q==",
+      "dev": true,
+      "requires": {
+        "es6-iterator": "~2.0.3",
+        "es6-symbol": "~3.1.3",
+        "next-tick": "~1.0.0"
+      }
+    },
     "es6-error": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/es6-error/-/es6-error-4.1.1.tgz",
       "integrity": "sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg==",
       "dev": true
+    },
+    "es6-iterator": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.3.tgz",
+      "integrity": "sha1-p96IkUGgWpSwhUQDstCg+/qY87c=",
+      "dev": true,
+      "requires": {
+        "d": "1",
+        "es5-ext": "^0.10.35",
+        "es6-symbol": "^3.1.1"
+      }
     },
     "es6-object-assign": {
       "version": "1.1.0",
@@ -31176,6 +31375,16 @@
       "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
       "integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w==",
       "dev": true
+    },
+    "es6-symbol": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.3.tgz",
+      "integrity": "sha512-NJ6Yn3FuDinBaBRWl/q5X/s4koRHBrgKAu+yGI6JCBeiu3qrcbJhwT2GeR/EXVfylRk8dpQVJoLEFhK+Mu31NA==",
+      "dev": true,
+      "requires": {
+        "d": "^1.0.1",
+        "ext": "^1.1.2"
+      }
     },
     "esbuild": {
       "version": "0.13.14",
@@ -31918,6 +32127,23 @@
           "requires": {
             "ms": "^2.1.1"
           }
+        }
+      }
+    },
+    "ext": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/ext/-/ext-1.6.0.tgz",
+      "integrity": "sha512-sdBImtzkq2HpkdRLtlLWDa6w4DX22ijZLKx8BMPUuKe1c5lbN6xwQDQCxSfxBQnHZ13ls/FH0MQZx/q/gr6FQg==",
+      "dev": true,
+      "requires": {
+        "type": "^2.5.0"
+      },
+      "dependencies": {
+        "type": {
+          "version": "2.5.0",
+          "resolved": "https://registry.npmjs.org/type/-/type-2.5.0.tgz",
+          "integrity": "sha512-180WMDQaIMm3+7hGXWf12GtdniDEy7nYcyFMKJn/eZz/6tSLXrUN9V0wKSbMjej0I1WHWbpREDEKHtqPQa9NNw==",
+          "dev": true
         }
       }
     },
@@ -35602,6 +35828,12 @@
         "matcher": "^4.0.0",
         "minimist": "^1.2.5"
       }
+    },
+    "next-tick": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz",
+      "integrity": "sha1-yobR/ogoFpsBICCOPchCS524NCw=",
+      "dev": true
     },
     "nice-try": {
       "version": "1.0.5",
@@ -39817,6 +40049,12 @@
       "resolved": "https://registry.npmjs.org/tweetnacl-util/-/tweetnacl-util-0.15.1.tgz",
       "integrity": "sha512-RKJBIj8lySrShN4w6i/BonWp2Z/uxwC3h4y7xsRrpP59ZboCd0GpEVsOnMDYLMmKBpYhb5TgHzZXy7wTfYFBRw=="
     },
+    "type": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/type/-/type-1.2.0.tgz",
+      "integrity": "sha512-+5nt5AAniqsCnu2cEQQdpzCAh33kVx8n0VoFidKpB1dVVLAN/F+bgVOqOJqOnEnrhp222clB5p3vUlD+1QAnfg==",
+      "dev": true
+    },
     "type-check": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
@@ -40106,6 +40344,15 @@
       "integrity": "sha512-Xv2a1P/yReAjAbhylMfFplFKj9GssgTwN7RlcTxBujFQcloStWNDQdc4g4NRWH9xS4i/FDk04vQBptAXoF3VcA==",
       "requires": {
         "object-assign": "^4.1.1"
+      }
+    },
+    "utf-8-validate": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-5.0.8.tgz",
+      "integrity": "sha512-k4dW/Qja1BYDl2qD4tOMB9PFVha/UJtxTc1cXYOe3WwA/2m0Yn4qB7wLMpJyLJ/7DR0XnTut3HsCSzDT4ZvKgA==",
+      "devOptional": true,
+      "requires": {
+        "node-gyp-build": "^4.3.0"
       }
     },
     "util": {
@@ -40410,6 +40657,37 @@
       "devOptional": true,
       "peer": true
     },
+    "websocket": {
+      "version": "1.0.34",
+      "resolved": "https://registry.npmjs.org/websocket/-/websocket-1.0.34.tgz",
+      "integrity": "sha512-PRDso2sGwF6kM75QykIesBijKSVceR6jL2G8NGYyq2XrItNC2P5/qL5XeR056GhA+Ly7JMFvJb9I312mJfmqnQ==",
+      "dev": true,
+      "requires": {
+        "bufferutil": "^4.0.1",
+        "debug": "^2.2.0",
+        "es5-ext": "^0.10.50",
+        "typedarray-to-buffer": "^3.1.5",
+        "utf-8-validate": "^5.0.2",
+        "yaeti": "^0.0.6"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "dev": true
+        }
+      }
+    },
     "websocket-stream": {
       "version": "5.5.2",
       "peer": true,
@@ -40617,6 +40895,12 @@
     "y18n": {
       "version": "3.2.2",
       "peer": true
+    },
+    "yaeti": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/yaeti/-/yaeti-0.0.6.tgz",
+      "integrity": "sha1-8m9ITXJoTPQr7ft2lwqhYI+/lXc=",
+      "dev": true
     },
     "yallist": {
       "version": "4.0.0",

--- a/packages/api/README.md
+++ b/packages/api/README.md
@@ -246,6 +246,14 @@ Users "resolve" a Key ID to the current _value_ of a _record_. Typically an IPFS
 
 It returns the resolved value AND the full name record (base 64 encoded, for client side verification).
 
+### 🤲 `GET /name/:key/watch`
+
+**❗️Experimental** this API may not work, may change, and may be removed in a future version.
+
+Watch for changes to the given key ID over a websocket connection.
+
+When changes to the `:key` are published, a JSON encoded message is sent over the websocket containing the new value and the full name record (base 64 encoded, for client side verification).
+
 ## Setup Sentry
 
 Inside the `/packages/api` folder create a file called `.env.local` with the following content.

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -36,12 +36,14 @@
     "miniflare": "^2.2.0",
     "mocha": "^9.2.0",
     "npm-run-all": "^4.1.5",
+    "p-defer": "^4.0.0",
     "process": "^0.11.10",
     "sade": "^1.8.1",
     "smoke": "^3.1.1",
     "stream": "^0.0.2",
     "stream-browserify": "^3.0.0",
-    "toucan-js": "^2.4.1"
+    "toucan-js": "^2.4.1",
+    "websocket": "^1.0.34"
   },
   "dependencies": {
     "@aws-sdk/client-s3": "^3.28.0",

--- a/packages/api/src/env.js
+++ b/packages/api/src/env.js
@@ -36,6 +36,29 @@ import pkg from '../package.json'
  * @property {S3Client} [s3Client]
  * @property {string} [s3BucketName]
  * @property {string} [s3BucketRegion]
+ * // Durable Objects
+ * @property {DurableObjectNamespace} NAME_ROOM
+ *
+ * From: https://github.com/cloudflare/workers-types
+ *
+ * @typedef {{
+ *  toString(): string
+ *  equals(other: DurableObjectId): boolean
+ *  readonly name?: string
+ * }} DurableObjectId
+ *
+ * @typedef {{
+ *   newUniqueId(options?: { jurisdiction?: string }): DurableObjectId
+ *   idFromName(name: string): DurableObjectId
+ *   idFromString(id: string): DurableObjectId
+ *   get(id: DurableObjectId): DurableObjectStub
+ * }} DurableObjectNamespace
+ *
+ * @typedef {{
+ *   readonly id: DurableObjectId
+ *   readonly name?: string
+ *   fetch(requestOrUrl: Request | string, requestInit?: RequestInit | Request): Promise<Response>
+ * }} DurableObjectStub
  */
 
 /**

--- a/packages/api/src/index.js
+++ b/packages/api/src/index.js
@@ -17,7 +17,7 @@ import {
   READ_WRITE
 } from './maintenance.js'
 import { notFound } from './utils/json-response.js'
-import { nameGet, namePost } from './name.js'
+import { nameGet, nameWatchGet, namePost } from './name.js'
 
 const router = Router()
 router.options('*', corsOptions)
@@ -53,6 +53,7 @@ router.get('/pins',                 mode['👀'](auth['📌'](pinsGet)))
 router.delete('/pins/:requestId',   mode['📝'](auth['📌'](pinDelete)))
 
 router.get('/name/:key',            mode['👀'](auth['🤲'](nameGet)))
+router.get('/name/:key/watch',      mode['👀'](auth['🤲'](nameWatchGet)))
 router.post('/name/:key',           mode['📝'](auth['🔒'](namePost)))
 
 router.delete('/user/uploads/:cid',      mode['📝'](auth['👮'](userUploadsDelete)))
@@ -114,3 +115,5 @@ export default {
     }
   }
 }
+
+export { NameRoom as NameRoom0 } from './name.js'

--- a/packages/api/src/name.js
+++ b/packages/api/src/name.js
@@ -157,8 +157,7 @@ export class NameRoom {
   static async join (req, ns, key) {
     const roomId = ns.idFromName(key)
     const room = ns.get(roomId)
-    const url = new URL(req.url)
-    url.pathname = '/websocket'
+    const url = new URL('/websocket', req.url)
     return room.fetch(url, req)
   }
 
@@ -171,8 +170,7 @@ export class NameRoom {
   static async broadcast (req, ns, key, data) {
     const roomId = ns.idFromName(key)
     const room = ns.get(roomId)
-    const url = new URL(req.url)
-    url.pathname = '/broadcast'
+    const url = new URL('/broadcast', req.url)
     return room.fetch(url, { method: 'POST', body: JSON.stringify(data) })
   }
 }

--- a/packages/api/src/name.js
+++ b/packages/api/src/name.js
@@ -69,7 +69,6 @@ export async function namePost (request, env, ctx) {
   )
 
   ctx.waitUntil((async () => {
-  // await ((async () => {
     const record = await env.db.resolveNameRecord(key)
     if (!record) return // shouldn't happen
     const { value } = ipns.unmarshal(uint8ArrayFromString(record, 'base64pad'))

--- a/packages/api/src/name.js
+++ b/packages/api/src/name.js
@@ -1,3 +1,5 @@
+/* eslint-env serviceworker */
+/* global WebSocketPair */
 import { fromString as uint8ArrayFromString } from 'uint8arrays/from-string'
 import { toString as uint8ArrayToString } from 'uint8arrays/to-string'
 import * as ipns from './utils/ipns/index.js'
@@ -38,8 +40,9 @@ export async function nameGet (request, env) {
 /**
  * @param {Request} request
  * @param {import('./env').Env} env
+ * @param {import('./index').Ctx} ctx
  */
-export async function namePost (request, env) {
+export async function namePost (request, env, ctx) {
   const { params: { key } } = request
   const keyCid = CID.parse(key, base36)
 
@@ -65,5 +68,116 @@ export async function namePost (request, env) {
     new PreciseDate(uint8ArrayToString(entry.validity)).getFullTime()
   )
 
+  ctx.waitUntil((async () => {
+    const record = await env.db.resolveNameRecord(key)
+    if (!record) return // shouldn't happen
+    const { value } = ipns.unmarshal(uint8ArrayFromString(record, 'base64pad'))
+    const data = { value: uint8ArrayToString(value), record }
+    await NameRoom.broadcast(request, env.NAME_ROOM, key, data)
+    await NameRoom.broadcast(request, env.NAME_ROOM, '*', data)
+  })())
+
   return new JSONResponse({ id: key }, { status: 202 })
+}
+
+/**
+ * @param {Request} request
+ * @param {import('./env').Env} env
+ */
+export async function nameWatchGet (request, env) {
+  const { params: { key } } = request
+  if (key === '*') {
+    return NameRoom.join(request, env.NAME_ROOM, '*')
+  }
+
+  const keyCid = CID.parse(key, base36)
+  if (keyCid.code !== libp2pKeyCode) {
+    throw new HTTPError(`invalid key code: ${keyCid.code}`, 400)
+  }
+
+  const record = await env.db.resolveNameRecord(key)
+  if (!record) {
+    throw new HTTPError(`record not found for key: ${key}`, 404)
+  }
+
+  return NameRoom.join(request, env.NAME_ROOM, key)
+}
+
+/**
+ * A Cloudflare Durable Object. Each instance is a group of users interested in
+ * a particular IPNS key ID. The static API is used by workers to communicate
+ * with it.
+ */
+export class NameRoom {
+  constructor () {
+    /** @type {Array<{ webSocket: WebSocket }>} */
+    this.sessions = []
+  }
+
+  /**
+   * @param {Request} request
+   * @returns {Promise<Response>}
+   */
+  async fetch (request) {
+    const url = new URL(request.url)
+    switch (url.pathname) {
+      // create new websocket connection
+      case '/websocket': {
+        if (request.headers.get('Upgrade') !== 'websocket') {
+          return new Response('expected websocket upgrade', { status: 400 })
+        }
+        /** @type {[WebSocket, WebSocket]} */
+        const [client, server] = Object.values(new WebSocketPair())
+        server.accept()
+
+        const session = { webSocket: server }
+        this.sessions.push(session)
+
+        const closeOrErrorHandler = () => {
+          this.sessions = this.sessions.filter(s => s !== session)
+        }
+        server.addEventListener('close', closeOrErrorHandler)
+        server.addEventListener('error', closeOrErrorHandler)
+
+        return new Response(null, { status: 101, webSocket: client })
+      }
+      // broadcast an updated value to everyone in the room
+      case '/broadcast': {
+        const data = await request.text()
+        for (const session of this.sessions) {
+          session.webSocket.send(data)
+        }
+        return new Response()
+      }
+      default:
+        return new Response('not found', { status: 404 })
+    }
+  }
+
+  /**
+   * @param {Request} req
+   * @param {import('./env').DurableObjectNamespace} ns
+   * @param {string} key IPNS Key ID
+   */
+  static async join (req, ns, key) {
+    const roomId = ns.idFromName(key)
+    const room = ns.get(roomId)
+    const url = new URL(req.url)
+    url.pathname = '/websocket'
+    return room.fetch(url, req)
+  }
+
+  /**
+   * @param {Request} req
+   * @param {import('./env').DurableObjectNamespace} ns
+   * @param {string} key IPNS Key ID
+   * @param {{ value: string, record: string }} data
+   */
+  static async broadcast (req, ns, key, data) {
+    const roomId = ns.idFromName(key)
+    const room = ns.get(roomId)
+    const url = new URL(req.url)
+    url.pathname = '/broadcast'
+    return room.fetch(new Request({ url, body: JSON.stringify(data) }))
+  }
 }

--- a/packages/api/test/name.spec.js
+++ b/packages/api/test/name.spec.js
@@ -57,15 +57,6 @@ describe('GET /name/:key/watch', () => {
     const name1Record0 = await createNameRecord(name1.privateKey, name1Value0)
     const name1Record1 = await updateNameRecord(name1.privateKey, name1Record0, name1Value1)
 
-    const publishRecord = async (key, record) => {
-      const publishRes = await fetch(new URL(`name/${key}`, endpoint), {
-        method: 'POST',
-        headers: { Authorization: `Bearer ${token}` },
-        body: uint8arrays.toString(record, 'base64pad')
-      })
-      assert(publishRes.ok)
-    }
-
     // listen for updates to name0
     /** @type {import('websocket').connection} */
     const conn = await new Promise((resolve, reject) => {
@@ -88,12 +79,12 @@ describe('GET /name/:key/watch', () => {
     })
 
     try {
-      await publishRecord(name0.id, name0Record0)
+      await publishRecord(token, name0.id, name0Record0)
       // we should NOT receive an update for this key
-      await publishRecord(name1.id, name1Record0)
+      await publishRecord(token, name1.id, name1Record0)
       // we should NOT receive an update for this key
-      await publishRecord(name1.id, name1Record1)
-      await publishRecord(name0.id, name0Record1)
+      await publishRecord(token, name1.id, name1Record1)
+      await publishRecord(token, name0.id, name0Record1)
 
       // wait for update message to be received
       await deferred.promise
@@ -119,15 +110,6 @@ describe('GET /name/:key/watch', () => {
     const name1Record0 = await createNameRecord(name1.privateKey, name1Value0)
     const name1Record1 = await updateNameRecord(name1.privateKey, name1Record0, name1Value1)
 
-    const publishRecord = async (key, record) => {
-      const publishRes = await fetch(new URL(`name/${key}`, endpoint), {
-        method: 'POST',
-        headers: { Authorization: `Bearer ${token}` },
-        body: uint8arrays.toString(record, 'base64pad')
-      })
-      assert(publishRes.ok)
-    }
-
     // listen for ALL updates
     /** @type {import('websocket').connection} */
     const conn = await new Promise((resolve, reject) => {
@@ -149,10 +131,10 @@ describe('GET /name/:key/watch', () => {
     })
 
     try {
-      await publishRecord(name1.id, name1Record0)
-      await publishRecord(name0.id, name0Record0)
-      await publishRecord(name1.id, name1Record1)
-      await publishRecord(name0.id, name0Record1)
+      await publishRecord(token, name1.id, name1Record0)
+      await publishRecord(token, name0.id, name0Record0)
+      await publishRecord(token, name1.id, name1Record1)
+      await publishRecord(token, name0.id, name0Record1)
 
       // wait for update messages to be received
       await deferred.promise
@@ -166,4 +148,13 @@ describe('GET /name/:key/watch', () => {
       conn.close()
     }
   })
+
+  async function publishRecord (token, key, record) {
+    const publishRes = await fetch(new URL(`name/${key}`, endpoint), {
+      method: 'POST',
+      headers: { Authorization: `Bearer ${token}` },
+      body: uint8arrays.toString(record, 'base64pad')
+    })
+    assert(publishRes.ok)
+  }
 })

--- a/packages/api/test/name.spec.js
+++ b/packages/api/test/name.spec.js
@@ -2,8 +2,12 @@
 import assert from 'assert'
 import * as uint8arrays from 'uint8arrays'
 import fetch from '@web-std/fetch'
+import websocket from 'websocket'
+import defer from 'p-defer'
 import { endpoint } from './scripts/constants.js'
-import { createNameKeypair, createNameRecord, getTestJWT } from './scripts/helpers.js'
+import { createNameKeypair, createNameRecord, updateNameRecord, getTestJWT } from './scripts/helpers.js'
+
+const WebSocketClient = websocket.client
 
 describe('GET /name/:key', () => {
   it('resolves key to value', async () => {
@@ -36,5 +40,130 @@ describe('POST /name/:key', () => {
     const resolved = await resolveRes.json()
     assert.strictEqual(resolved.record, uint8arrays.toString(record, 'base64pad'))
     assert.strictEqual(resolved.value, value)
+  })
+})
+
+describe('GET /name/:key/watch', () => {
+  it('watches for publishes to a key', async () => {
+    const token = await getTestJWT()
+    const name0 = await createNameKeypair()
+    const name1 = await createNameKeypair()
+    const name0Value0 = '/ipfs/bafybeiauyddeo2axgargy56kwxirquxaxso3nobtjtjvoqu552oqciudrm'
+    const name0Value1 = '/ipfs/bafkreiem4twkqzsq2aj4shbycd4yvoj2cx72vezicletlhi7dijjciqpui'
+    const name1Value0 = '/ipfs/bafkreid7fbwjx4swwewit5txzttoja4t4xnkj3rx3q7dlbj76gvixuq35y'
+    const name1Value1 = '/ipfs/bafybeihiyjghsq7gob7vj3vurqf5i4eth3h57ixpaajdxtvi7p4snhag2a'
+    const name0Record0 = await createNameRecord(name0.privateKey, name0Value0)
+    const name0Record1 = await updateNameRecord(name0.privateKey, name0Record0, name0Value1)
+    const name1Record0 = await createNameRecord(name1.privateKey, name1Value0)
+    const name1Record1 = await updateNameRecord(name1.privateKey, name1Record0, name1Value1)
+
+    const publishRecord = async (key, record) => {
+      const publishRes = await fetch(new URL(`name/${key}`, endpoint), {
+        method: 'POST',
+        headers: { Authorization: `Bearer ${token}` },
+        body: uint8arrays.toString(record, 'base64pad')
+      })
+      assert(publishRes.ok)
+    }
+
+    // listen for updates to name0
+    /** @type {import('websocket').connection} */
+    const conn = await new Promise((resolve, reject) => {
+      const client = new WebSocketClient()
+      client.connect(new URL(`name/${name0.id}/watch`, endpoint).toString())
+      client.on('connect', resolve).on('connectFailed', reject)
+    })
+
+    // we're going to publish on two keys, but we're only listening on one
+    // so we should only receive 2 messages.
+    const expectedMsgCount = 2
+    /** @type {import('websocket').Message[]} */
+    const msgs = []
+    const deferred = defer()
+    conn.on('message', msg => {
+      msgs.push(msg)
+      if (msgs.length >= expectedMsgCount) {
+        deferred.resolve()
+      }
+    })
+
+    try {
+      await publishRecord(name0.id, name0Record0)
+      // we should NOT receive an update for this key
+      await publishRecord(name1.id, name1Record0)
+      // we should NOT receive an update for this key
+      await publishRecord(name1.id, name1Record1)
+      await publishRecord(name0.id, name0Record1)
+
+      // wait for update message to be received
+      await deferred.promise
+
+      assert.strictEqual(msgs.length, expectedMsgCount)
+      assert.strictEqual(JSON.parse(msgs[0].utf8Data).value, name0Value0)
+      assert.strictEqual(JSON.parse(msgs[1].utf8Data).value, name0Value1)
+    } finally {
+      conn.close()
+    }
+  })
+
+  it('watches for publishes to all keys', async () => {
+    const token = await getTestJWT()
+    const name0 = await createNameKeypair()
+    const name1 = await createNameKeypair()
+    const name0Value0 = '/ipfs/bafybeiauyddeo2axgargy56kwxirquxaxso3nobtjtjvoqu552oqciudrm'
+    const name0Value1 = '/ipfs/bafkreiem4twkqzsq2aj4shbycd4yvoj2cx72vezicletlhi7dijjciqpui'
+    const name1Value0 = '/ipfs/bafkreid7fbwjx4swwewit5txzttoja4t4xnkj3rx3q7dlbj76gvixuq35y'
+    const name1Value1 = '/ipfs/bafybeihiyjghsq7gob7vj3vurqf5i4eth3h57ixpaajdxtvi7p4snhag2a'
+    const name0Record0 = await createNameRecord(name0.privateKey, name0Value0)
+    const name0Record1 = await updateNameRecord(name0.privateKey, name0Record0, name0Value1)
+    const name1Record0 = await createNameRecord(name1.privateKey, name1Value0)
+    const name1Record1 = await updateNameRecord(name1.privateKey, name1Record0, name1Value1)
+
+    const publishRecord = async (key, record) => {
+      const publishRes = await fetch(new URL(`name/${key}`, endpoint), {
+        method: 'POST',
+        headers: { Authorization: `Bearer ${token}` },
+        body: uint8arrays.toString(record, 'base64pad')
+      })
+      assert(publishRes.ok)
+    }
+
+    // listen for ALL updates
+    /** @type {import('websocket').connection} */
+    const conn = await new Promise((resolve, reject) => {
+      const client = new WebSocketClient()
+      client.connect(new URL('name/*/watch', endpoint).toString())
+      client.on('connect', resolve).on('connectFailed', reject)
+    })
+
+    // we're going to publish on two keys
+    const expectedMsgCount = 4
+    /** @type {import('websocket').Message[]} */
+    const msgs = []
+    const deferred = defer()
+    conn.on('message', msg => {
+      msgs.push(msg)
+      if (msgs.length >= expectedMsgCount) {
+        deferred.resolve()
+      }
+    })
+
+    try {
+      await publishRecord(name1.id, name1Record0)
+      await publishRecord(name0.id, name0Record0)
+      await publishRecord(name1.id, name1Record1)
+      await publishRecord(name0.id, name0Record1)
+
+      // wait for update messages to be received
+      await deferred.promise
+
+      assert.strictEqual(msgs.length, expectedMsgCount)
+      assert.strictEqual(JSON.parse(msgs[0].utf8Data).value, name1Value0)
+      assert.strictEqual(JSON.parse(msgs[1].utf8Data).value, name0Value0)
+      assert.strictEqual(JSON.parse(msgs[2].utf8Data).value, name1Value1)
+      assert.strictEqual(JSON.parse(msgs[3].utf8Data).value, name0Value1)
+    } finally {
+      conn.close()
+    }
   })
 })

--- a/packages/api/test/scripts/helpers.js
+++ b/packages/api/test/scripts/helpers.js
@@ -10,6 +10,7 @@ import { JWT_ISSUER } from '../../src/constants.js'
 import { SALT } from './worker-globals.js'
 
 const libp2pKeyCode = 0x72
+const lifetime = 1000 * 60 * 60
 
 export async function createNameKeypair () {
   const privKey = await keys.generateKeyPair('Ed25519', 2048)
@@ -21,15 +22,31 @@ export async function createNameKeypair () {
 }
 
 /**
- * @param {Uint8Array} privKey base64 encoded private key
+ * @param {Uint8Array} privKey Private key
  * @param {string} value IPFS path
  * @param {bigint} seqno Sequence number
  */
 export async function createNameRecord (privKey, value, seqno = 0n) {
   const privKeyObj = await keys.unmarshalPrivateKey(privKey)
-  const lifetime = 1000 * 60 * 60
   const entry = await ipns.create(privKeyObj, uint8arrays.fromString(value), seqno, lifetime)
   return ipns.marshal(entry)
+}
+
+/**
+ * @param {Uint8Array} privKey Private key
+ * @param {Uint8Array} existingRecord Current IPNS record
+ * @param {string} newValue IPFS path
+ */
+export async function updateNameRecord (privKey, existingRecord, newValue) {
+  const privKeyObj = await keys.unmarshalPrivateKey(privKey)
+  const existingEntry = ipns.unmarshal(existingRecord)
+  const newEntry = await ipns.create(
+    privKeyObj,
+    uint8arrays.fromString(newValue),
+    existingEntry.sequence + 1n,
+    lifetime
+  )
+  return ipns.marshal(newEntry)
 }
 
 export function getTestJWT (sub = 'test-magic-issuer', name = 'test-magic-issuer') {

--- a/packages/api/wrangler.toml
+++ b/packages/api/wrangler.toml
@@ -15,6 +15,9 @@ dir = "dist"
 main = "index.mjs"
 # NOTE: Make sure the main field in your package.json references the Worker script you want to publish.
 
+[durable_objects]
+bindings = [{ name = "NAME_ROOM", class_name = "NameRoom0" }]
+
 # ---- Environment specific overrides below ! ----
 # NOTE: wrangler automatically assigns each env the root `name` with the env name suffixed on the end
 # NOTE: wrangler tries to find an account_id defined at the root if workers_dev = true is not provided on your env.


### PR DESCRIPTION
This PR adds support for websockets to w3name. Establish a websocket connection to `wss://api.web3.storage/name/:key/watch` and receive JSON encoded messages like: `{ key: string, value: string, record: string }` when updates to the key are published.

* [x] Refactor to ESM to allow usage of "Durable Objects" https://github.com/web3-storage/web3.storage/pull/902
* [x] Configuration to enable `NameRoom` as a durable object
* [ ] Client API (will do in separate PR)

supersedes https://github.com/web3-storage/web3.storage/pull/653

Related to https://github.com/web3-storage/web3.storage/issues/659