### PR TITLE
feat Code preview animations

### DIFF
--- a/packages/website/components/codepreview/codepreview.js
+++ b/packages/website/components/codepreview/codepreview.js
@@ -1,10 +1,12 @@
 // ===================================================================== Imports
-import { useState } from 'react';
+import { useState, useRef, useEffect } from 'react';
 import clsx from 'clsx';
 import hljs from 'highlight.js/lib/core';
 import javascript from 'highlight.js/lib/languages/javascript';
-hljs.registerLanguage('javascript', javascript);
 
+import CopyIcon from '../../assets/icons/copy.js';
+
+hljs.registerLanguage('javascript', javascript);
 // ====================================================================== Params
 /**
  * @param {Object} props
@@ -13,22 +15,121 @@ hljs.registerLanguage('javascript', javascript);
 // ====================================================================== Export
 export default function CodePreview({ block }) {
   const [selectedTab, setSelectedTab] = useState(0);
+  const [contentHeight, setContentHeight] = useState('unset');
+  const [contentInViewport, setContentInViewport] = useState(false);
+  const [copyMessage, setCopyMessage] = useState('');
+  const contentRef = useRef(/** @type {any} */ (null));
+
+  const calculateContentHeight = () => {
+    const height = contentRef.current.offsetHeight + 24 + 'px';
+    setContentHeight(height);
+  };
+
+  useEffect(() => {
+    const contentInViewportCheck = () => {
+      if (contentRef.current) {
+        const rect = contentRef.current.getBoundingClientRect();
+        if (rect.top >= 0 && rect.bottom <= (window.innerHeight || document.documentElement.clientHeight)) {
+          if (!contentInViewport) {
+            setContentInViewport(true);
+          }
+        }
+      }
+    };
+
+    setTimeout(() => {
+      calculateContentHeight();
+      contentInViewportCheck();
+    }, 1000);
+
+    const resize = () => {
+      calculateContentHeight();
+    };
+    const scroll = () => {
+      contentInViewportCheck();
+    };
+
+    window.addEventListener('resize', resize);
+    window.addEventListener('scroll', scroll);
+
+    return () => {
+      window.removeEventListener('resize', resize);
+      window.removeEventListener('scroll', scroll);
+    };
+  }, [contentInViewport]);
+
+  useEffect(() => {
+    calculateContentHeight();
+  }, [selectedTab]);
 
   const handleTabSelection = (e, ind) => {
     setSelectedTab(ind);
+    setCopyMessage('');
+  };
+
+  const fallbackCopyTextToClipboard = txt => {
+    if (typeof document !== 'undefined') {
+      const textArea = document.createElement('textarea');
+      textArea.value = txt;
+      textArea.style.top = '0';
+      textArea.style.left = '0';
+      textArea.style.position = 'fixed';
+
+      document.body.appendChild(textArea);
+      textArea.focus();
+      textArea.select();
+
+      try {
+        const successful = document.execCommand('copy');
+        const msg = successful ? 'Copied!' : 'Could not copy...';
+        setCopyMessage(msg);
+      } catch (err) {
+        console.error(err);
+      }
+
+      document.body.removeChild(textArea);
+    }
+  };
+
+  const copyToClipboard = txt => {
+    if (!navigator.clipboard) {
+      fallbackCopyTextToClipboard(txt);
+      return;
+    }
+    navigator.clipboard.writeText(txt).then(
+      function () {
+        setCopyMessage('Copied!');
+      },
+      function (err) {
+        setCopyMessage('Could not copy...');
+        console.error(err);
+      }
+    );
   };
 
   let highlightedCode = [];
   block.tabs.forEach((tab, i) => {
-    highlightedCode.push('');
+    highlightedCode.push({
+      html: '',
+      text: '',
+    });
+
     tab.lines.forEach((line, j) => {
       const spacing = `${j + 1 < 10 ? ' ' : ''}`;
       const lineNumber = `<span class="code-line-number">${j + 1 + spacing}</span>`;
-      const nextLine = `${lineNumber} ${hljs.highlight(line, { language: 'javascript' }).value}<br>`;
-      highlightedCode[i] = highlightedCode[i] + nextLine;
+      const nextLine =
+        j < tab.lines.length - 1
+          ? `${lineNumber} ${hljs.highlight(line, { language: 'javascript' }).value}<br>`
+          : contentInViewport
+          ? `${lineNumber} <span class="cp-typed">${line}<span class="cp-cursor">|</span></span><br>`
+          : `${lineNumber} <br>`;
+      highlightedCode[i].html = highlightedCode[i].html + nextLine;
+      highlightedCode[i].text = highlightedCode[i].text + '\n' + line;
     });
   });
-  const code = highlightedCode[selectedTab];
+
+  const code = highlightedCode[selectedTab].html;
+  const copyText = highlightedCode[selectedTab].text;
   const output = block.tabs[selectedTab].output;
 
   return (
@@ -49,17 +150,33 @@ export default function CodePreview({ block }) {
           </button>
         ))}
       </div>
-      <div className="code-preview-tab">
-        <pre>
-          <code dangerouslySetInnerHTML={{ __html: code }}></code>
-          {output && (
-            <>
-              <code> </code>
-              <code className="code-preview-output-label">{output.label}</code>
-              <code className="code-preview-output-value">{output.value}</code>
-            </>
-          )}
-        </pre>
+
+      <div className="code-preview-wrapper" style={{ height: contentHeight }}>
+        <div ref={contentRef} className="code-preview-content">
+          <pre>
+            <code dangerouslySetInnerHTML={{ __html: code }}></code>
+
+            <div className={clsx('cp-copy-icon', output ? 'before-output' : '')}>
+              <div className="cp-copy-message">{copyMessage}</div>
+              <button
+                onClick={() => {
+                  copyToClipboard(copyText);
+                }}
+              >
+                <CopyIcon />
+              </button>
+            </div>
+
+            {output && (
+              <>
+                <code> </code>
+                <code className="code-preview-output-label">{output.label}</code>
+
+                <code className="code-preview-output-value">{output.value}</code>
+              </>
+            )}
+          </pre>
+        </div>
       </div>
     </div>
   );

--- a/packages/website/components/codepreview/codepreview.scss
+++ b/packages/website/components/codepreview/codepreview.scss
@@ -13,6 +13,7 @@ $cpTabColor: #2a272e;
   display: flex;
   flex-direction: row;
   justify-content: flex-start;
+  height: 2.25rem;
 }
 
 .cp-thumb {
@@ -24,9 +25,9 @@ $cpTabColor: #2a272e;
   @include fontWeight_Semibold;
   letter-spacing: 0.07em;
   line-height: leading(17, 10);
-  border-radius: 0.25rem 0.25rem 0 0;
-  background-color: $cpTabColor;
   z-index: 1;
+  transform: translateY(0);
+  transition: 200ms ease;
   cursor: pointer;
 
   @include mini {
@@ -36,34 +37,69 @@ $cpTabColor: #2a272e;
     padding: 0.75rem 2rem 0.25rem 2rem;
   }
 
+  &:hover {
+    &:not(.cp-selected) {
+      transform: translateY(-0.5rem);
+    }
+  }
+
+  &:before {
+    content: '';
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: calc(100% + 0.5rem);
+    border-radius: 0.25rem 0.25rem 0 0;
+    background-color: $cpTabColor;
+    z-index: -1;
+  }
+
   &:after {
     content: '';
     position: absolute;
     right: 1px;
     top: 1px;
-    width: 2rem;
-    height: calc(100% - 2px);
+    width: 2.5rem;
+    height: calc(100% + 0.5rem);
     transform: translateX(50%);
     border-right: 1.25rem solid transparent;
     border-left: 1.25rem solid transparent;
-    border-bottom: 2rem solid $cpTabColor;
+    border-bottom: 2.6875rem solid $cpTabColor;
   }
   &.cp-selected {
-    background-color: $cpWindowColor;
+    &:before {
+      background-color: $cpWindowColor;
+    }
     z-index: 2;
     &:after {
-      border-bottom: 2rem solid $cpWindowColor;
+      border-bottom: 2.6875rem solid $cpWindowColor;
     }
   }
 }
 
 // //////////////////////////////////////////////////////////////////////// code
-.code-preview-tab {
+.code-preview-wrapper {
   position: relative;
   padding: 0.75rem;
   border-radius: 0 0.25rem 0.25rem 0.25rem;
   background-color: #1f1d29;
   z-index: 3;
+  transition: 200ms ease;
+  overflow: hidden;
+  &:before {
+    content: '';
+    position: absolute;
+    top: 0.75rem;
+    left: 0.75rem;
+    width: calc(100% - 1.5rem);
+    height: calc(100% - 1.5rem);
+    background-color: $ebony;
+  }
+}
+
+.code-preview-content {
+  position: relative;
   pre {
     background-color: $ebony;
     display: flex;
@@ -81,6 +117,12 @@ $cpTabColor: #2a272e;
     font-family: 'Suisse Intl Mono';
     font-size: 0.75rem;
     line-height: leading(28, 14);
+  }
+
+  &:hover {
+    .cp-copy-icon {
+      opacity: 1;
+    }
   }
 }
 
@@ -124,6 +166,42 @@ $cpTabColor: #2a272e;
   margin-left: 1.25rem;
 }
 
+.cp-copy-icon {
+  position: absolute;
+  display: flex;
+  right: 1.5rem;
+  bottom: 1.5rem;
+  opacity: 0;
+  transition: 200ms ease;
+
+  &.before-output {
+    transform: translateY(-4.5rem);
+  }
+  button {
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+  }
+  svg {
+    transform: scale(1.25);
+    opacity: 0.7;
+    transition: 200ms ease;
+  }
+  &:hover {
+    svg {
+      opacity: 1;
+    }
+  }
+}
+
+.cp-copy-message {
+  @include fontSize_Tiny;
+  font-family: 'SuisseIntl';
+  margin: 0 0.5rem;
+  line-height: 1;
+  opacity: 0.7;
+}
+
 // ////////////////////////////////////////////////////////////////// scroll bar
 pre::-webkit-scrollbar {
   height: 0.5rem;
@@ -138,4 +216,33 @@ pre::-webkit-scrollbar-thumb {
   background-color: $cpWindowColor;
   border-radius: 0.5rem;
   outline: 1px solid #333038;
+}
+
+// /////////////////////////////////////////////////////////////////// animation
+
+.cp-typed {
+  display: inline-flex;
+  white-space: nowrap;
+  line-height: leading(28, 14);
+  overflow: hidden;
+  width: 100%;
+  animation: type 5s steps(60, end);
+}
+
+.cp-cursor {
+  animation: blink 1s infinite;
+  @include fontSize_Regular;
+  line-height: 1.3;
+}
+
+@keyframes type {
+  from {
+    width: 0;
+  }
+}
+
+@keyframes blink {
+  to {
+    opacity: 0;
+  }
 }


### PR DESCRIPTION
Visual effects and animations added in this PR:

1. Height transition on the code preview window when switching tabs
2. Hover effect on inactive tabs ("Store" and "Retrieve")
3. The last line of code in the selected tab appears like it's being typed out when it enters the viewport and when switching tabs
4.  A 'copy to clipboard' button appears when hovering over the code block

Copy to clipboard functionality has also been added