### PR TITLE
fix: disable swc minify

### DIFF
--- a/packages/website/.babelrc
+++ b/packages/website/.babelrc
@@ -1,0 +1,4 @@
+{
+  "presets": ["next/babel"]
+}
+  

--- a/packages/website/next.config.js
+++ b/packages/website/next.config.js
@@ -39,7 +39,6 @@ const nextConfig = {
       '/ipfs-404.html': { page: '/404' },
     }
   },
-  swcMinify: false
 }
 
 module.exports = nextConfig

--- a/packages/website/next.config.js
+++ b/packages/website/next.config.js
@@ -39,6 +39,7 @@ const nextConfig = {
       '/ipfs-404.html': { page: '/404' },
     }
   },
+  swcMinify: false
 }
 
 module.exports = nextConfig


### PR DESCRIPTION
Getting this on cloudflare:

```
16:03:34.483 | info  - Creating an optimized production build...
-- | --
16:03:34.974 | info  - Attempted to load @next/swc-linux-x64-gnu, but it was not installed
16:03:34.976 | info  - Attempted to load @next/swc-linux-x64-gnux32, but it was not installed
16:03:34.985 | info  - Attempted to load @next/swc-linux-x64-musl, but it was not installed
16:03:34.986 | error - Failed to load SWC binary for linux/x64, see more info here: https://nextjs.org/docs/messages/failed-loading-swc
```

Disabling for now as per: https://nextjs.org/docs/messages/failed-loading-swc