### PR TITLE
fix: client update deps

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4134,8 +4134,9 @@
       "license": "ISC"
     },
     "node_modules/@web-std/blob": {
-      "version": "3.0.3",
-      "license": "MIT",
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@web-std/blob/-/blob-3.0.4.tgz",
+      "integrity": "sha512-+dibyiw+uHYK4dX5cJ7HA+gtDAaUUe6JsOryp2ZpAC7h4ICsh49E34JwHoEKPlPvP0llCrNzz45vvD+xX5QDBg==",
       "dependencies": {
         "@web-std/stream": "1.0.0",
         "web-encoding": "1.1.5"
@@ -5653,8 +5654,9 @@
       }
     },
     "node_modules/cborg": {
-      "version": "1.6.0",
-      "license": "Apache-2.0",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/cborg/-/cborg-1.8.0.tgz",
+      "integrity": "sha512-zT4TJQJJFXLGpd0iMmj1gQCscbcrBxC6X5S0D9bdA8nH34ZbsSdtzJXD0A2ZJzBWP95WI1pKX9CLkwW6UpolwA==",
       "bin": {
         "cborg": "cli.js"
       }
@@ -8555,8 +8557,9 @@
       }
     },
     "node_modules/files-from-path": {
-      "version": "0.2.3",
-      "license": "(Apache-2.0 AND MIT)",
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/files-from-path/-/files-from-path-0.2.4.tgz",
+      "integrity": "sha512-sOy3xCgcF76RwSrqFjE1me81Zpwbdm3l9HdzehlPAHvwZejNzQZmHUVYFoPl3YmHqluas3hiAuAAEl8iNd8QSw==",
       "dependencies": {
         "err-code": "^3.0.1",
         "ipfs-unixfs": "^6.0.5",
@@ -16504,8 +16507,9 @@
       }
     },
     "node_modules/streaming-iterables": {
-      "version": "6.0.0",
-      "license": "MIT",
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/streaming-iterables/-/streaming-iterables-6.2.0.tgz",
+      "integrity": "sha512-3AYC8oB60WyD1ic7uHmN/vm2oRGzRnQ3XFBl/bFMDi1q1+nc5/vjMmiE4vroIya3jG59t87VpyAj/iXYxyw9AA==",
       "engines": {
         "node": ">=10"
       }
@@ -18842,19 +18846,19 @@
       "license": "(Apache-2.0 OR MIT)",
       "dependencies": {
         "@ipld/car": "^3.1.4",
-        "@web-std/blob": "^3.0.3",
+        "@web-std/blob": "^3.0.4",
         "@web-std/fetch": "^3.0.3",
         "@web-std/file": "^3.0.2",
         "@web3-storage/parse-link-header": "^3.1.0",
         "browser-readablestream-to-it": "^1.0.3",
         "carbites": "^1.0.6",
-        "cborg": "^1.6.0",
-        "files-from-path": "^0.2.3",
+        "cborg": "^1.8.0",
+        "files-from-path": "^0.2.4",
         "ipfs-car": "^0.6.2",
         "ipns": "^0.16.0",
         "libp2p-crypto": "^0.21.0",
         "p-retry": "^4.5.0",
-        "streaming-iterables": "^6.0.0",
+        "streaming-iterables": "^6.2.0",
         "uint8arrays": "^3.0.0"
       },
       "devDependencies": {
@@ -22839,7 +22843,9 @@
       "dev": true
     },
     "@web-std/blob": {
-      "version": "3.0.3",
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@web-std/blob/-/blob-3.0.4.tgz",
+      "integrity": "sha512-+dibyiw+uHYK4dX5cJ7HA+gtDAaUUe6JsOryp2ZpAC7h4ICsh49E34JwHoEKPlPvP0llCrNzz45vvD+xX5QDBg==",
       "requires": {
         "@web-std/stream": "1.0.0",
         "web-encoding": "1.1.5"
@@ -24910,7 +24916,9 @@
       }
     },
     "cborg": {
-      "version": "1.6.0"
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/cborg/-/cborg-1.8.0.tgz",
+      "integrity": "sha512-zT4TJQJJFXLGpd0iMmj1gQCscbcrBxC6X5S0D9bdA8nH34ZbsSdtzJXD0A2ZJzBWP95WI1pKX9CLkwW6UpolwA=="
     },
     "chainsaw": {
       "version": "0.1.0",
@@ -26852,7 +26860,9 @@
       }
     },
     "files-from-path": {
-      "version": "0.2.3",
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/files-from-path/-/files-from-path-0.2.4.tgz",
+      "integrity": "sha512-sOy3xCgcF76RwSrqFjE1me81Zpwbdm3l9HdzehlPAHvwZejNzQZmHUVYFoPl3YmHqluas3hiAuAAEl8iNd8QSw==",
       "requires": {
         "err-code": "^3.0.1",
         "ipfs-unixfs": "^6.0.5",
@@ -31868,7 +31878,9 @@
       }
     },
     "streaming-iterables": {
-      "version": "6.0.0"
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/streaming-iterables/-/streaming-iterables-6.2.0.tgz",
+      "integrity": "sha512-3AYC8oB60WyD1ic7uHmN/vm2oRGzRnQ3XFBl/bFMDi1q1+nc5/vjMmiE4vroIya3jG59t87VpyAj/iXYxyw9AA=="
     },
     "streamsearch": {
       "version": "0.1.2",
@@ -32805,17 +32817,17 @@
         "@rollup/plugin-json": "^4.1.0",
         "@rollup/plugin-node-resolve": "^13.1.3",
         "@types/mocha": "9.0.0",
-        "@web-std/blob": "^3.0.3",
+        "@web-std/blob": "^3.0.4",
         "@web-std/fetch": "^3.0.3",
         "@web-std/file": "^3.0.2",
         "@web3-storage/parse-link-header": "^3.1.0",
         "browser-readablestream-to-it": "^1.0.3",
         "bundlesize": "^0.18.1",
         "carbites": "^1.0.6",
-        "cborg": "^1.6.0",
+        "cborg": "^1.8.0",
         "cors": "^2.8.5",
         "del-cli": "^4.0.0",
-        "files-from-path": "^0.2.3",
+        "files-from-path": "^0.2.4",
         "hundreds": "0.0.9",
         "ipfs-car": "^0.6.2",
         "ipns": "^0.16.0",
@@ -32831,7 +32843,7 @@
         "rollup-plugin-multi-input": "1.3.1",
         "rollup-plugin-terser": "^7.0.2",
         "smoke": "^3.1.1",
-        "streaming-iterables": "^6.0.0",
+        "streaming-iterables": "^6.2.0",
         "typedoc": "0.22.10",
         "uint8arrays": "^3.0.0",
         "uvu": "0.5.3"

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -31,19 +31,19 @@
   },
   "dependencies": {
     "@ipld/car": "^3.1.4",
-    "@web-std/blob": "^3.0.3",
+    "@web-std/blob": "^3.0.4",
     "@web-std/fetch": "^3.0.3",
     "@web-std/file": "^3.0.2",
     "@web3-storage/parse-link-header": "^3.1.0",
     "browser-readablestream-to-it": "^1.0.3",
     "carbites": "^1.0.6",
-    "cborg": "^1.6.0",
-    "files-from-path": "^0.2.3",
+    "cborg": "^1.8.0",
+    "files-from-path": "^0.2.4",
     "ipfs-car": "^0.6.2",
     "ipns": "^0.16.0",
     "libp2p-crypto": "^0.21.0",
     "p-retry": "^4.5.0",
-    "streaming-iterables": "^6.0.0",
+    "streaming-iterables": "^6.2.0",
     "uint8arrays": "^3.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Updates deps, specially noted `@web-std/blob@3.0.4` has an important fix for Node.js usage of Blob and `files-from-path@0.2.4` has a new feature requested from community.