### PR TITLE
fix: remove availability column

### DIFF
--- a/packages/website/pages/files.js
+++ b/packages/website/pages/files.js
@@ -44,8 +44,7 @@ const QuestionMark = () => (
 )
 
 const TOOLTIPS = {
-  PIN_STATUS: (<span>Reports the status of a file or piece of data stored on Web3.Storage’s IPFS Cluster. Status might not be fully up-to-date. Data is still available even when still in Queuing state.</span>),
-  AVAILABILITY: (<span>Reports the status of a file or piece of data stored on Web3.Storage’s IPFS nodes.</span>),
+  PIN_STATUS: (<span>Reports the status of a file or piece of data stored on Web3.Storage’s IPFS Cluster. Status might not be fully up-to-date. Data will be available on IPFS even when still in Queuing state provided the uploaded completed successfully.</span>),
 
   CID: (<span>
     The <strong>c</strong>ontent <strong>id</strong>entifier for a file or a piece of data.<span> </span>
@@ -270,11 +269,6 @@ const UploadItem = ({ upload, index, toggle, selectedFiles, showCopiedMessage })
       </TableElement>
       <TableElement {...sharedArgs} centered>
         <span className="flex justify-center">
-          Available
-        </span>
-      </TableElement>
-      <TableElement {...sharedArgs} centered>
-        <span className="flex justify-center">
           {pinStatus}
           {getPinStatusTooltip(pinStatus, upload.pins.length)}
         </span>
@@ -429,13 +423,6 @@ export default function Files({ isLoggedIn }) {
             <span className="flex w-100 justify-center items-center">CID
               <Tooltip placement='top' overlay={TOOLTIPS.CID} overlayClassName='table-tooltip'>
                 { QuestionMark() }
-              </Tooltip>
-            </span>
-          </TableHeader>
-          <TableHeader>
-            <span className="flex w-100 justify-center">Availability
-              <Tooltip placement='top' overlay={TOOLTIPS.AVAILABILITY} overlayClassName='table-tooltip'>
-                {QuestionMark()}
               </Tooltip>
             </span>
           </TableHeader>


### PR DESCRIPTION
It has traditionally taken a while to get an updated pin status for an upload. It's due to a number of reasons which we're working to resolve.

_Often times_ when an upload has a pin status of `PinQueued` it IS actually already available on IPFS. _However_, this is not ALWAYS the case. If a large upload comprising of multiple CARs does not complete fully then the status will remain as `PinQueued`/`PinError` and since we haven't received all the data is is NOT available on IPFS (and will never be unless the upload is retried).

IMHO we should NEVER say that something is available when there is a chance it is not. Lets temporarily remove this column until we can communicate availability beetter without misleading users.