### PR TITLE
fix Message banner dynamic height

### DIFF
--- a/packages/website/components/messagebanner/messagebanner.js
+++ b/packages/website/components/messagebanner/messagebanner.js
@@ -111,7 +111,7 @@ export default function MessageBanner() {
               className={clsx(
                 'message-banner-content',
                 maintenanceMessage ? 'banner-alert' : '',
-                wasPreviouslyClosed ? 'mb-previously-closed' : ''
+                wasPreviouslyClosed && !maintenanceMessage ? 'mb-previously-closed' : ''
               )}
               style={{
                 transform: `translateY(${messageBannerWasClicked && !maintenanceMessage ? '-' + bannerHeight : 0})`,

--- a/packages/website/components/messagebanner/messagebanner.js
+++ b/packages/website/components/messagebanner/messagebanner.js
@@ -1,5 +1,5 @@
 // ===================================================================== Imports
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import { useQuery } from 'react-query';
 import clsx from 'clsx';
 
@@ -11,6 +11,9 @@ import GeneralPageData from '../../content/pages/general.json';
 // ===================================================================== Exports
 export default function MessageBanner() {
   const [messageBannerWasClicked, setMessageBannerWasClicked] = useState(false);
+  const [wasPreviouslyClosed, setWasPreviouslyClosed] = useState(false);
+  const [bannerHeight, setBannerHeight] = useState('unset');
+  const messageBannerRef = useRef(/** @type {any} */ (null));
   const bannerPrompt = GeneralPageData.message_banner.content;
   const maintenceAlert = GeneralPageData.message_banner.maintenceAlert;
   let link = GeneralPageData.message_banner.url;
@@ -27,9 +30,29 @@ export default function MessageBanner() {
 
       if (bannerPrompt === oldMessage && elapsedTime < 604800000) {
         setMessageBannerWasClicked(true);
+        setWasPreviouslyClosed(true);
       }
     }
   }, [bannerPrompt]);
+
+  const calculateBannerHeight = time => {
+    if (messageBannerRef.current) {
+      setBannerHeight('unset');
+      setTimeout(() => {
+        const height = messageBannerRef.current.clientHeight;
+        setBannerHeight(height + 'px');
+      }, time);
+    }
+  };
+
+  useEffect(() => {
+    calculateBannerHeight(1000);
+    const resize = () => {
+      calculateBannerHeight(100);
+    };
+    window.addEventListener('resize', resize);
+    return () => window.removeEventListener('resize', resize);
+  }, [messageBannerRef]);
 
   const { data: statusPageData, error: statusPageError } = useQuery('get-statuspage-summary', () =>
     getStatusPageSummary()
@@ -71,27 +94,33 @@ export default function MessageBanner() {
     setMessageBannerWasClicked(true);
   };
 
+  const CustomElement = maintenanceMessage ? 'div' : 'a';
+
   return (
     <section
       id="section_message-banner"
-      className={clsx(!messageBannerWasClicked || maintenanceMessage ? 'show-message-banner' : '')}
+      ref={messageBannerRef}
+      style={{ height: !messageBannerWasClicked || maintenanceMessage ? bannerHeight : 0 }}
     >
       <div className="grid-noGutter">
         <div className="col">
           <div className="message-banner-container">
-            <a
+            <CustomElement
               href={link}
               target="_blank"
               className={clsx(
                 'message-banner-content',
                 maintenanceMessage ? 'banner-alert' : '',
-                'message-banner-transition'
+                wasPreviouslyClosed ? 'mb-previously-closed' : ''
               )}
+              style={{
+                transform: `translateY(${messageBannerWasClicked && !maintenanceMessage ? '-' + bannerHeight : 0})`,
+              }}
               dangerouslySetInnerHTML={{ __html: bannerContent }}
               onClick={() => messageBannerClick(bannerPrompt)}
               onKeyPress={() => messageBannerClick(bannerPrompt)}
               rel="noreferrer"
-            ></a>
+            ></CustomElement>
           </div>
         </div>
       </div>
@@ -99,8 +128,7 @@ export default function MessageBanner() {
       <button
         className={clsx(
           'message-banner-close-button',
-          'message-banner-transition',
-          maintenanceMessage ? 'hide-banner-close' : ''
+          maintenanceMessage || messageBannerWasClicked ? 'hide-banner-close' : ''
         )}
         onClick={() => messageBannerClick(bannerPrompt)}
         onKeyPress={() => messageBannerClick(bannerPrompt)}

--- a/packages/website/components/messagebanner/messagebanner.js
+++ b/packages/website/components/messagebanner/messagebanner.js
@@ -111,7 +111,8 @@ export default function MessageBanner() {
               className={clsx(
                 'message-banner-content',
                 maintenanceMessage ? 'banner-alert' : '',
-                wasPreviouslyClosed && !maintenanceMessage ? 'mb-previously-closed' : ''
+                wasPreviouslyClosed && !maintenanceMessage ? 'mb-previously-closed' : '',
+                bannerContent.length > 120 ? 'mb-reduced-fontsize' : ''
               )}
               style={{
                 transform: `translateY(${messageBannerWasClicked && !maintenanceMessage ? '-' + bannerHeight : 0})`,

--- a/packages/website/components/messagebanner/messagebanner.scss
+++ b/packages/website/components/messagebanner/messagebanner.scss
@@ -1,18 +1,8 @@
-$messageBannerHeight: 3.25rem;
-
 #section_message-banner {
   background-color: $ebony;
   position: relative;
   z-index: 100;
-  height: 0rem;
   transition: 200ms ease;
-
-  &.show-message-banner {
-    height: $messageBannerHeight;
-    .message-banner-transition {
-      transform: translateY(0);
-    }
-  }
 
   ::-moz-selection {
     background-color: $white;
@@ -34,11 +24,16 @@ $messageBannerHeight: 3.25rem;
   justify-content: center;
   padding: 0.53125rem 0;
   color: white;
+  @include small {
+    padding: 0.53125rem 2rem;
+  }
 }
+
 .message-banner-content {
   margin: auto 0;
   display: inline;
   text-align: center;
+  transition: 200ms ease;
   @include fontSize_Small;
   @include fontWeight_Medium;
   .banner-gradient-text {
@@ -60,6 +55,10 @@ $messageBannerHeight: 3.25rem;
       }
     }
   }
+
+  &.mb-previously-closed {
+    transform: translateY(-150%) !important;
+  }
 }
 
 .message-banner-close-button {
@@ -74,9 +73,4 @@ $messageBannerHeight: 3.25rem;
   &.hide-banner-close {
     display: none;
   }
-}
-
-.message-banner-transition {
-  transform: translateY(-1 * $messageBannerHeight);
-  transition: 200ms ease;
 }

--- a/packages/website/components/messagebanner/messagebanner.scss
+++ b/packages/website/components/messagebanner/messagebanner.scss
@@ -59,6 +59,10 @@
   &.mb-previously-closed {
     transform: translateY(-150%) !important;
   }
+
+  &.mb-reduced-fontsize {
+    @include fontSize_Tiny;
+  }
 }
 
 .message-banner-close-button {

--- a/packages/website/next-env.d.ts
+++ b/packages/website/next-env.d.ts
@@ -1,5 +1,4 @@
 /// <reference types="next" />
-/// <reference types="next/types/global" />
 /// <reference types="next/image-types/global" />
 
 // NOTE: This file should not be edited


### PR DESCRIPTION
A fix to add dynamic height to the message banner while still preserving animation on close. The component now calculates and sets its height using an useEffect hook. This enables a css transition with the height value not known beforehand. Also font size is reduced to 13pt for messages above 120 characters.