### PR TITLE
fix: use upsertpins

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22026,7 +22026,7 @@
     },
     "packages/api": {
       "name": "@web3-storage/api",
-      "version": "5.1.0",
+      "version": "5.1.4",
       "license": "(Apache-2.0 OR MIT)",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.28.0",
@@ -22635,7 +22635,7 @@
     },
     "packages/client": {
       "name": "web3.storage",
-      "version": "3.5.3",
+      "version": "3.5.4",
       "license": "(Apache-2.0 OR MIT)",
       "dependencies": {
         "@ipld/car": "^3.1.4",

--- a/packages/api/src/utils/pin.js
+++ b/packages/api/src/utils/pin.js
@@ -135,18 +135,18 @@ export async function waitOkPins (cid, cluster, waitTime = MAX_PIN_STATUS_CHECK_
  * @param {import('@web3-storage/db').DBClient} db
  * @param {number} waitTime
  * @param {number} checkInterval
- * @return {Promise.<import('@web3-storage/db/db-client-types').PinsUpsertInput[]>}
+ * @return {Promise.<import('@web3-storage/db/db-client-types').PinUpsertInput[]>}
  */
 export async function waitAndUpdateOkPins (cid, cluster, db, waitTime = MAX_PIN_STATUS_CHECK_TIME, checkInterval = PIN_STATUS_CHECK_INTERVAL) {
   const okPins = await waitOkPins(cid, cluster, waitTime, checkInterval)
   const pins = okPins.map((pin) => {
     return {
-      _id: pin._id,
+      id: pin._id,
       status: pin.status,
       cid,
       locationId: pin.location._id
     }
   })
   await db.upsertPins(pins)
-  return pins
+  return okPins
 }

--- a/packages/api/src/utils/pin.js
+++ b/packages/api/src/utils/pin.js
@@ -135,10 +135,19 @@ export async function waitOkPins (cid, cluster, waitTime = MAX_PIN_STATUS_CHECK_
  * @param {import('@web3-storage/db').DBClient} db
  * @param {number} waitTime
  * @param {number} checkInterval
- * @return {Promise.<import('@web3-storage/db/db-client-types').PinUpsertInput[]>}
+ * @return {Promise.<import('@web3-storage/db/db-client-types').PinsUpsertInput[]>}
  */
 export async function waitAndUpdateOkPins (cid, cluster, db, waitTime = MAX_PIN_STATUS_CHECK_TIME, checkInterval = PIN_STATUS_CHECK_INTERVAL) {
   const okPins = await waitOkPins(cid, cluster, waitTime, checkInterval)
-  await db.upsertPins(okPins)
-  return okPins
+  const pins = okPins.map((pin) => {
+    return {
+      id: pin.id,
+      status: pin.status,
+      cid,
+      locationId: pin.location.id,
+      updated: new Date().toISOString()
+    }
+  })
+  await db.upsertPins(pins)
+  return pins
 }

--- a/packages/api/src/utils/pin.js
+++ b/packages/api/src/utils/pin.js
@@ -141,11 +141,10 @@ export async function waitAndUpdateOkPins (cid, cluster, db, waitTime = MAX_PIN_
   const okPins = await waitOkPins(cid, cluster, waitTime, checkInterval)
   const pins = okPins.map((pin) => {
     return {
-      id: pin.id,
+      _id: pin._id,
       status: pin.status,
       cid,
-      locationId: pin.location.id,
-      updated: new Date().toISOString()
+      locationId: pin.location._id
     }
   })
   await db.upsertPins(pins)

--- a/packages/api/src/utils/pin.js
+++ b/packages/api/src/utils/pin.js
@@ -139,8 +139,6 @@ export async function waitOkPins (cid, cluster, waitTime = MAX_PIN_STATUS_CHECK_
  */
 export async function waitAndUpdateOkPins (cid, cluster, db, waitTime = MAX_PIN_STATUS_CHECK_TIME, checkInterval = PIN_STATUS_CHECK_INTERVAL) {
   const okPins = await waitOkPins(cid, cluster, waitTime, checkInterval)
-  for (const pin of okPins) {
-    await db.upsertPin(cid, pin)
-  }
+  await db.upsertPins(okPins)
   return okPins
 }

--- a/packages/cron/src/jobs/pins.js
+++ b/packages/cron/src/jobs/pins.js
@@ -99,7 +99,7 @@ export async function updatePinStatuses ({ cluster, db }) {
       log(`📌 ${pin.contentCid}@${pin.location.peerId}: ${pin.status} => ${status}`)
 
       return {
-        _id: pin._id,
+        id: pin._id,
         status: status,
         cid: pin.contentCid,
         locationId: pin.location._id

--- a/packages/cron/src/jobs/pins.js
+++ b/packages/cron/src/jobs/pins.js
@@ -99,11 +99,10 @@ export async function updatePinStatuses ({ cluster, db }) {
       log(`📌 ${pin.contentCid}@${pin.location.peerId}: ${pin.status} => ${status}`)
 
       return {
-        id: pin._id,
+        _id: pin._id,
         status: status,
-        content_cid: pin.contentCid,
-        pin_location_id: pin.location._id,
-        updated_at: new Date().toISOString()
+        cid: pin.contentCid,
+        locationId: pin.location._id
       }
     }))
 

--- a/packages/db/db-client-types.ts
+++ b/packages/db/db-client-types.ts
@@ -73,6 +73,13 @@ export type PinItem = PinUpsertInput & {
   updated: definitions['pin']['updated_at']
 }
 
+export type PinsUpsertInput = {
+  id?: definitions['pin']['id'],
+  status: definitions['pin']['status'],
+  cid: definitions['pin_request']['content_cid']
+  locationId: definitions['pin_location']['id']
+  updated: definitions['pin']['updated_at'],
+}
 
 export type PinItemOutput = {
   _id?: string

--- a/packages/db/db-client-types.ts
+++ b/packages/db/db-client-types.ts
@@ -74,7 +74,7 @@ export type PinItem = PinUpsertInput & {
 }
 
 export type PinsUpsertInput = {
-  _id: string
+  id: string
   status: definitions['pin']['status']
   cid: definitions['pin_request']['content_cid']
   locationId: string

--- a/packages/db/db-client-types.ts
+++ b/packages/db/db-client-types.ts
@@ -62,7 +62,7 @@ export type AuthKeyItemOutput = {
 
 // Pin
 export type PinUpsertInput = {
-  id?: definitions['pin']['id'],
+  _id?: string,
   status: definitions['pin']['status'],
   location: Location,
 }
@@ -74,11 +74,10 @@ export type PinItem = PinUpsertInput & {
 }
 
 export type PinsUpsertInput = {
-  id?: definitions['pin']['id'],
-  status: definitions['pin']['status'],
+  _id: string
+  status: definitions['pin']['status']
   cid: definitions['pin_request']['content_cid']
-  locationId: definitions['pin_location']['id']
-  updated: definitions['pin']['updated_at'],
+  locationId: string
 }
 
 export type PinItemOutput = {
@@ -222,7 +221,7 @@ export type UploadOutput = definitions['upload'] & {
 }
 
 export type Location = {
-  id?: definitions['pin_location']['id']
+  _id?: string
   peerId: definitions['pin_location']['peer_id']
   peerName?: definitions['pin_location']['peer_name']
   region?: definitions['pin_location']['region']

--- a/packages/db/index.d.ts
+++ b/packages/db/index.d.ts
@@ -20,6 +20,7 @@ import type {
   PinRequestItemOutput,
   PinSyncRequestOutput,
   PinUpsertInput,
+  PinsUpsertInput,
   BackupOutput,
   PsaPinRequestItem,
   PsaPinRequestUpsertOutput,
@@ -45,7 +46,7 @@ export class DBClient {
   getStatus (cid: string): Promise<ContentItemOutput>
   getBackups (uploadId: number): Promise<Array<BackupOutput>>
   upsertPin (cid: string, pin: PinUpsertInput): Promise<number>
-  upsertPins (pins: Array<PinUpsertInput>): Promise<void>
+  upsertPins (pins: Array<PinsUpsertInput>): Promise<void>
   getPins (cid: string): Promise<Array<PinItemOutput>>
   getPinRequests ({ size }: { size: number }): Promise<Array<PinRequestItemOutput>>
   deletePinRequests (ids: Array<number>): Promise<void>

--- a/packages/db/index.d.ts
+++ b/packages/db/index.d.ts
@@ -50,9 +50,9 @@ export class DBClient {
   getPins (cid: string): Promise<Array<PinItemOutput>>
   getPinRequests ({ size }: { size: number }): Promise<Array<PinRequestItemOutput>>
   deletePinRequests (ids: Array<number>): Promise<void>
-  createPinSyncRequests (pinSyncRequests: Array<number>): Promise<void>
-  getPinSyncRequests ({ to, after }: { to: string, after: string }): Promise<PinSyncRequestOutput>
-  deletePinSyncRequests (ids: Array<number>): Promise<void>
+  createPinSyncRequests (pinSyncRequests: Array<string>): Promise<void>
+  getPinSyncRequests ({ to, after, size }: { to: string, after?: string, size?: number }): Promise<PinSyncRequestOutput>
+  deletePinSyncRequests (ids: Array<string>): Promise<void>
   getDeals (cid: string): Promise<Deal[]>
   getDealsForCids (cids: string[]): Promise<Record<string, Deal[]>>
   createKey (key: CreateAuthKeyInput): Promise<CreateAuthKeyOutput>

--- a/packages/db/index.js
+++ b/packages/db/index.js
@@ -438,7 +438,7 @@ export class DBClient {
   /**
    * Upsert given pin status.
    *
-   * @param {Array<import('./db-client-types').PinUpsertInput>} pins
+   * @param {Array<import('./db-client-types').PinsUpsertInput>} pins
    */
   async upsertPins (pins) {
     const { error } = await this._client

--- a/packages/db/index.js
+++ b/packages/db/index.js
@@ -440,14 +440,23 @@ export class DBClient {
   }
 
   /**
-   * Upsert given pin status.
+   * Upsert pins.
+   *
+   * NOTE: currently only used to batch update the pin status.
    *
    * @param {Array<import('./db-client-types').PinsUpsertInput>} pins
    */
   async upsertPins (pins) {
+    const now = new Date().toISOString()
     const { error } = await this._client
       .from('pin')
-      .upsert(pins, { count: 'exact', returning: 'minimal' })
+      .upsert(pins.map(pin => ({
+        id: pin._id,
+        status: pin.status,
+        content_cid: pin.cid,
+        pin_location_id: pin.locationId,
+        updated_at: now
+      })), { count: 'exact', returning: 'minimal' })
 
     if (error) {
       throw new DBError(error)

--- a/packages/db/index.js
+++ b/packages/db/index.js
@@ -451,7 +451,7 @@ export class DBClient {
     const { error } = await this._client
       .from('pin')
       .upsert(pins.map(pin => ({
-        id: pin._id,
+        id: pin.id,
         status: pin.status,
         content_cid: pin.cid,
         pin_location_id: pin.locationId,

--- a/packages/db/test/pin-sync-request.spec.js
+++ b/packages/db/test/pin-sync-request.spec.js
@@ -110,7 +110,7 @@ describe('pin-sync-request', () => {
 
     // Update all Pins to Pinned
     await client.upsertPins(pinSyncReqs.map(psr => ({
-      _id: psr.pin._id,
+      id: psr.pin._id,
       status: 'Pinned',
       cid: psr.pin.contentCid,
       locationId: psr.pin.location._id

--- a/packages/db/test/pin-sync-request.spec.js
+++ b/packages/db/test/pin-sync-request.spec.js
@@ -60,6 +60,7 @@ describe('pin-sync-request', () => {
       {
         status: 'Pinning',
         location: {
+          id: 1,
           peerId: '12D3KooWFe387JFDpgNEVCP5ARut7gRkX7YuJCXMStpkq714ziK6',
           peerName: 'web3-storage-sv15',
           region: 'region'
@@ -68,6 +69,7 @@ describe('pin-sync-request', () => {
       {
         status: 'Pinning',
         location: {
+          id: 2,
           peerId: '12D3KooWFe387JFDpgNEVCP5ARut7gRkX7YuJCXMStpkq714ziK7',
           peerName: 'web3-storage-sv16',
           region: 'region'
@@ -76,6 +78,7 @@ describe('pin-sync-request', () => {
       {
         status: 'Pinned',
         location: {
+          id: 3,
           peerId: '12D3KooWFe387JFDpgNEVCP5ARut7gRkX7YuJCXMStpkq714ziK8',
           peerName: 'web3-storage-sv17',
           region: 'region'
@@ -107,11 +110,10 @@ describe('pin-sync-request', () => {
 
     // Update all Pins to Pinned
     await client.upsertPins(pinSyncReqs.map(psr => ({
-      id: psr.pin._id,
+      _id: psr.pin._id,
       status: 'Pinned',
-      content_cid: psr.pin.contentCid,
-      pin_location_id: psr.pin.location._id,
-      updated_at: new Date().toISOString()
+      cid: psr.pin.contentCid,
+      locationId: psr.pin.location._id
     })))
 
     const { data: pinSyncReqsAfterUpdate } = await client.getPinSyncRequests({ to })


### PR DESCRIPTION
We were looping a list of pins and using `upsertPin` to change the status to 'Pinned'. Instead we should use `upsertPins` to batch update all of them in one request.