### PR TITLE
style: data progress bar animation

### DIFF
--- a/packages/website/components/account/storageManager/storageManager.scss
+++ b/packages/website/components/account/storageManager/storageManager.scss
@@ -141,9 +141,23 @@
   }
 }
 .storage-manager-meter-used {
-  @include gradient_Background_BluePurple;
+  background: linear-gradient(
+    45deg,
+    $cyan 0%,
+    $royalBlue 12.5%,
+    $heliotrope 25%,
+    $cyan 37.5%,
+    $royalBlue 50%,
+    $heliotrope 62.5%,
+    $cyan 75%,
+    $royalBlue 87.5%,
+    $heliotrope 100%
+  );
+  background-size: 410%;
+  background-position: 50% 0;
   @include borderRadius_UltraLarge;
   height: 1.5rem;
   top: 0;
   left: 0;
+  transition: 250ms ease-out;
 }

--- a/packages/website/components/account/storageManager/storageManager.tsx
+++ b/packages/website/components/account/storageManager/storageManager.tsx
@@ -37,7 +37,7 @@ const StorageManager = ({ className = '', content }: StorageManagerProps) => {
   });
   const usedStorage = useMemo(() => data?.usedStorage || 0, [data]);
   const [componentInViewport, setComponentInViewport] = useState(false);
-  const storageManagerRef = useRef<HTMLElement>(null);
+  const storageManagerRef = useRef<HTMLDivElement>(null);
 
   const { maxSpaceLabel, unlockLabel, usedSpacePercentage } = useMemo<{
     maxSpaceLabel: string;
@@ -68,11 +68,15 @@ const StorageManager = ({ className = '', content }: StorageManagerProps) => {
 
   useEffect(() => {
     setTimeout(() => {
-      setComponentInViewport(elementIsInViewport(storageManagerRef.current));
+      const result = elementIsInViewport(storageManagerRef.current);
+      setComponentInViewport(result);
     }, 1000);
     const scroll = () => {
       if (!componentInViewport) {
-        setComponentInViewport(elementIsInViewport(storageManagerRef.current));
+        const result = elementIsInViewport(storageManagerRef.current);
+        if (componentInViewport !== result) {
+          setComponentInViewport(result);
+        }
       }
     };
     window.addEventListener('scroll', scroll);

--- a/packages/website/components/card/card-tier.js
+++ b/packages/website/components/card/card-tier.js
@@ -1,0 +1,134 @@
+// ===================================================================== Imports
+import { useCallback, useEffect, useState, useRef, useMemo } from 'react';
+import { useRouter } from 'next/router';
+import clsx from 'clsx';
+
+import Button from '../button/button';
+import countly from '../../lib/countly';
+import { elementIsInViewport } from '../../lib/utils.js';
+
+// ====================================================================== Params
+/**
+ * @param {Object} props
+ * @param {Object} props.card
+ * @param {Object} props.cardsGroup
+ * @param {number} props.index
+ * @param {any} props.onCardLoad
+ */
+// ====================================================================== Export
+export default function Card({ card, cardsGroup = [], index = 0, onCardLoad }) {
+  const [cardIsInViewport, setCardIsInViewport] = useState(false);
+  const cardRef = useRef(/** @type {any} */ (null));
+  const router = useRouter();
+  const tracking = {};
+  if (typeof card.cta === 'object') {
+    if (card.cta.event) {
+      tracking.event = countly.events[card.cta.event];
+    }
+    if (card.cta.ui) {
+      tracking.ui = countly.ui[card.cta.ui];
+    }
+    if (card.cta.action) {
+      tracking.action = card.cta.action;
+    }
+  }
+  // ================================================================= Functions
+  useEffect(() => {
+    if (onCardLoad) {
+      onCardLoad('loaded');
+    }
+  }, [onCardLoad]);
+
+  const handleButtonClick = useCallback(
+    cta => {
+      if (cta.url) {
+        router.push(cta.url);
+      }
+    },
+    [router]
+  );
+
+  const progressBarWidth = useMemo(() => {
+    const len = cardsGroup.length;
+    let sum = 0;
+    let weight = 0;
+
+    for (let i = 0; i < index + 1; i++) {
+      weight = weight + (i + 1);
+    }
+    for (let i = 0; i < len; i++) {
+      sum = sum + (i + 1);
+    }
+    return Math.round((weight / sum) * 75);
+  }, [cardsGroup, index]);
+
+  useEffect(() => {
+    setCardIsInViewport(elementIsInViewport(cardRef.current));
+    const scroll = () => {
+      if (!cardIsInViewport) {
+        setCardIsInViewport(elementIsInViewport(cardRef.current));
+      }
+    };
+    window.addEventListener('scroll', scroll);
+    return () => {
+      window.removeEventListener('scroll', scroll);
+    };
+  }, [cardIsInViewport]);
+
+  const cardStyles = {
+    width: !cardIsInViewport ? '2.5rem' : `${progressBarWidth}%`,
+    transition: `${progressBarWidth * 25}ms ease-out`,
+    backgroundPosition: !cardIsInViewport ? '0 0' : `-75% 0`,
+  };
+
+  // ========================================================= Templates [Cards]
+  return (
+    <div ref={cardRef} className={clsx('card', `type__${card.type}`)}>
+      <div className="grid-middle-noGutter">
+        <div className="col-12">
+          <div className={'feature_storage-bar'}>
+            <div className={'feature_storage-bar-highlight'} style={cardStyles}></div>
+
+            {cardsGroup.map((card, j) => (
+              <div key={card.title} className="storage-bar-tier">
+                <span className={clsx('storage-bar-tier-label', index < j ? 'display' : '')}>{card.title}</span>
+              </div>
+            ))}
+          </div>
+        </div>
+
+        <div className="col-4_md-5_sm-6_mi-12">
+          <div className={'card_panel-left'}>
+            {card.label && <div className="label">{card.label}</div>}
+
+            {card.title && <div className="title">{card.title}</div>}
+
+            {card.description && (
+              <div className="description" dangerouslySetInnerHTML={{ __html: card.description }}></div>
+            )}
+
+            {card.cta && (
+              <Button
+                className={'cta'}
+                variant={card.cta.theme}
+                tracking={tracking}
+                onClick={() => handleButtonClick(card.cta)}
+                onKeyPress={() => handleButtonClick(card.cta)}
+              >
+                {card.cta.text}
+              </Button>
+            )}
+          </div>
+        </div>
+
+        <div className="col-7_sm-6_mi-0">
+          <div className={'card_panel-right'}>
+            {card.description && (
+              <div className="description" dangerouslySetInnerHTML={{ __html: card.description }}></div>
+            )}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/packages/website/components/card/card-tier.js
+++ b/packages/website/components/card/card-tier.js
@@ -66,7 +66,10 @@ export default function Card({ card, cardsGroup = [], index = 0, onCardLoad }) {
     setCardIsInViewport(elementIsInViewport(cardRef.current));
     const scroll = () => {
       if (!cardIsInViewport) {
-        setCardIsInViewport(elementIsInViewport(cardRef.current));
+        const result = elementIsInViewport(cardRef.current);
+        if (cardIsInViewport !== result) {
+          setCardIsInViewport(result);
+        }
       }
     };
     window.addEventListener('scroll', scroll);

--- a/packages/website/components/card/card.js
+++ b/packages/website/components/card/card.js
@@ -5,6 +5,7 @@ import clsx from 'clsx';
 import Image from 'next/image';
 import Link from 'next/link';
 
+import CardTier from './card-tier';
 import Button from '../button/button';
 import NpmIcon from '../../assets/icons/npmicon';
 import Windows from '../../assets/icons/windows';
@@ -138,67 +139,7 @@ export default function Card({ card, cardsGroup = [], index = 0, targetClass, on
 
   // ========================================================= Templates [Cards]
   if (card.type === 'E') {
-    const len = cardsGroup.length;
-    let sum = 0;
-    let weight = 0;
-
-    for (let i = 0; i < index + 1; i++) {
-      weight = weight + (i + 1);
-    }
-    for (let i = 0; i < len; i++) {
-      sum = sum + (i + 1);
-    }
-    const width = Math.round((weight / sum) * 75) + '%';
-
-    return (
-      <div className={clsx('card', `type__${card.type}`)}>
-        <div className="grid-middle-noGutter">
-          <div className="col-12">
-            <div className={'feature_storage-bar'}>
-              <div className={'feature_storage-bar-highlight'} style={{ width: width }}></div>
-
-              {cardsGroup.map((card, j) => (
-                <div key={card.title} className="storage-bar-tier">
-                  <span className={clsx('storage-bar-tier-label', index < j ? 'display' : '')}>{card.title}</span>
-                </div>
-              ))}
-            </div>
-          </div>
-
-          <div className="col-4_md-5_sm-6_mi-12">
-            <div className={'card_panel-left'}>
-              {card.label && <div className="label">{card.label}</div>}
-
-              {card.title && <div className="title">{card.title}</div>}
-
-              {card.description && (
-                <div className="description" dangerouslySetInnerHTML={{ __html: card.description }}></div>
-              )}
-
-              {card.cta && (
-                <Button
-                  className={'cta'}
-                  variant={card.cta.theme}
-                  tracking={tracking}
-                  onClick={() => handleButtonClick(card.cta)}
-                  onKeyPress={() => handleButtonClick(card.cta)}
-                >
-                  {card.cta.text}
-                </Button>
-              )}
-            </div>
-          </div>
-
-          <div className="col-7_sm-6_mi-0">
-            <div className={'card_panel-right'}>
-              {card.description && (
-                <div className="description" dangerouslySetInnerHTML={{ __html: card.description }}></div>
-              )}
-            </div>
-          </div>
-        </div>
-      </div>
-    );
+    return <CardTier card={card} cardsGroup={cardsGroup} index={index} onCardLoad={onCardLoad} />;
   }
 
   return (

--- a/packages/website/components/card/card.scss
+++ b/packages/website/components/card/card.scss
@@ -295,12 +295,24 @@
       position: absolute;
       top: -1px;
       left: 0;
-      width: 3rem;
+      width: 2.5rem;
       height: calc(100% + 2px);
       border-radius: 1.125rem;
-      background: linear-gradient(80deg, #1ffbff 0%, #4880ff 50%, #9c48ff 100%);
+      background: linear-gradient(
+        80deg,
+        #1ffbff 0%,
+        #4880ff 17%,
+        #9c48ff 34%,
+        #1ffbff 50%,
+        #4880ff 67%,
+        #9c48ff 83%,
+        #1ffbff 100%
+      );
+      background-size: 300%;
+      background-position: 0 0;
       box-shadow: 0 2px 8px rgba(#210f55, 0.33);
       z-index: 1;
+      transition: 250ms ease-out;
     }
 
     .storage-bar-tier {

--- a/packages/website/components/codepreview/codepreview.js
+++ b/packages/website/components/codepreview/codepreview.js
@@ -4,6 +4,7 @@ import clsx from 'clsx';
 import hljs from 'highlight.js/lib/core';
 import javascript from 'highlight.js/lib/languages/javascript';
 
+import { elementIsInViewport } from '../../lib/utils.js';
 import CopyIcon from '../../assets/icons/copy.js';
 
 hljs.registerLanguage('javascript', javascript);
@@ -27,13 +28,8 @@ export default function CodePreview({ block }) {
 
   useEffect(() => {
     const contentInViewportCheck = () => {
-      if (contentRef.current) {
-        const rect = contentRef.current.getBoundingClientRect();
-        if (rect.top >= 0 && rect.bottom <= (window.innerHeight || document.documentElement.clientHeight)) {
-          if (!contentInViewport) {
-            setContentInViewport(true);
-          }
-        }
+      if (!contentInViewport) {
+        setContentInViewport(elementIsInViewport(contentRef.current));
       }
     };
 

--- a/packages/website/lib/utils.js
+++ b/packages/website/lib/utils.js
@@ -80,3 +80,15 @@ export const standardizeSiblingHeights = (target, reset) => {
     }
   }
 }
+
+/**
+ * Utility to check if element is in viewport
+ *
+ * @param {HTMLElement} element element to test
+ */
+export const elementIsInViewport = (element) => {
+  if (element && typeof window !== 'undefined' && typeof document !== 'undefined') {
+    const rect = element.getBoundingClientRect();
+    return (rect.top >= 0 && rect.bottom <= (window.innerHeight || document.documentElement.clientHeight))
+  }
+}

--- a/packages/website/lib/utils.js
+++ b/packages/website/lib/utils.js
@@ -84,11 +84,13 @@ export const standardizeSiblingHeights = (target, reset) => {
 /**
  * Utility to check if element is in viewport
  *
- * @param {HTMLElement} element element to test
+ * @param {any} element element to test
+ * @returns {boolean}
  */
 export const elementIsInViewport = (element) => {
   if (element && typeof window !== 'undefined' && typeof document !== 'undefined') {
     const rect = element.getBoundingClientRect();
     return (rect.top >= 0 && rect.bottom <= (window.innerHeight || document.documentElement.clientHeight))
   }
+  return false
 }

--- a/packages/website/next-env.d.ts
+++ b/packages/website/next-env.d.ts
@@ -1,5 +1,4 @@
 /// <reference types="next" />
-/// <reference types="next/types/global" />
 /// <reference types="next/image-types/global" />
 
 // NOTE: This file should not be edited


### PR DESCRIPTION
Added animations to storage progress bars in tiers cards and the storage manager in the app ui. When cards first enter the viewport the progress bar now animates from 0 to its intended width. I added the function for checking if an element is in the viewport to `lib/utils` for use in the future.