### PR TITLE
docs: browser CDN example

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4145,12 +4145,6 @@
       "integrity": "sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==",
       "license": "MIT"
     },
-    "node_modules/@types/parse-link-header": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@types/parse-link-header/-/parse-link-header-1.0.1.tgz",
-      "integrity": "sha512-E2+Go9rQgPbmpkeA2iFXTWSTxX38KXlXwcdiIbt71Oorqr+G5QtH4AhpuDdxwRVyiTzdUrHnaaIumW/LhiZwVg==",
-      "dev": true
-    },
     "node_modules/@types/pbkdf2": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/@types/pbkdf2/-/pbkdf2-3.1.0.tgz",
@@ -4362,6 +4356,11 @@
       "resolved": "https://registry.npmjs.org/@web3-storage/multipart-parser/-/multipart-parser-1.0.0.tgz",
       "integrity": "sha512-BEO6al7BYqcnfX15W2cnGR+Q566ACXAT9UQykORCWW80lmkpWsnEob6zJS1ZVBKsSJC8+7vJkHwlp+lXG1UCdw==",
       "license": "(Apache-2.0 AND MIT)"
+    },
+    "node_modules/@web3-storage/parse-link-header": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@web3-storage/parse-link-header/-/parse-link-header-3.0.0.tgz",
+      "integrity": "sha512-8XVacInZeeJT0qoTJxE5Ohf2duxd+Tpk6H83WBjav5J4etC6FxXW55KNSnOaAGtHaG/PpN2ZDecRpRcKBYPCyA=="
     },
     "node_modules/@web3-storage/pinpin": {
       "resolved": "packages/pinpin",
@@ -16401,14 +16400,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/parse-link-header": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/parse-link-header/-/parse-link-header-2.0.0.tgz",
-      "integrity": "sha512-xjU87V0VyHZybn2RrCX5TIFGxTVZE6zqqZWMPlIKiSKuWh/X5WZdt+w1Ki1nXB+8L/KtL+nZ4iq+sfI6MrhhMw==",
-      "dependencies": {
-        "xtend": "~4.0.1"
-      }
-    },
     "node_modules/parse-ms": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/parse-ms/-/parse-ms-2.1.0.tgz",
@@ -22026,7 +22017,7 @@
     },
     "packages/api": {
       "name": "@web3-storage/api",
-      "version": "5.1.4",
+      "version": "5.2.0",
       "license": "(Apache-2.0 OR MIT)",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.28.0",
@@ -22641,6 +22632,7 @@
         "@web-std/blob": "^3.0.1",
         "@web-std/fetch": "^3.0.0",
         "@web-std/file": "^3.0.0",
+        "@web3-storage/parse-link-header": "^3.0.0",
         "browser-readablestream-to-it": "^1.0.3",
         "carbites": "^1.0.6",
         "cborg": "^1.6.0",
@@ -22649,7 +22641,6 @@
         "ipns": "^0.16.0",
         "libp2p-crypto": "^0.21.0",
         "p-retry": "^4.5.0",
-        "parse-link-header": "^2.0.0",
         "streaming-iterables": "^6.0.0",
         "uint8arrays": "^3.0.0"
       },
@@ -22659,7 +22650,6 @@
         "@rollup/plugin-json": "^4.1.0",
         "@rollup/plugin-node-resolve": "^13.1.3",
         "@types/mocha": "9.0.0",
-        "@types/parse-link-header": "^1.0.1",
         "bundlesize": "^0.18.1",
         "cors": "^2.8.5",
         "del-cli": "^4.0.0",
@@ -23813,7 +23803,7 @@
     },
     "packages/website": {
       "name": "@web3-storage/website",
-      "version": "1.9.1",
+      "version": "1.10.0",
       "dependencies": {
         "@magic-ext/oauth": "^0.7.0",
         "@tailwindcss/typography": "^0.4.1",
@@ -26923,12 +26913,6 @@
       "resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.0.tgz",
       "integrity": "sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA=="
     },
-    "@types/parse-link-header": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@types/parse-link-header/-/parse-link-header-1.0.1.tgz",
-      "integrity": "sha512-E2+Go9rQgPbmpkeA2iFXTWSTxX38KXlXwcdiIbt71Oorqr+G5QtH4AhpuDdxwRVyiTzdUrHnaaIumW/LhiZwVg==",
-      "dev": true
-    },
     "@types/pbkdf2": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/@types/pbkdf2/-/pbkdf2-3.1.0.tgz",
@@ -27836,6 +27820,11 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@web3-storage/multipart-parser/-/multipart-parser-1.0.0.tgz",
       "integrity": "sha512-BEO6al7BYqcnfX15W2cnGR+Q566ACXAT9UQykORCWW80lmkpWsnEob6zJS1ZVBKsSJC8+7vJkHwlp+lXG1UCdw=="
+    },
+    "@web3-storage/parse-link-header": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@web3-storage/parse-link-header/-/parse-link-header-3.0.0.tgz",
+      "integrity": "sha512-8XVacInZeeJT0qoTJxE5Ohf2duxd+Tpk6H83WBjav5J4etC6FxXW55KNSnOaAGtHaG/PpN2ZDecRpRcKBYPCyA=="
     },
     "@web3-storage/pinpin": {
       "version": "file:packages/pinpin",
@@ -37041,14 +37030,6 @@
         "json-parse-better-errors": "^1.0.1"
       }
     },
-    "parse-link-header": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/parse-link-header/-/parse-link-header-2.0.0.tgz",
-      "integrity": "sha512-xjU87V0VyHZybn2RrCX5TIFGxTVZE6zqqZWMPlIKiSKuWh/X5WZdt+w1Ki1nXB+8L/KtL+nZ4iq+sfI6MrhhMw==",
-      "requires": {
-        "xtend": "~4.0.1"
-      }
-    },
     "parse-ms": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/parse-ms/-/parse-ms-2.1.0.tgz",
@@ -40545,10 +40526,10 @@
         "@rollup/plugin-json": "^4.1.0",
         "@rollup/plugin-node-resolve": "^13.1.3",
         "@types/mocha": "9.0.0",
-        "@types/parse-link-header": "^1.0.1",
         "@web-std/blob": "^3.0.1",
         "@web-std/fetch": "^3.0.0",
         "@web-std/file": "^3.0.0",
+        "@web3-storage/parse-link-header": "^3.0.0",
         "browser-readablestream-to-it": "^1.0.3",
         "bundlesize": "^0.18.1",
         "carbites": "^1.0.6",
@@ -40565,7 +40546,6 @@
         "npm-run-all": "^4.1.5",
         "nyc": "15.1.0",
         "p-retry": "^4.5.0",
-        "parse-link-header": "^2.0.0",
         "playwright-test": "^7.2.2",
         "rollup": "2.63.0",
         "rollup-plugin-multi-input": "1.3.1",

--- a/packages/client/examples/browser/cdn/README.md
+++ b/packages/client/examples/browser/cdn/README.md
@@ -1,0 +1,16 @@
+# web3.storage in the browser from a CDN
+
+A demo using the [`web3.storage`](https://www.npmjs.com/package/web3.storage) client in the browser to pre-calculate the CID for an asset then store it on web3.storage.
+
+Content addressing, IPFS, Filecoin, web3.storage... it's all pretty rad! Here is gateway URL for the Content ID of this example, (stored via web3.storage of course!) so you can check it out in your browser! https://dweb.link/ipfs/bafybeic5r5yxjh5xpmeczfp34ysrjcoa66pllnjgffahopzrl5yhex7d7i
+
+## Getting started
+
+Open `index.html` in your favourite browser and add your files 🚀. 
+
+You need an API token, which you can get by signing in to web3.storage, and clicking "Create an API token"
+
+## Screenshot
+
+![screenshot of the browser demo](https://user-images.githubusercontent.com/58871/127395300-331a21cf-90ab-4471-93e3-5c7e289ce321.png)
+

--- a/packages/client/examples/browser/cdn/index.html
+++ b/packages/client/examples/browser/cdn/index.html
@@ -1,0 +1,124 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>web3.storage</title>
+    <style>
+      body {
+        font-size: 16px;
+        font-family: -apple-system, system-ui;
+        padding: 0;
+        margin: 0;
+      }
+      form {
+        width: 500px;
+        padding: 16px;
+        max-width: 100%;
+        display: block;
+        margin: 0 auto;
+        color:#333;
+      }
+      label {
+        display: block;
+        padding: 32px 0 8px;
+        font-weight: 700;
+      }
+      #token {
+        width: 100%;
+        padding: 4px;
+        font-size: 1.2rem;
+      }
+      #output {
+        display: block;
+        padding: 16px;
+        margin: 0;
+        color: lime;
+        background:#222;
+        font-family: Courier New, ui-monospace, monospace;
+        font-weight: 500;
+        line-height: 1.6;
+        position: fixed;
+        bottom: 0;
+        height: 33.3%;
+        width: 100%;
+        overflow-y: scroll;
+      }
+      #output a {
+        color: aqua
+      }
+      input[type=submit] {
+        display: block;
+        padding: 4px 16px;
+        font-weight: 700;
+        font-size: 16px;
+        margin-top: 32px;
+      }
+      h1 {
+        text-align: center;
+        font-size: 24px;
+      }
+      h1 span {
+        display: block;
+      }
+    </style>
+  </head>
+  <body>
+    <header>
+      <h1>⁂
+        <span>web3.storage</span>
+      </h1>
+    </header>
+    <form id="upload-form">
+      <label for="token">Paste your web3.storage API token here</label>
+      <input type="password" id="token" required />
+      <label>Pick files to store</label>
+      <input type="file" id="filepicker" name="fileList" multiple required />
+      <input type="submit" value="Submit" id="submit" />
+    </form>
+    <div id="output"></div>
+    <script type="module">
+      import { Web3Storage } from 'https://cdn.jsdelivr.net/npm/web3.storage/dist/bundle.esm.min.js'
+
+      const form = document.querySelector('#upload-form')
+      const filepicker = document.querySelector('#filepicker')
+      const tokenInput = document.querySelector('#token')
+      const output = document.querySelector('#output')
+
+      showMessage('> ⁂ waiting for form submission...')
+
+      form.addEventListener('submit', async function (event) {
+        // don't reload the page!
+        event.preventDefault()
+
+        showMessage('> 📦 creating web3.storage client')
+        const token = tokenInput.value
+        const client = new Web3Storage({ token })
+
+        showMessage('> 🤖 chunking and hashing the files (in your browser!) to calculate the Content ID')
+        const files = filepicker.files
+        const cid = await client.put(files, {
+          onRootCidReady: (localCid) => {
+            showMessage(`> 🔑 locally calculated Content ID: ${localCid} `)
+            showMessage('> 📡 sending files to web3.storage ')
+          },
+          onStoredChunk: (bytes) => showMessage(`> 🛰 sent ${bytes.toLocaleString()} bytes to web3.storage`)
+        })
+        showMessage(`> ✅ web3.storage now hosting ${cid}`)
+        showLink(`https://dweb.link/ipfs/${cid}`)
+      }, false)
+
+      function showMessage (text) {
+        const node = document.createElement('div')
+        node.innerText = text
+        output.appendChild(node)
+      }
+
+      function showLink (url) {
+        const node = document.createElement('a')
+        node.href = url
+        node.innerText = `> 🔗 ${url}`
+        output.appendChild(node)
+      }
+    </script>
+  </body>
+</html>

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -34,6 +34,7 @@
     "@web-std/blob": "^3.0.1",
     "@web-std/fetch": "^3.0.0",
     "@web-std/file": "^3.0.0",
+    "@web3-storage/parse-link-header": "^3.0.0",
     "browser-readablestream-to-it": "^1.0.3",
     "carbites": "^1.0.6",
     "cborg": "^1.6.0",
@@ -42,7 +43,6 @@
     "ipns": "^0.16.0",
     "libp2p-crypto": "^0.21.0",
     "p-retry": "^4.5.0",
-    "parse-link-header": "^2.0.0",
     "streaming-iterables": "^6.0.0",
     "uint8arrays": "^3.0.0"
   },
@@ -52,7 +52,6 @@
     "@rollup/plugin-json": "^4.1.0",
     "@rollup/plugin-node-resolve": "^13.1.3",
     "@types/mocha": "9.0.0",
-    "@types/parse-link-header": "^1.0.1",
     "bundlesize": "^0.18.1",
     "cors": "^2.8.5",
     "del-cli": "^4.0.0",

--- a/packages/client/src/lib.js
+++ b/packages/client/src/lib.js
@@ -16,7 +16,7 @@
 import { transform } from 'streaming-iterables'
 import pRetry from 'p-retry'
 import { pack } from 'ipfs-car/pack'
-import parseLink from 'parse-link-header'
+import { parseLinkHeader } from '@web3-storage/parse-link-header'
 import { unpackStream } from 'ipfs-car/unpack'
 import { TreewalkCarSplitter } from 'carbites/treewalk'
 import { CarReader } from '@ipld/car'
@@ -469,13 +469,13 @@ function toWeb3Response (res) {
 async function * paginator (fn, service, opts) {
   let res = await fn(service, opts)
   yield res
-  let link = parseLink(res.headers.get('Link') || '')
+  let link = parseLinkHeader(res.headers.get('Link') || '')
   // @ts-ignore
   while (link && link.next) {
     // @ts-ignore
     res = await fn(service, link.next)
     yield res
-    link = parseLink(res.headers.get('Link') || '')
+    link = parseLinkHeader(res.headers.get('Link') || '')
   }
 }
 


### PR DESCRIPTION
Adds an exmaple showing how to load the Web3.Storage client from a CDN in a browser.

Had to swap out the `parse-link-header` module because it uses Node.js globals (`process`) and pulls in a bunch of unnecessary deps.