### PR TITLE
chore: use miniflare for local dev

### DIFF
--- a/packages/api/.env.local.tpl
+++ b/packages/api/.env.local.tpl
@@ -1,0 +1,33 @@
+# Copy me to .env.local and fill out the missing values
+
+# Cloudflare worker variables for local testing with miniflare
+#
+# see: https://miniflare.dev/core/variables-secrets
+#  
+# Requires local cluster & postgres containers to be running
+#  _check docker is running_
+#  npm run cluster:start -w packages/api 
+#  npm start -w packages/db
+#
+# usage:
+#  npx miniflare --env .env.local
+
+# Crate a magic.link account and grab the secret key
+MAGIC_SECRET_KEY=
+
+# Open https://csprng.xyz/v1/api and use the value of `Data`, or just use this one. it's for dev, it's ok.
+SALT="Q6d8sTZa+wpIPrppPq6VdIKEbknjrsSCQklh/hVU4U0="
+
+# base64 test:test - the creds for the local cluster test container
+CLUSTER_BASIC_AUTH_TOKEN="dGVzdDp0ZXN0"
+
+# PostgREST API token, for role "postgres", using secret value PGRST_JWT_SECRET from './postgres/docker/docker-compose.yml' see: https://postgrest.org/en/v8.0/tutorials/tut1.html#step-3-sign-a-token
+PG_REST_JWT="eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJyb2xlIjoicG9zdGdyZXMifQ.oM0SXF31Vs1nfwCaDxjlczE237KcNKhTpKEYxMX-jEU"
+
+# no need for localtunnel, miniflare runs on localhost
+CLUSTER_API_URL=http://127.0.0.1:9094
+
+# no need for localtunnel, miniflare runs on localhost
+PG_REST_URL=http://127.0.0.1:3000
+
+ENV=dev

--- a/packages/api/README.md
+++ b/packages/api/README.md
@@ -4,7 +4,33 @@ The HTTP interface implemented as a Cloudflare Worker
 
 ## Getting started
 
-One time set up of your cloudflare worker subdomain for dev:
+We use miniflare to run the api locally, and docker to run ipfs-cluster and postgres with postREST.
+
+```sh
+# Copy <.env.local.tpl> to `.env.local` and fill out the missing worker vars.
+cp .env.local.tpl .env.local
+
+# Install the deps
+npm install
+```
+
+With docker running locally, start all the things:
+
+```
+npm start
+```
+
+🎉 miniflare is running in watch mode; you can save changes to the api code and the worker will update.
+
+Kill the process to stop miniflare, then run `npm run stop` to shutdown the cluster and postgres
+
+```sh
+npm run stop
+```
+
+## Setting up a cloudflare worker
+
+One time set up of your cloudflare worker subdomain. You only need to do this if you want to test in a real cloudflare worker.
 
 - `npm install` - Install the project dependencies
 - Sign up to Cloudflare and log in with your default browser.

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -9,7 +9,8 @@
     "lt": "npm-run-all -p lt:*",
     "lt:cluster": "npx localtunnel --port 9094 --subdomain \"$(whoami)-cluster-api-web3-storage\"",
     "lt:postgres": "npx localtunnel --port 3000 --subdomain \"$(whoami)-postgres-api-web3-storage\"",
-    "start": "wrangler dev --env $(whoami)",
+    "start": "npm-run-all -p cluster:start pg:start -s miniflare",
+    "stop": "npm-run-all -p cluster:stop pg:stop",
     "dev": "wrangler dev --env $(whoami)",
     "publish": "wrangler publish --env $(whoami)",
     "build": "node scripts/cli.js build",
@@ -19,7 +20,10 @@
     "mock:backup": "smoke -p 9096 test/mocks/backup",
     "cluster:start": "web3-storage-tools cluster --start",
     "cluster:stop": "web3-storage-tools cluster --stop",
-    "cluster:reset": "web3-storage-tools cluster --clean"
+    "cluster:reset": "web3-storage-tools cluster --clean",
+    "pg:start": "cd ../db && npm start",
+    "pg:stop": "cd ../db && npm run stop",
+    "miniflare": "miniflare --env .env.local --watch"
   },
   "devDependencies": {
     "@sentry/cli": "^1.72.1",


### PR DESCRIPTION
- add a .env.local file to configure miniflare for local dev.
- update README with a much simpler "Getting Started" path.

Having just waded through the old getting started process again, this is *so much better* and I love it.


License: (Apache-2.0 AND MIT)
Signed-off-by: Oli Evans <oli@tableflip.io>