### PR TITLE
fix: version endpoint info

### DIFF
--- a/.github/workflows/api.yml
+++ b/.github/workflows/api.yml
@@ -45,6 +45,7 @@ jobs:
         # workaround for https://github.com/cloudflare/wrangler-action/issues/59 to use node 16
         uses: web3-storage/wrangler-action@node16
         env:
+          ENV: 'staging' # inform the build process what the env is
           SENTRY_TOKEN: ${{ secrets.SENTRY_TOKEN}}
           SENTRY_UPLOAD: ${{ secrets.SENTRY_UPLOAD}}
         with:
@@ -84,6 +85,7 @@ jobs:
         # workaround for https://github.com/cloudflare/wrangler-action/issues/59 to use node 16
         uses: web3-storage/wrangler-action@node16
         env:
+          ENV: 'production' # inform the build process what the env is
           SENTRY_TOKEN: ${{ secrets.SENTRY_TOKEN}}
           SENTRY_UPLOAD: ${{ secrets.SENTRY_UPLOAD}}
         with:

--- a/packages/api/scripts/cli.js
+++ b/packages/api/scripts/cli.js
@@ -23,6 +23,7 @@ prog
     // custom prefix here not pkg.name.
     // See https://docs.sentry.io/platforms/javascript/guides/cordova/configuration/releases/
     const sentryRelease = `web3-api@${pkg.version}-${opts.env}+${git.short(__dirname)}`
+    console.log(`Building ${sentryRelease}`)
 
     await build({
       entryPoints: [path.join(__dirname, '..', 'src', 'index.js')],
@@ -58,6 +59,7 @@ prog
 
     // Sentry release and sourcemap upload
     if (process.env.SENTRY_UPLOAD === 'true') {
+      console.log(`Uploading to Sentry ${sentryRelease}`)
       const cli = new Sentry(undefined, {
         authToken: process.env.SENTRY_TOKEN,
         org: 'protocol-labs-it',

--- a/packages/api/scripts/cli.js
+++ b/packages/api/scripts/cli.js
@@ -17,7 +17,7 @@ const prog = sade('api')
 prog
   .command('build')
   .describe('Build the worker.')
-  .option('--env', 'Environment', 'dev')
+  .option('--env', 'Environment', process.env.ENV)
   .action(async (opts) => {
     // Release name cannot contain slashes, and are global per org, so we use
     // custom prefix here not pkg.name.

--- a/packages/api/scripts/cli.js
+++ b/packages/api/scripts/cli.js
@@ -49,7 +49,6 @@ prog
         VERSION: JSON.stringify(version),
         COMMITHASH: JSON.stringify(git.long(__dirname)),
         BRANCH: JSON.stringify(git.branch(__dirname)),
-        ENV: opts.env || 'dev',
         global: 'globalThis'
       },
       minify: opts.env !== 'dev',

--- a/packages/api/scripts/cli.js
+++ b/packages/api/scripts/cli.js
@@ -22,7 +22,7 @@ prog
     // Release name cannot contain slashes, and are global per org, so we use
     // custom prefix here not pkg.name.
     // See https://docs.sentry.io/platforms/javascript/guides/cordova/configuration/releases/
-    const version = `web3-api@${pkg.version}-${opts.env}+${git.short(__dirname)}`
+    const sentryRelease = `web3-api@${pkg.version}-${opts.env}+${git.short(__dirname)}`
 
     await build({
       entryPoints: [path.join(__dirname, '..', 'src', 'index.js')],
@@ -46,7 +46,8 @@ prog
         }
       }],
       define: {
-        VERSION: JSON.stringify(version),
+        SENTRY_RELEASE: JSON.stringify(sentryRelease),
+        VERSION: JSON.stringify(pkg.version),
         COMMITHASH: JSON.stringify(git.long(__dirname)),
         BRANCH: JSON.stringify(git.branch(__dirname)),
         global: 'globalThis'
@@ -64,18 +65,18 @@ prog
         dist: git.short(__dirname)
       })
 
-      await cli.releases.new(version)
-      await cli.releases.setCommits(version, {
+      await cli.releases.new(sentryRelease)
+      await cli.releases.setCommits(sentryRelease, {
         auto: true,
         ignoreEmpty: true,
         ignoreMissing: true
       })
-      await cli.releases.uploadSourceMaps(version, {
+      await cli.releases.uploadSourceMaps(sentryRelease, {
         include: [path.join(__dirname, '..', 'dist')],
         urlPrefix: '/'
       })
-      await cli.releases.finalize(version)
-      await cli.releases.newDeploy(version, { env: opts.env })
+      await cli.releases.finalize(sentryRelease)
+      await cli.releases.newDeploy(sentryRelease, { env: opts.env })
     }
   })
 

--- a/packages/api/src/env.js
+++ b/packages/api/src/env.js
@@ -1,4 +1,4 @@
-/* global BRANCH, VERSION, COMMITHASH */
+/* global BRANCH, VERSION, COMMITHASH, SENTRY_RELEASE */
 import Toucan from 'toucan-js'
 import { S3Client } from '@aws-sdk/client-s3/dist-es/S3Client.js'
 import { Magic } from '@magic-sdk/admin'
@@ -72,6 +72,7 @@ export function envAll (req, env, ctx) {
   env.BRANCH = BRANCH
   env.VERSION = VERSION
   env.COMMITHASH = COMMITHASH
+  env.SENTRY_RELEASE = SENTRY_RELEASE
 
   env.sentry = env.SENTRY_DSN && new Toucan({
     dsn: env.SENTRY_DSN,

--- a/packages/api/src/env.js
+++ b/packages/api/src/env.js
@@ -1,3 +1,4 @@
+/* global BRANCH, VERSION, COMMITHASH */
 import Toucan from 'toucan-js'
 import { S3Client } from '@aws-sdk/client-s3/dist-es/S3Client.js'
 import { Magic } from '@magic-sdk/admin'
@@ -67,6 +68,11 @@ import pkg from '../package.json'
  * @param {import('./index.js').Ctx} ctx
  */
 export function envAll (req, env, ctx) {
+  // These values are replaced at build time by esbuild `define`
+  env.BRANCH = BRANCH
+  env.VERSION = VERSION
+  env.COMMITHASH = COMMITHASH
+
   env.sentry = env.SENTRY_DSN && new Toucan({
     dsn: env.SENTRY_DSN,
     context: ctx,

--- a/packages/api/test/scripts/worker-globals.js
+++ b/packages/api/test/scripts/worker-globals.js
@@ -1,7 +1,4 @@
 export const ENV = 'dev'
-export const BRANCH = 'test'
-export const VERSION = 'test'
-export const COMMITHASH = 'test'
 export const MAINTENANCE_MODE = 'rw'
 export const SALT = 'test-salt'
 export const MAGIC_SECRET_KEY = 'test-magic-secret-key'

--- a/packages/api/test/version.spec.js
+++ b/packages/api/test/version.spec.js
@@ -6,7 +6,7 @@ import { fileURLToPath } from 'url'
 import git from 'git-rev-sync'
 import fetch from '@web-std/fetch'
 import { endpoint } from './scripts/constants.js'
-import { MAINTENANCE_MODE, ENV } from './scripts/worker-globals.js'
+import { MAINTENANCE_MODE } from './scripts/worker-globals.js'
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
 const pkg = JSON.parse(fs.readFileSync(path.join(__dirname, '..', 'package.json'), 'utf8'))
@@ -16,7 +16,7 @@ describe('GET /version', () => {
     const res = await fetch(new URL('version/', endpoint))
     assert(res.ok)
     const { version, commit, branch, mode } = await res.json()
-    assert.strictEqual(version, `web3-api@${pkg.version}-${ENV}+${git.short(__dirname)}`)
+    assert.strictEqual(version, pkg.version)
     assert.strictEqual(commit, git.long(__dirname))
     assert.strictEqual(branch, git.branch(__dirname))
     assert.strictEqual(mode, MAINTENANCE_MODE)

--- a/packages/api/test/version.spec.js
+++ b/packages/api/test/version.spec.js
@@ -1,22 +1,24 @@
 /* eslint-env mocha */
 import assert from 'assert'
+import fs from 'fs'
+import path from 'path'
+import { fileURLToPath } from 'url'
+import git from 'git-rev-sync'
 import fetch from '@web-std/fetch'
 import { endpoint } from './scripts/constants.js'
-import {
-  VERSION,
-  COMMITHASH,
-  BRANCH,
-  MAINTENANCE_MODE
-} from './scripts/worker-globals.js'
+import { MAINTENANCE_MODE, ENV } from './scripts/worker-globals.js'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+const pkg = JSON.parse(fs.readFileSync(path.join(__dirname, '..', 'package.json'), 'utf8'))
 
 describe('GET /version', () => {
   it('retrieves version', async () => {
     const res = await fetch(new URL('version/', endpoint))
     assert(res.ok)
     const { version, commit, branch, mode } = await res.json()
-    assert.strictEqual(version, VERSION)
-    assert.strictEqual(commit, COMMITHASH)
-    assert.strictEqual(branch, BRANCH)
+    assert.strictEqual(version, `web3-api@${pkg.version}-${ENV}+${git.short(__dirname)}`)
+    assert.strictEqual(commit, git.long(__dirname))
+    assert.strictEqual(branch, git.branch(__dirname))
     assert.strictEqual(mode, MAINTENANCE_MODE)
   })
 })


### PR DESCRIPTION
tweak the esbuild define config to set the git info in the api build.

The `define` api only replaces the exact token, where it finds it seperated by whitespace, with the exact value provided. So the key `VERSION` was not matching on `env.VERSION`, so our envAll function now sets these values on the env for us by pulling them from magic globals that esbuild will set.

I removed the `define` config for ENV as i'm pretty sure that is set at runtime by cloudflare/miniflare and we shouldn't be attempting to burn it into the worker bundle, but would like someone to sanity check me there.

```console
❯ curl "https://api.web3.storage/version"
{"mode":"rw"}

❯ curl "http://127.0.0.1:8787/version"
{"version":"web3-api@5.1.4-dev+9068490","commit":"9068490aaa4dbe037e8e6aa9eaad706a46f11aed","branch":"main","mode":"rw"}
```

see: https://esbuild.github.io/api/#define

fixes: #1016 

License: (Apache-2.0 AND MIT)
Signed-off-by: Oli Evans <oli@tableflip.io>