### PR TITLE
Fix: docker cluster container name conflict

### DIFF
--- a/packages/tools/docker/cluster/docker-compose.yml
+++ b/packages/tools/docker/cluster/docker-compose.yml
@@ -36,7 +36,6 @@ services:
   ##################################################################################
 
     ipfs0:
-      container_name: ipfs0
       image: ipfs/go-ipfs:v0.10.0 # update this when go-ipfs M1 macs https://github.com/ipfs/go-ipfs/issues/8645
       volumes:
         - ipfs0:/data/ipfs
@@ -46,7 +45,6 @@ services:
       #- "8080:8080" # ipfs gateway - expose if needed/wanted
         
     cluster0:
-      container_name: cluster0
       image: ipfs/ipfs-cluster:latest
       depends_on:
         - ipfs0


### PR DESCRIPTION
This PR fixes an a docker conflict issue that prevents the cluster to start due to a conflict in containers names.