### PR TITLE
chore: sentry sourcemaps for worker.mjs

### DIFF
--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -71,7 +71,7 @@
   },
   "bundlesize": [
     {
-      "path": "./dist/index.mjs",
+      "path": "./dist/worker.mjs",
       "maxSize": "1 MB"
     }
   ]

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "type": "module",
   "license": "(Apache-2.0 OR MIT)",
-  "main": "./dist/index.mjs",
+  "main": "./dist/worker.mjs",
   "scripts": {
     "lt": "npm-run-all -p lt:*",
     "lt:cluster": "npx localtunnel --port 9094 --subdomain \"$(whoami)-cluster-api-web3-storage\"",

--- a/packages/api/scripts/cli.js
+++ b/packages/api/scripts/cli.js
@@ -29,7 +29,7 @@ prog
       entryPoints: [path.join(__dirname, '..', 'src', 'index.js')],
       bundle: true,
       format: 'esm',
-      outfile: path.join(__dirname, '..', 'dist', 'index.mjs'),
+      outfile: path.join(__dirname, '..', 'dist', 'worker.mjs'),
       legalComments: 'external',
       inject: [path.join(__dirname, 'node-globals.js')],
       plugins: [{

--- a/packages/api/scripts/cli.js
+++ b/packages/api/scripts/cli.js
@@ -54,7 +54,7 @@ prog
         global: 'globalThis'
       },
       minify: opts.env !== 'dev',
-      sourcemap: true
+      sourcemap: 'external'
     })
 
     // Sentry release and sourcemap upload
@@ -74,8 +74,9 @@ prog
         ignoreMissing: true
       })
       await cli.releases.uploadSourceMaps(sentryRelease, {
+        // validate: true,
         include: [path.join(__dirname, '..', 'dist')],
-        urlPrefix: '/'
+        ext: ['map', 'mjs']
       })
       await cli.releases.finalize(sentryRelease)
       await cli.releases.newDeploy(sentryRelease, { env: opts.env })

--- a/packages/api/src/env.js
+++ b/packages/api/src/env.js
@@ -83,7 +83,8 @@ export function envAll (req, env, ctx) {
     allowedSearchParams: /(.*)/,
     debug: false,
     rewriteFrames: {
-      root: '/'
+      // strip . from start of the filename ./worker.mjs as set by cloudflare, to make absolute path `/worker.mjs`
+      iteratee: (frame) => ({ ...frame, filename: frame.filename.substring(1) })
     },
     environment: env.ENV,
     release: env.SENTRY_RELEASE,

--- a/packages/api/src/env.js
+++ b/packages/api/src/env.js
@@ -78,6 +78,7 @@ export function envAll (req, env, ctx) {
   env.sentry = env.SENTRY_DSN && new Toucan({
     dsn: env.SENTRY_DSN,
     context: ctx,
+    request: req,
     allowedHeaders: ['user-agent', 'x-client'],
     allowedSearchParams: /(.*)/,
     debug: false,

--- a/packages/api/wrangler.toml
+++ b/packages/api/wrangler.toml
@@ -12,7 +12,7 @@ watch_dir = "src"
 [build.upload]
 format = "modules"
 dir = "dist"
-main = "index.mjs"
+main = "worker.mjs"
 # NOTE: Make sure the main field in your package.json references the Worker script you want to publish.
 
 [durable_objects]


### PR DESCRIPTION
- [x] rename output to be worker.mjs see: https://developers.cloudflare.com/workers/cli-wrangler/configuration#modules
- [x] add request info to sentry log.  see: https://github.com/robertcepa/toucan-js#equivalent-of-above-as-a-module-mjs
- [x] tell sentry to upload bundle with .mjs extention. it only uploads .js by default. https://docs.sentry.io/product/cli/releases/#sentry-cli-sourcemaps
- [x] strip the `sourceMappingURL` comment from the bundle by using `external` as esbuild sourcemap mode. This is one less thing to go wrong / confuse sentry.
- [x] strip `.` from the start of the `filename` on stackframes as reported by the worker environment, so we just get reports from '/worker.mjs` and sentry can find the bundle for it.

Screenshot shows we now get **stacktraces!** _and_ **Request info** like the url and the user agent!!11!

<img width="848" alt="Screenshot 2022-02-25 at 22 01 21" src="https://user-images.githubusercontent.com/58871/155809135-13f44703-a140-45c0-bf2a-6385575d3567.png">


fixes: https://github.com/web3-storage/web3.storage/issues/983

previous: https://github.com/web3-storage/web3.storage/pull/505

License: (Apache-2.0 AND MIT)
Signed-off-by: Oli Evans <oli@tableflip.io>