### PR TITLE
fix: verify s3 backup integrity on upload

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -54,7 +54,8 @@
     },
     "node_modules/@aws-crypto/crc32": {
       "version": "2.0.0",
-      "license": "Apache-2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/crc32/-/crc32-2.0.0.tgz",
+      "integrity": "sha512-TvE1r2CUueyXOuHdEigYjIZVesInd9KN+K/TFFNfkkxRThiNxO6i4ZqqAVMoEjAamZZ1AA8WXJkjCz7YShHPQA==",
       "dependencies": {
         "@aws-crypto/util": "^2.0.0",
         "@aws-sdk/types": "^3.1.0",
@@ -63,22 +64,59 @@
     },
     "node_modules/@aws-crypto/crc32/node_modules/tslib": {
       "version": "1.14.1",
-      "license": "0BSD"
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+    },
+    "node_modules/@aws-crypto/crc32c": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/crc32c/-/crc32c-2.0.0.tgz",
+      "integrity": "sha512-vF0eMdMHx3O3MoOXUfBZry8Y4ZDtcuskjjKgJz8YfIDjLStxTZrYXk+kZqtl6A0uCmmiN/Eb/JbC/CndTV1MHg==",
+      "dependencies": {
+        "@aws-crypto/util": "^2.0.0",
+        "@aws-sdk/types": "^3.1.0",
+        "tslib": "^1.11.1"
+      }
+    },
+    "node_modules/@aws-crypto/crc32c/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "node_modules/@aws-crypto/ie11-detection": {
       "version": "2.0.0",
-      "license": "Apache-2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/ie11-detection/-/ie11-detection-2.0.0.tgz",
+      "integrity": "sha512-pkVXf/dq6PITJ0jzYZ69VhL8VFOFoPZLZqtU/12SGnzYuJOOGNfF41q9GxdI1yqC8R13Rq3jOLKDFpUJFT5eTA==",
       "dependencies": {
         "tslib": "^1.11.1"
       }
     },
     "node_modules/@aws-crypto/ie11-detection/node_modules/tslib": {
       "version": "1.14.1",
-      "license": "0BSD"
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+    },
+    "node_modules/@aws-crypto/sha1-browser": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha1-browser/-/sha1-browser-2.0.0.tgz",
+      "integrity": "sha512-3fIVRjPFY8EG5HWXR+ZJZMdWNRpwbxGzJ9IH9q93FpbgCH8u8GHRi46mZXp3cYD7gealmyqpm3ThZwLKJjWJhA==",
+      "dependencies": {
+        "@aws-crypto/ie11-detection": "^2.0.0",
+        "@aws-crypto/supports-web-crypto": "^2.0.0",
+        "@aws-sdk/types": "^3.1.0",
+        "@aws-sdk/util-locate-window": "^3.0.0",
+        "@aws-sdk/util-utf8-browser": "^3.0.0",
+        "tslib": "^1.11.1"
+      }
+    },
+    "node_modules/@aws-crypto/sha1-browser/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "node_modules/@aws-crypto/sha256-browser": {
       "version": "2.0.0",
-      "license": "Apache-2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-2.0.0.tgz",
+      "integrity": "sha512-rYXOQ8BFOaqMEHJrLHul/25ckWH6GTJtdLSajhlqGMx0PmSueAuvboCuZCTqEKlxR8CQOwRarxYMZZSYlhRA1A==",
       "dependencies": {
         "@aws-crypto/ie11-detection": "^2.0.0",
         "@aws-crypto/sha256-js": "^2.0.0",
@@ -92,11 +130,13 @@
     },
     "node_modules/@aws-crypto/sha256-browser/node_modules/tslib": {
       "version": "1.14.1",
-      "license": "0BSD"
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "node_modules/@aws-crypto/sha256-js": {
       "version": "2.0.0",
-      "license": "Apache-2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-2.0.0.tgz",
+      "integrity": "sha512-VZY+mCY4Nmrs5WGfitmNqXzaE873fcIZDu54cbaDaaamsaTOP1DBImV9F4pICc3EHjQXujyE8jig+PFCaew9ig==",
       "dependencies": {
         "@aws-crypto/util": "^2.0.0",
         "@aws-sdk/types": "^3.1.0",
@@ -105,22 +145,26 @@
     },
     "node_modules/@aws-crypto/sha256-js/node_modules/tslib": {
       "version": "1.14.1",
-      "license": "0BSD"
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "node_modules/@aws-crypto/supports-web-crypto": {
       "version": "2.0.0",
-      "license": "Apache-2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-2.0.0.tgz",
+      "integrity": "sha512-Ge7WQ3E0OC7FHYprsZV3h0QIcpdyJLvIeg+uTuHqRYm8D6qCFJoiC+edSzSyFiHtZf+NOQDJ1q46qxjtzIY2nA==",
       "dependencies": {
         "tslib": "^1.11.1"
       }
     },
     "node_modules/@aws-crypto/supports-web-crypto/node_modules/tslib": {
       "version": "1.14.1",
-      "license": "0BSD"
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "node_modules/@aws-crypto/util": {
       "version": "2.0.1",
-      "license": "Apache-2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-2.0.1.tgz",
+      "integrity": "sha512-JJmFFwvbm08lULw4Nm5QOLg8+lAQeC8aCXK5xrtxntYzYXCGfHwUJ4Is3770Q7HmICsXthGQ+ZsDL7C2uH3yBQ==",
       "dependencies": {
         "@aws-sdk/types": "^3.1.0",
         "@aws-sdk/util-utf8-browser": "^3.0.0",
@@ -129,13 +173,15 @@
     },
     "node_modules/@aws-crypto/util/node_modules/tslib": {
       "version": "1.14.1",
-      "license": "0BSD"
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "node_modules/@aws-sdk/abort-controller": {
-      "version": "3.52.0",
-      "license": "Apache-2.0",
+      "version": "3.53.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.53.0.tgz",
+      "integrity": "sha512-Xe7IX2mpf/qOjh1LrPnJ1UtiDw3cBlmy8n+Q2xSP5vaS/9IH0OMdQUveC9MV9HSgzICX+xzbPyUuSKc+4tufBQ==",
       "dependencies": {
-        "@aws-sdk/types": "3.52.0",
+        "@aws-sdk/types": "3.53.0",
         "tslib": "^2.3.0"
       },
       "engines": {
@@ -144,68 +190,74 @@
     },
     "node_modules/@aws-sdk/chunked-blob-reader": {
       "version": "3.52.0",
-      "license": "Apache-2.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/chunked-blob-reader/-/chunked-blob-reader-3.52.0.tgz",
+      "integrity": "sha512-BAZhriHHfvnGOd0P9xcnGu8DGyxOa0lgmEw+Tc6nZpXJzx0P+1Sd76q5gE5d/IZ0r5VTB6rfwwKUoG6iShNCwQ==",
       "dependencies": {
         "tslib": "^2.3.0"
       }
     },
     "node_modules/@aws-sdk/chunked-blob-reader-native": {
       "version": "3.52.0",
-      "license": "Apache-2.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/chunked-blob-reader-native/-/chunked-blob-reader-native-3.52.0.tgz",
+      "integrity": "sha512-/hVzC0Q12/mWRMBBQD3v82xsLSxZ4RwG6N44XP7MuJoHy4ui4T7D9RSuvBpzzr/4fqF0w9M7XYv6aM4BD2pFIQ==",
       "dependencies": {
         "@aws-sdk/util-base64-browser": "3.52.0",
         "tslib": "^2.3.0"
       }
     },
     "node_modules/@aws-sdk/client-s3": {
-      "version": "3.52.0",
-      "license": "Apache-2.0",
+      "version": "3.53.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.53.1.tgz",
+      "integrity": "sha512-uAhjR/TAuXNct6BL/shVg2f/6Zg1EZoXTG8KIywfmLitiUF0PvYwfwSPtNohkz6czgTs/rtirAZHAQKi8jjieA==",
       "dependencies": {
+        "@aws-crypto/sha1-browser": "2.0.0",
         "@aws-crypto/sha256-browser": "2.0.0",
         "@aws-crypto/sha256-js": "2.0.0",
-        "@aws-sdk/client-sts": "3.52.0",
-        "@aws-sdk/config-resolver": "3.52.0",
-        "@aws-sdk/credential-provider-node": "3.52.0",
-        "@aws-sdk/eventstream-serde-browser": "3.52.0",
-        "@aws-sdk/eventstream-serde-config-resolver": "3.52.0",
-        "@aws-sdk/eventstream-serde-node": "3.52.0",
-        "@aws-sdk/fetch-http-handler": "3.52.0",
-        "@aws-sdk/hash-blob-browser": "3.52.0",
-        "@aws-sdk/hash-node": "3.52.0",
-        "@aws-sdk/hash-stream-node": "3.52.0",
-        "@aws-sdk/invalid-dependency": "3.52.0",
-        "@aws-sdk/md5-js": "3.52.0",
-        "@aws-sdk/middleware-apply-body-checksum": "3.52.0",
-        "@aws-sdk/middleware-bucket-endpoint": "3.52.0",
-        "@aws-sdk/middleware-content-length": "3.52.0",
-        "@aws-sdk/middleware-expect-continue": "3.52.0",
-        "@aws-sdk/middleware-host-header": "3.52.0",
-        "@aws-sdk/middleware-location-constraint": "3.52.0",
-        "@aws-sdk/middleware-logger": "3.52.0",
-        "@aws-sdk/middleware-retry": "3.52.0",
-        "@aws-sdk/middleware-sdk-s3": "3.52.0",
-        "@aws-sdk/middleware-serde": "3.52.0",
-        "@aws-sdk/middleware-signing": "3.52.0",
-        "@aws-sdk/middleware-ssec": "3.52.0",
-        "@aws-sdk/middleware-stack": "3.52.0",
-        "@aws-sdk/middleware-user-agent": "3.52.0",
-        "@aws-sdk/node-config-provider": "3.52.0",
-        "@aws-sdk/node-http-handler": "3.52.0",
-        "@aws-sdk/protocol-http": "3.52.0",
-        "@aws-sdk/smithy-client": "3.52.0",
-        "@aws-sdk/types": "3.52.0",
-        "@aws-sdk/url-parser": "3.52.0",
+        "@aws-sdk/client-sts": "3.53.0",
+        "@aws-sdk/config-resolver": "3.53.0",
+        "@aws-sdk/credential-provider-node": "3.53.0",
+        "@aws-sdk/eventstream-serde-browser": "3.53.0",
+        "@aws-sdk/eventstream-serde-config-resolver": "3.53.0",
+        "@aws-sdk/eventstream-serde-node": "3.53.0",
+        "@aws-sdk/fetch-http-handler": "3.53.0",
+        "@aws-sdk/hash-blob-browser": "3.53.0",
+        "@aws-sdk/hash-node": "3.53.0",
+        "@aws-sdk/hash-stream-node": "3.53.1",
+        "@aws-sdk/invalid-dependency": "3.53.0",
+        "@aws-sdk/md5-js": "3.53.0",
+        "@aws-sdk/middleware-bucket-endpoint": "3.53.0",
+        "@aws-sdk/middleware-content-length": "3.53.0",
+        "@aws-sdk/middleware-expect-continue": "3.53.0",
+        "@aws-sdk/middleware-flexible-checksums": "3.53.0",
+        "@aws-sdk/middleware-host-header": "3.53.0",
+        "@aws-sdk/middleware-location-constraint": "3.53.0",
+        "@aws-sdk/middleware-logger": "3.53.0",
+        "@aws-sdk/middleware-retry": "3.53.0",
+        "@aws-sdk/middleware-sdk-s3": "3.53.0",
+        "@aws-sdk/middleware-serde": "3.53.0",
+        "@aws-sdk/middleware-signing": "3.53.0",
+        "@aws-sdk/middleware-ssec": "3.53.0",
+        "@aws-sdk/middleware-stack": "3.53.0",
+        "@aws-sdk/middleware-user-agent": "3.53.0",
+        "@aws-sdk/node-config-provider": "3.53.0",
+        "@aws-sdk/node-http-handler": "3.53.0",
+        "@aws-sdk/protocol-http": "3.53.0",
+        "@aws-sdk/smithy-client": "3.53.0",
+        "@aws-sdk/types": "3.53.0",
+        "@aws-sdk/url-parser": "3.53.0",
         "@aws-sdk/util-base64-browser": "3.52.0",
         "@aws-sdk/util-base64-node": "3.52.0",
         "@aws-sdk/util-body-length-browser": "3.52.0",
         "@aws-sdk/util-body-length-node": "3.52.0",
-        "@aws-sdk/util-defaults-mode-browser": "3.52.0",
-        "@aws-sdk/util-defaults-mode-node": "3.52.0",
-        "@aws-sdk/util-user-agent-browser": "3.52.0",
-        "@aws-sdk/util-user-agent-node": "3.52.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.53.0",
+        "@aws-sdk/util-defaults-mode-node": "3.53.0",
+        "@aws-sdk/util-stream-browser": "3.53.0",
+        "@aws-sdk/util-stream-node": "3.53.0",
+        "@aws-sdk/util-user-agent-browser": "3.53.0",
+        "@aws-sdk/util-user-agent-node": "3.53.0",
         "@aws-sdk/util-utf8-browser": "3.52.0",
         "@aws-sdk/util-utf8-node": "3.52.0",
-        "@aws-sdk/util-waiter": "3.52.0",
+        "@aws-sdk/util-waiter": "3.53.0",
         "@aws-sdk/xml-builder": "3.52.0",
         "entities": "2.2.0",
         "fast-xml-parser": "3.19.0",
@@ -216,36 +268,37 @@
       }
     },
     "node_modules/@aws-sdk/client-sso": {
-      "version": "3.52.0",
-      "license": "Apache-2.0",
+      "version": "3.53.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.53.0.tgz",
+      "integrity": "sha512-X32YHHc5MO7xO4W3Ly8DeryieeEiDOsnl6ypBkfML7loO3M0ckvvL+HnNUR1J+HYyseEV7V93BsF/A1z5HmINQ==",
       "dependencies": {
         "@aws-crypto/sha256-browser": "2.0.0",
         "@aws-crypto/sha256-js": "2.0.0",
-        "@aws-sdk/config-resolver": "3.52.0",
-        "@aws-sdk/fetch-http-handler": "3.52.0",
-        "@aws-sdk/hash-node": "3.52.0",
-        "@aws-sdk/invalid-dependency": "3.52.0",
-        "@aws-sdk/middleware-content-length": "3.52.0",
-        "@aws-sdk/middleware-host-header": "3.52.0",
-        "@aws-sdk/middleware-logger": "3.52.0",
-        "@aws-sdk/middleware-retry": "3.52.0",
-        "@aws-sdk/middleware-serde": "3.52.0",
-        "@aws-sdk/middleware-stack": "3.52.0",
-        "@aws-sdk/middleware-user-agent": "3.52.0",
-        "@aws-sdk/node-config-provider": "3.52.0",
-        "@aws-sdk/node-http-handler": "3.52.0",
-        "@aws-sdk/protocol-http": "3.52.0",
-        "@aws-sdk/smithy-client": "3.52.0",
-        "@aws-sdk/types": "3.52.0",
-        "@aws-sdk/url-parser": "3.52.0",
+        "@aws-sdk/config-resolver": "3.53.0",
+        "@aws-sdk/fetch-http-handler": "3.53.0",
+        "@aws-sdk/hash-node": "3.53.0",
+        "@aws-sdk/invalid-dependency": "3.53.0",
+        "@aws-sdk/middleware-content-length": "3.53.0",
+        "@aws-sdk/middleware-host-header": "3.53.0",
+        "@aws-sdk/middleware-logger": "3.53.0",
+        "@aws-sdk/middleware-retry": "3.53.0",
+        "@aws-sdk/middleware-serde": "3.53.0",
+        "@aws-sdk/middleware-stack": "3.53.0",
+        "@aws-sdk/middleware-user-agent": "3.53.0",
+        "@aws-sdk/node-config-provider": "3.53.0",
+        "@aws-sdk/node-http-handler": "3.53.0",
+        "@aws-sdk/protocol-http": "3.53.0",
+        "@aws-sdk/smithy-client": "3.53.0",
+        "@aws-sdk/types": "3.53.0",
+        "@aws-sdk/url-parser": "3.53.0",
         "@aws-sdk/util-base64-browser": "3.52.0",
         "@aws-sdk/util-base64-node": "3.52.0",
         "@aws-sdk/util-body-length-browser": "3.52.0",
         "@aws-sdk/util-body-length-node": "3.52.0",
-        "@aws-sdk/util-defaults-mode-browser": "3.52.0",
-        "@aws-sdk/util-defaults-mode-node": "3.52.0",
-        "@aws-sdk/util-user-agent-browser": "3.52.0",
-        "@aws-sdk/util-user-agent-node": "3.52.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.53.0",
+        "@aws-sdk/util-defaults-mode-node": "3.53.0",
+        "@aws-sdk/util-user-agent-browser": "3.53.0",
+        "@aws-sdk/util-user-agent-node": "3.53.0",
         "@aws-sdk/util-utf8-browser": "3.52.0",
         "@aws-sdk/util-utf8-node": "3.52.0",
         "tslib": "^2.3.0"
@@ -255,39 +308,40 @@
       }
     },
     "node_modules/@aws-sdk/client-sts": {
-      "version": "3.52.0",
-      "license": "Apache-2.0",
+      "version": "3.53.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.53.0.tgz",
+      "integrity": "sha512-MNG+Pmw/zZQ0kboZtsc8UEGM9pn8abjStDN0Yk67fwFAZMqz8sUHDtFXpa3gSXMrFqBwT+jMFXmIxqiq7XuAeA==",
       "dependencies": {
         "@aws-crypto/sha256-browser": "2.0.0",
         "@aws-crypto/sha256-js": "2.0.0",
-        "@aws-sdk/config-resolver": "3.52.0",
-        "@aws-sdk/credential-provider-node": "3.52.0",
-        "@aws-sdk/fetch-http-handler": "3.52.0",
-        "@aws-sdk/hash-node": "3.52.0",
-        "@aws-sdk/invalid-dependency": "3.52.0",
-        "@aws-sdk/middleware-content-length": "3.52.0",
-        "@aws-sdk/middleware-host-header": "3.52.0",
-        "@aws-sdk/middleware-logger": "3.52.0",
-        "@aws-sdk/middleware-retry": "3.52.0",
-        "@aws-sdk/middleware-sdk-sts": "3.52.0",
-        "@aws-sdk/middleware-serde": "3.52.0",
-        "@aws-sdk/middleware-signing": "3.52.0",
-        "@aws-sdk/middleware-stack": "3.52.0",
-        "@aws-sdk/middleware-user-agent": "3.52.0",
-        "@aws-sdk/node-config-provider": "3.52.0",
-        "@aws-sdk/node-http-handler": "3.52.0",
-        "@aws-sdk/protocol-http": "3.52.0",
-        "@aws-sdk/smithy-client": "3.52.0",
-        "@aws-sdk/types": "3.52.0",
-        "@aws-sdk/url-parser": "3.52.0",
+        "@aws-sdk/config-resolver": "3.53.0",
+        "@aws-sdk/credential-provider-node": "3.53.0",
+        "@aws-sdk/fetch-http-handler": "3.53.0",
+        "@aws-sdk/hash-node": "3.53.0",
+        "@aws-sdk/invalid-dependency": "3.53.0",
+        "@aws-sdk/middleware-content-length": "3.53.0",
+        "@aws-sdk/middleware-host-header": "3.53.0",
+        "@aws-sdk/middleware-logger": "3.53.0",
+        "@aws-sdk/middleware-retry": "3.53.0",
+        "@aws-sdk/middleware-sdk-sts": "3.53.0",
+        "@aws-sdk/middleware-serde": "3.53.0",
+        "@aws-sdk/middleware-signing": "3.53.0",
+        "@aws-sdk/middleware-stack": "3.53.0",
+        "@aws-sdk/middleware-user-agent": "3.53.0",
+        "@aws-sdk/node-config-provider": "3.53.0",
+        "@aws-sdk/node-http-handler": "3.53.0",
+        "@aws-sdk/protocol-http": "3.53.0",
+        "@aws-sdk/smithy-client": "3.53.0",
+        "@aws-sdk/types": "3.53.0",
+        "@aws-sdk/url-parser": "3.53.0",
         "@aws-sdk/util-base64-browser": "3.52.0",
         "@aws-sdk/util-base64-node": "3.52.0",
         "@aws-sdk/util-body-length-browser": "3.52.0",
         "@aws-sdk/util-body-length-node": "3.52.0",
-        "@aws-sdk/util-defaults-mode-browser": "3.52.0",
-        "@aws-sdk/util-defaults-mode-node": "3.52.0",
-        "@aws-sdk/util-user-agent-browser": "3.52.0",
-        "@aws-sdk/util-user-agent-node": "3.52.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.53.0",
+        "@aws-sdk/util-defaults-mode-node": "3.53.0",
+        "@aws-sdk/util-user-agent-browser": "3.53.0",
+        "@aws-sdk/util-user-agent-node": "3.53.0",
         "@aws-sdk/util-utf8-browser": "3.52.0",
         "@aws-sdk/util-utf8-node": "3.52.0",
         "entities": "2.2.0",
@@ -299,11 +353,12 @@
       }
     },
     "node_modules/@aws-sdk/config-resolver": {
-      "version": "3.52.0",
-      "license": "Apache-2.0",
+      "version": "3.53.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.53.0.tgz",
+      "integrity": "sha512-wAqP/xNx49H1dutHWHjhKduaKtAcDg2KoH25W6peW2qXZ6OfpVcxRIBbJE4Z0yGOmFFaxw0OeH3h2ptP7tdhGQ==",
       "dependencies": {
-        "@aws-sdk/signature-v4": "3.52.0",
-        "@aws-sdk/types": "3.52.0",
+        "@aws-sdk/signature-v4": "3.53.0",
+        "@aws-sdk/types": "3.53.0",
         "@aws-sdk/util-config-provider": "3.52.0",
         "tslib": "^2.3.0"
       },
@@ -312,11 +367,12 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-env": {
-      "version": "3.52.0",
-      "license": "Apache-2.0",
+      "version": "3.53.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.53.0.tgz",
+      "integrity": "sha512-ocqZ4w7y7eay2M+uUBAD6NkhikUPoajEFX1/7iMvEFMmS5MyzjuolHPNK7Hh8lFmPyoflxaMXJVKO8C1MguA/A==",
       "dependencies": {
-        "@aws-sdk/property-provider": "3.52.0",
-        "@aws-sdk/types": "3.52.0",
+        "@aws-sdk/property-provider": "3.53.0",
+        "@aws-sdk/types": "3.53.0",
         "tslib": "^2.3.0"
       },
       "engines": {
@@ -324,13 +380,14 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-imds": {
-      "version": "3.52.0",
-      "license": "Apache-2.0",
+      "version": "3.53.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.53.0.tgz",
+      "integrity": "sha512-aKc8POSqCi58566KhF1p8Sxt7LHehMnshyfQzNAOB7xshSxuWg41rxafnQU4Soq9Tz7q5bwkauR2CEUihv/TRg==",
       "dependencies": {
-        "@aws-sdk/node-config-provider": "3.52.0",
-        "@aws-sdk/property-provider": "3.52.0",
-        "@aws-sdk/types": "3.52.0",
-        "@aws-sdk/url-parser": "3.52.0",
+        "@aws-sdk/node-config-provider": "3.53.0",
+        "@aws-sdk/property-provider": "3.53.0",
+        "@aws-sdk/types": "3.53.0",
+        "@aws-sdk/url-parser": "3.53.0",
         "tslib": "^2.3.0"
       },
       "engines": {
@@ -338,17 +395,18 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-ini": {
-      "version": "3.52.0",
-      "license": "Apache-2.0",
+      "version": "3.53.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.53.0.tgz",
+      "integrity": "sha512-g+UoJ1ikDrfpI1wHAhlrcBtX4OHxoLV6vakirpG27hhFwuMih565Q/Sjn3o5hLT8PBlWxwT2YeRuxCjtaL3cDA==",
       "dependencies": {
-        "@aws-sdk/credential-provider-env": "3.52.0",
-        "@aws-sdk/credential-provider-imds": "3.52.0",
-        "@aws-sdk/credential-provider-sso": "3.52.0",
-        "@aws-sdk/credential-provider-web-identity": "3.52.0",
-        "@aws-sdk/property-provider": "3.52.0",
+        "@aws-sdk/credential-provider-env": "3.53.0",
+        "@aws-sdk/credential-provider-imds": "3.53.0",
+        "@aws-sdk/credential-provider-sso": "3.53.0",
+        "@aws-sdk/credential-provider-web-identity": "3.53.0",
+        "@aws-sdk/property-provider": "3.53.0",
         "@aws-sdk/shared-ini-file-loader": "3.52.0",
-        "@aws-sdk/types": "3.52.0",
-        "@aws-sdk/util-credentials": "3.52.0",
+        "@aws-sdk/types": "3.53.0",
+        "@aws-sdk/util-credentials": "3.53.0",
         "tslib": "^2.3.0"
       },
       "engines": {
@@ -356,19 +414,20 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-node": {
-      "version": "3.52.0",
-      "license": "Apache-2.0",
+      "version": "3.53.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.53.0.tgz",
+      "integrity": "sha512-sy0NeuJHOBhe7XwxCX2y+YZAB4CqcHveyXJfT6mv7eY6bYQskkMTCPp2D586hSH3c6cfIsmvLSxNhNJApj1Atw==",
       "dependencies": {
-        "@aws-sdk/credential-provider-env": "3.52.0",
-        "@aws-sdk/credential-provider-imds": "3.52.0",
-        "@aws-sdk/credential-provider-ini": "3.52.0",
-        "@aws-sdk/credential-provider-process": "3.52.0",
-        "@aws-sdk/credential-provider-sso": "3.52.0",
-        "@aws-sdk/credential-provider-web-identity": "3.52.0",
-        "@aws-sdk/property-provider": "3.52.0",
+        "@aws-sdk/credential-provider-env": "3.53.0",
+        "@aws-sdk/credential-provider-imds": "3.53.0",
+        "@aws-sdk/credential-provider-ini": "3.53.0",
+        "@aws-sdk/credential-provider-process": "3.53.0",
+        "@aws-sdk/credential-provider-sso": "3.53.0",
+        "@aws-sdk/credential-provider-web-identity": "3.53.0",
+        "@aws-sdk/property-provider": "3.53.0",
         "@aws-sdk/shared-ini-file-loader": "3.52.0",
-        "@aws-sdk/types": "3.52.0",
-        "@aws-sdk/util-credentials": "3.52.0",
+        "@aws-sdk/types": "3.53.0",
+        "@aws-sdk/util-credentials": "3.53.0",
         "tslib": "^2.3.0"
       },
       "engines": {
@@ -376,13 +435,14 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-process": {
-      "version": "3.52.0",
-      "license": "Apache-2.0",
+      "version": "3.53.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.53.0.tgz",
+      "integrity": "sha512-nazHndueCa4y5jUM58OHSysb52E953r3VhmpCs0qIv1ZH5Ijs3kT/usbUq7Yms7pcpaUmpu00VZTc6IfOOC0GA==",
       "dependencies": {
-        "@aws-sdk/property-provider": "3.52.0",
+        "@aws-sdk/property-provider": "3.53.0",
         "@aws-sdk/shared-ini-file-loader": "3.52.0",
-        "@aws-sdk/types": "3.52.0",
-        "@aws-sdk/util-credentials": "3.52.0",
+        "@aws-sdk/types": "3.53.0",
+        "@aws-sdk/util-credentials": "3.53.0",
         "tslib": "^2.3.0"
       },
       "engines": {
@@ -390,14 +450,15 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-sso": {
-      "version": "3.52.0",
-      "license": "Apache-2.0",
+      "version": "3.53.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.53.0.tgz",
+      "integrity": "sha512-EongClNxdVw+O4y+S0mZFjNeLHv1ssdAnBM/9L1PfR6sH06eikVmU6isEN2quwoKBy9HRVPaIVF075Q8QIpipg==",
       "dependencies": {
-        "@aws-sdk/client-sso": "3.52.0",
-        "@aws-sdk/property-provider": "3.52.0",
+        "@aws-sdk/client-sso": "3.53.0",
+        "@aws-sdk/property-provider": "3.53.0",
         "@aws-sdk/shared-ini-file-loader": "3.52.0",
-        "@aws-sdk/types": "3.52.0",
-        "@aws-sdk/util-credentials": "3.52.0",
+        "@aws-sdk/types": "3.53.0",
+        "@aws-sdk/util-credentials": "3.53.0",
         "tslib": "^2.3.0"
       },
       "engines": {
@@ -405,11 +466,12 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-web-identity": {
-      "version": "3.52.0",
-      "license": "Apache-2.0",
+      "version": "3.53.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.53.0.tgz",
+      "integrity": "sha512-YbysBkX3mbomHJZULxk/3jyQ7NWn6rZ68IDY28bmp8cNWajWeGzDxKmR4Y+c8gNiN2ziWjUZWfHcnZC056/79Q==",
       "dependencies": {
-        "@aws-sdk/property-provider": "3.52.0",
-        "@aws-sdk/types": "3.52.0",
+        "@aws-sdk/property-provider": "3.53.0",
+        "@aws-sdk/types": "3.53.0",
         "tslib": "^2.3.0"
       },
       "engines": {
@@ -417,22 +479,24 @@
       }
     },
     "node_modules/@aws-sdk/eventstream-marshaller": {
-      "version": "3.52.0",
-      "license": "Apache-2.0",
+      "version": "3.53.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-marshaller/-/eventstream-marshaller-3.53.0.tgz",
+      "integrity": "sha512-Vt8OjC0hgF0rNcGPbMEROnM5SHODzRdQsG9Y+M2suWDkUqFoh8+6m4v9c/ej3iudAEydZDLcnpV9yGv/CTqceg==",
       "dependencies": {
         "@aws-crypto/crc32": "2.0.0",
-        "@aws-sdk/types": "3.52.0",
+        "@aws-sdk/types": "3.53.0",
         "@aws-sdk/util-hex-encoding": "3.52.0",
         "tslib": "^2.3.0"
       }
     },
     "node_modules/@aws-sdk/eventstream-serde-browser": {
-      "version": "3.52.0",
-      "license": "Apache-2.0",
+      "version": "3.53.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-browser/-/eventstream-serde-browser-3.53.0.tgz",
+      "integrity": "sha512-B+nAlXet/NSEIzaN4fZYGwoFHBYtURuXUE+Ru4EaWyC8+vBEdeO4Vs9o/8mlZSHGiUn41QYYqiZvd+OKweTtBA==",
       "dependencies": {
-        "@aws-sdk/eventstream-marshaller": "3.52.0",
-        "@aws-sdk/eventstream-serde-universal": "3.52.0",
-        "@aws-sdk/types": "3.52.0",
+        "@aws-sdk/eventstream-marshaller": "3.53.0",
+        "@aws-sdk/eventstream-serde-universal": "3.53.0",
+        "@aws-sdk/types": "3.53.0",
         "tslib": "^2.3.0"
       },
       "engines": {
@@ -440,10 +504,11 @@
       }
     },
     "node_modules/@aws-sdk/eventstream-serde-config-resolver": {
-      "version": "3.52.0",
-      "license": "Apache-2.0",
+      "version": "3.53.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-config-resolver/-/eventstream-serde-config-resolver-3.53.0.tgz",
+      "integrity": "sha512-4O66c1aSgfdWfbr2pUJTONReVwA4oWQ/fRMhcAMhacqbPko5+3v0Iy/vOiVCm6Isa4K2kVpOUN0L+64niE7jag==",
       "dependencies": {
-        "@aws-sdk/types": "3.52.0",
+        "@aws-sdk/types": "3.53.0",
         "tslib": "^2.3.0"
       },
       "engines": {
@@ -451,12 +516,13 @@
       }
     },
     "node_modules/@aws-sdk/eventstream-serde-node": {
-      "version": "3.52.0",
-      "license": "Apache-2.0",
+      "version": "3.53.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-node/-/eventstream-serde-node-3.53.0.tgz",
+      "integrity": "sha512-92rlY8M8+nU4mUm3j4gtJiv9HY2fGTGLSIGLukOXAUf7xuJ220L+9ZInS4ToiRgq+dOSt8cFPCxRVpQtNesBfA==",
       "dependencies": {
-        "@aws-sdk/eventstream-marshaller": "3.52.0",
-        "@aws-sdk/eventstream-serde-universal": "3.52.0",
-        "@aws-sdk/types": "3.52.0",
+        "@aws-sdk/eventstream-marshaller": "3.53.0",
+        "@aws-sdk/eventstream-serde-universal": "3.53.0",
+        "@aws-sdk/types": "3.53.0",
         "tslib": "^2.3.0"
       },
       "engines": {
@@ -464,11 +530,12 @@
       }
     },
     "node_modules/@aws-sdk/eventstream-serde-universal": {
-      "version": "3.52.0",
-      "license": "Apache-2.0",
+      "version": "3.53.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-universal/-/eventstream-serde-universal-3.53.0.tgz",
+      "integrity": "sha512-Y3OjTAKhDyz2UyLE0ATmDD3RFyBfJLWeBQkpJu7qICI0XYN2tmV1mCkQUtkT3e4s+UxnuUOa55YQpdUsQUWIDA==",
       "dependencies": {
-        "@aws-sdk/eventstream-marshaller": "3.52.0",
-        "@aws-sdk/types": "3.52.0",
+        "@aws-sdk/eventstream-marshaller": "3.53.0",
+        "@aws-sdk/types": "3.53.0",
         "tslib": "^2.3.0"
       },
       "engines": {
@@ -476,31 +543,34 @@
       }
     },
     "node_modules/@aws-sdk/fetch-http-handler": {
-      "version": "3.52.0",
-      "license": "Apache-2.0",
+      "version": "3.53.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.53.0.tgz",
+      "integrity": "sha512-0CcEYarIAVAoGzu1ClO2xDq30Jii6AevDFJYR7M9yojqAMvwjP31DY4/qfPc2nCpSAd9dASR6vcx6r/RoIynVg==",
       "dependencies": {
-        "@aws-sdk/protocol-http": "3.52.0",
-        "@aws-sdk/querystring-builder": "3.52.0",
-        "@aws-sdk/types": "3.52.0",
+        "@aws-sdk/protocol-http": "3.53.0",
+        "@aws-sdk/querystring-builder": "3.53.0",
+        "@aws-sdk/types": "3.53.0",
         "@aws-sdk/util-base64-browser": "3.52.0",
         "tslib": "^2.3.0"
       }
     },
     "node_modules/@aws-sdk/hash-blob-browser": {
-      "version": "3.52.0",
-      "license": "Apache-2.0",
+      "version": "3.53.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/hash-blob-browser/-/hash-blob-browser-3.53.0.tgz",
+      "integrity": "sha512-A3xa0o1W9/tALw0/yoXyBKfxsMlzi1BvzEgCFUU2y914yBo62FiIf1E+BX42m9MfPJ87SD+l3O5QcptMVWvarw==",
       "dependencies": {
         "@aws-sdk/chunked-blob-reader": "3.52.0",
         "@aws-sdk/chunked-blob-reader-native": "3.52.0",
-        "@aws-sdk/types": "3.52.0",
+        "@aws-sdk/types": "3.53.0",
         "tslib": "^2.3.0"
       }
     },
     "node_modules/@aws-sdk/hash-node": {
-      "version": "3.52.0",
-      "license": "Apache-2.0",
+      "version": "3.53.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.53.0.tgz",
+      "integrity": "sha512-0xK5PSUUVOPttvCLWrrUTmrKe7Fz6njPdBYvB3ESk1whXL+TY3syJj4em63Sq6yFyeuXdqyTzqfcs9fU2puWkA==",
       "dependencies": {
-        "@aws-sdk/types": "3.52.0",
+        "@aws-sdk/types": "3.53.0",
         "@aws-sdk/util-buffer-from": "3.52.0",
         "tslib": "^2.3.0"
       },
@@ -509,10 +579,11 @@
       }
     },
     "node_modules/@aws-sdk/hash-stream-node": {
-      "version": "3.52.0",
-      "license": "Apache-2.0",
+      "version": "3.53.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/hash-stream-node/-/hash-stream-node-3.53.1.tgz",
+      "integrity": "sha512-y7pUc6EtkG3TscZR9dpR/BCauP/lRepU+Td43Oe9VUhD6l3lS3TuIHUwB7PEU7NeSU9iqWuflBVK/IBWXrfH3w==",
       "dependencies": {
-        "@aws-sdk/types": "3.52.0",
+        "@aws-sdk/types": "3.53.0",
         "tslib": "^2.3.0"
       },
       "engines": {
@@ -520,16 +591,18 @@
       }
     },
     "node_modules/@aws-sdk/invalid-dependency": {
-      "version": "3.52.0",
-      "license": "Apache-2.0",
+      "version": "3.53.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-3.53.0.tgz",
+      "integrity": "sha512-qp2qRFa1a/AjZRCe6MZCpbaXo5t4enGAtch/83fuH4rRkzVOctYox1gyTGTliHk28rjMREtSgZDQZojp5/5M5w==",
       "dependencies": {
-        "@aws-sdk/types": "3.52.0",
+        "@aws-sdk/types": "3.53.0",
         "tslib": "^2.3.0"
       }
     },
     "node_modules/@aws-sdk/is-array-buffer": {
       "version": "3.52.0",
-      "license": "Apache-2.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.52.0.tgz",
+      "integrity": "sha512-5Pe9QKrOeSZb9Z8gtlx9CDMfxH8EiNdClBfXBbc6CiUM7y6l7UintYHkm133zM5XTqtMRYY1jaD8svVAoRPApA==",
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -538,34 +611,23 @@
       }
     },
     "node_modules/@aws-sdk/md5-js": {
-      "version": "3.52.0",
-      "license": "Apache-2.0",
+      "version": "3.53.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/md5-js/-/md5-js-3.53.0.tgz",
+      "integrity": "sha512-+XbYdbxgWniyC7E4kqHC0z0Qsud/EMv9RuKghWLr7IwbUjfR7zix5+AVw3XR+FWrKrDAlyRBhyzG+60STliuiA==",
       "dependencies": {
-        "@aws-sdk/types": "3.52.0",
+        "@aws-sdk/types": "3.53.0",
         "@aws-sdk/util-utf8-browser": "3.52.0",
         "@aws-sdk/util-utf8-node": "3.52.0",
         "tslib": "^2.3.0"
       }
     },
-    "node_modules/@aws-sdk/middleware-apply-body-checksum": {
-      "version": "3.52.0",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/is-array-buffer": "3.52.0",
-        "@aws-sdk/protocol-http": "3.52.0",
-        "@aws-sdk/types": "3.52.0",
-        "tslib": "^2.3.0"
-      },
-      "engines": {
-        "node": ">= 12.0.0"
-      }
-    },
     "node_modules/@aws-sdk/middleware-bucket-endpoint": {
-      "version": "3.52.0",
-      "license": "Apache-2.0",
+      "version": "3.53.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-bucket-endpoint/-/middleware-bucket-endpoint-3.53.0.tgz",
+      "integrity": "sha512-q88eevXUkUWp6e/vHGnpt8/8TjscbfW6CWGpexj3DFWt3WZhEhExcoGwwszoL4FQfMFWBL+11EKNZm2orHqDwg==",
       "dependencies": {
-        "@aws-sdk/protocol-http": "3.52.0",
-        "@aws-sdk/types": "3.52.0",
+        "@aws-sdk/protocol-http": "3.53.0",
+        "@aws-sdk/types": "3.53.0",
         "@aws-sdk/util-arn-parser": "3.52.0",
         "@aws-sdk/util-config-provider": "3.52.0",
         "tslib": "^2.3.0"
@@ -575,11 +637,12 @@
       }
     },
     "node_modules/@aws-sdk/middleware-content-length": {
-      "version": "3.52.0",
-      "license": "Apache-2.0",
+      "version": "3.53.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.53.0.tgz",
+      "integrity": "sha512-CXANhpL2MAE2tPKmu0cOf4Fd99useIj5kgX6UA+HWg/ZbJ4qBg6Q4W/nYVt+OuukeqwEEbpt3wv0lKQ8k/vINQ==",
       "dependencies": {
-        "@aws-sdk/protocol-http": "3.52.0",
-        "@aws-sdk/types": "3.52.0",
+        "@aws-sdk/protocol-http": "3.53.0",
+        "@aws-sdk/types": "3.53.0",
         "tslib": "^2.3.0"
       },
       "engines": {
@@ -587,12 +650,29 @@
       }
     },
     "node_modules/@aws-sdk/middleware-expect-continue": {
-      "version": "3.52.0",
-      "license": "Apache-2.0",
+      "version": "3.53.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-expect-continue/-/middleware-expect-continue-3.53.0.tgz",
+      "integrity": "sha512-aMKtfOX9b1yx0ER0QspN2jOR/Q1ucRYEaR46yOUPjdcMHHnGxuk3kimsyGqgFm2+pPJdi9FRd9S2eC/tNjYn8w==",
       "dependencies": {
-        "@aws-sdk/middleware-header-default": "3.52.0",
-        "@aws-sdk/protocol-http": "3.52.0",
-        "@aws-sdk/types": "3.52.0",
+        "@aws-sdk/middleware-header-default": "3.53.0",
+        "@aws-sdk/protocol-http": "3.53.0",
+        "@aws-sdk/types": "3.53.0",
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-flexible-checksums": {
+      "version": "3.53.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-flexible-checksums/-/middleware-flexible-checksums-3.53.0.tgz",
+      "integrity": "sha512-g069Es0Sy3So2HRz+UAwaubFKkGuxwhEf6OS9pmovY2+2yfZBOLoQmf7jS50RgbxJcUDoI7uuKZrp0BcdLDgEg==",
+      "dependencies": {
+        "@aws-crypto/crc32": "2.0.0",
+        "@aws-crypto/crc32c": "2.0.0",
+        "@aws-sdk/is-array-buffer": "3.52.0",
+        "@aws-sdk/protocol-http": "3.53.0",
+        "@aws-sdk/types": "3.53.0",
         "tslib": "^2.3.0"
       },
       "engines": {
@@ -600,11 +680,12 @@
       }
     },
     "node_modules/@aws-sdk/middleware-header-default": {
-      "version": "3.52.0",
-      "license": "Apache-2.0",
+      "version": "3.53.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-header-default/-/middleware-header-default-3.53.0.tgz",
+      "integrity": "sha512-eQLFdNBzydZoocnj7YDVO+AJZ3YhuImZ1GXzGsF9FN8IdSjuE4gwB8BQhG6vuUg3GVe+sI+7VUJT6h55OaDBXw==",
       "dependencies": {
-        "@aws-sdk/protocol-http": "3.52.0",
-        "@aws-sdk/types": "3.52.0",
+        "@aws-sdk/protocol-http": "3.53.0",
+        "@aws-sdk/types": "3.53.0",
         "tslib": "^2.3.0"
       },
       "engines": {
@@ -612,11 +693,12 @@
       }
     },
     "node_modules/@aws-sdk/middleware-host-header": {
-      "version": "3.52.0",
-      "license": "Apache-2.0",
+      "version": "3.53.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.53.0.tgz",
+      "integrity": "sha512-w5qMAUgy52fvJGqzqruNJhv4BtkanE4I368zWiysmwXXL5xmpKs8TpkGqcSQw4g2wKS8MR2Yxh21LukHlsgAJw==",
       "dependencies": {
-        "@aws-sdk/protocol-http": "3.52.0",
-        "@aws-sdk/types": "3.52.0",
+        "@aws-sdk/protocol-http": "3.53.0",
+        "@aws-sdk/types": "3.53.0",
         "tslib": "^2.3.0"
       },
       "engines": {
@@ -624,10 +706,11 @@
       }
     },
     "node_modules/@aws-sdk/middleware-location-constraint": {
-      "version": "3.52.0",
-      "license": "Apache-2.0",
+      "version": "3.53.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-location-constraint/-/middleware-location-constraint-3.53.0.tgz",
+      "integrity": "sha512-HtBy8L3XNbovHLVh6wtIIThsbdTsX+jv09M9Cmmu80eM1WXw5Uu6lJX6FdIQXfMXBTZjnmHRL+72CxEtsets8g==",
       "dependencies": {
-        "@aws-sdk/types": "3.52.0",
+        "@aws-sdk/types": "3.53.0",
         "tslib": "^2.3.0"
       },
       "engines": {
@@ -635,10 +718,11 @@
       }
     },
     "node_modules/@aws-sdk/middleware-logger": {
-      "version": "3.52.0",
-      "license": "Apache-2.0",
+      "version": "3.53.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.53.0.tgz",
+      "integrity": "sha512-jMME8OOyPHliHhVD3FaBQ+4X+FDCQovw6CYGqPdqP0JUuhR8E1LWKHV1+xRpkpOICKwBnIXrgD8/0NQo/+Z84A==",
       "dependencies": {
-        "@aws-sdk/types": "3.52.0",
+        "@aws-sdk/types": "3.53.0",
         "tslib": "^2.3.0"
       },
       "engines": {
@@ -646,12 +730,13 @@
       }
     },
     "node_modules/@aws-sdk/middleware-retry": {
-      "version": "3.52.0",
-      "license": "Apache-2.0",
+      "version": "3.53.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.53.0.tgz",
+      "integrity": "sha512-TKEdTLP//SjasunU3/yX7avXMxhIEDoSOaiwj77zEpPGF2NWcR99UFfqNLeJsRPCyzYScYo1JSuxIwgXHNIhyQ==",
       "dependencies": {
-        "@aws-sdk/protocol-http": "3.52.0",
-        "@aws-sdk/service-error-classification": "3.52.0",
-        "@aws-sdk/types": "3.52.0",
+        "@aws-sdk/protocol-http": "3.53.0",
+        "@aws-sdk/service-error-classification": "3.53.0",
+        "@aws-sdk/types": "3.53.0",
         "tslib": "^2.3.0",
         "uuid": "^8.3.2"
       },
@@ -660,12 +745,13 @@
       }
     },
     "node_modules/@aws-sdk/middleware-sdk-s3": {
-      "version": "3.52.0",
-      "license": "Apache-2.0",
+      "version": "3.53.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.53.0.tgz",
+      "integrity": "sha512-cq2NFixf5HBctPaUUMjV97M++q18e/WDrM61lN7eMHfdXW+TlYv4tVF9y9MaE7dpoNp7G0ORLsz05JdVdUI33g==",
       "dependencies": {
-        "@aws-sdk/protocol-http": "3.52.0",
-        "@aws-sdk/signature-v4": "3.52.0",
-        "@aws-sdk/types": "3.52.0",
+        "@aws-sdk/protocol-http": "3.53.0",
+        "@aws-sdk/signature-v4": "3.53.0",
+        "@aws-sdk/types": "3.53.0",
         "@aws-sdk/util-arn-parser": "3.52.0",
         "tslib": "^2.3.0"
       },
@@ -677,14 +763,15 @@
       }
     },
     "node_modules/@aws-sdk/middleware-sdk-sts": {
-      "version": "3.52.0",
-      "license": "Apache-2.0",
+      "version": "3.53.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.53.0.tgz",
+      "integrity": "sha512-b9AUXYqA5jaUTpWu7wPZz43RQnmy1WGPFVHd8CvcUzFdMzwJlQeH4wq+sEdZ1KtIsz6n6TmY7vobzrScgq3ftg==",
       "dependencies": {
-        "@aws-sdk/middleware-signing": "3.52.0",
-        "@aws-sdk/property-provider": "3.52.0",
-        "@aws-sdk/protocol-http": "3.52.0",
-        "@aws-sdk/signature-v4": "3.52.0",
-        "@aws-sdk/types": "3.52.0",
+        "@aws-sdk/middleware-signing": "3.53.0",
+        "@aws-sdk/property-provider": "3.53.0",
+        "@aws-sdk/protocol-http": "3.53.0",
+        "@aws-sdk/signature-v4": "3.53.0",
+        "@aws-sdk/types": "3.53.0",
         "tslib": "^2.3.0"
       },
       "engines": {
@@ -692,10 +779,11 @@
       }
     },
     "node_modules/@aws-sdk/middleware-serde": {
-      "version": "3.52.0",
-      "license": "Apache-2.0",
+      "version": "3.53.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.53.0.tgz",
+      "integrity": "sha512-jPoou51ULWN2PpvWkDF3wLKnTezyM33NBdF89mvfnI4++Za0/NpuL12636YqWLXt2CK87u8cA2Q+7Opob7KocA==",
       "dependencies": {
-        "@aws-sdk/types": "3.52.0",
+        "@aws-sdk/types": "3.53.0",
         "tslib": "^2.3.0"
       },
       "engines": {
@@ -703,13 +791,14 @@
       }
     },
     "node_modules/@aws-sdk/middleware-signing": {
-      "version": "3.52.0",
-      "license": "Apache-2.0",
+      "version": "3.53.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.53.0.tgz",
+      "integrity": "sha512-r3g2ytin1YbhXCDedMfR7ZSlt1B39GWA0+J04ZZzUdevtnS2VnkFNhsanO5os/WOpVUV7iqk/ncJgSpn9LI2DA==",
       "dependencies": {
-        "@aws-sdk/property-provider": "3.52.0",
-        "@aws-sdk/protocol-http": "3.52.0",
-        "@aws-sdk/signature-v4": "3.52.0",
-        "@aws-sdk/types": "3.52.0",
+        "@aws-sdk/property-provider": "3.53.0",
+        "@aws-sdk/protocol-http": "3.53.0",
+        "@aws-sdk/signature-v4": "3.53.0",
+        "@aws-sdk/types": "3.53.0",
         "tslib": "^2.3.0"
       },
       "engines": {
@@ -717,10 +806,11 @@
       }
     },
     "node_modules/@aws-sdk/middleware-ssec": {
-      "version": "3.52.0",
-      "license": "Apache-2.0",
+      "version": "3.53.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-ssec/-/middleware-ssec-3.53.0.tgz",
+      "integrity": "sha512-2p2QT3PNepUC5MwT+t0l9bf7MlRHw6DN6CLg4Dptgr3SFR2k8LjUp2S7dJqg4qrhXRiiO7lTZK57PaPPR90dFw==",
       "dependencies": {
-        "@aws-sdk/types": "3.52.0",
+        "@aws-sdk/types": "3.53.0",
         "tslib": "^2.3.0"
       },
       "engines": {
@@ -728,8 +818,9 @@
       }
     },
     "node_modules/@aws-sdk/middleware-stack": {
-      "version": "3.52.0",
-      "license": "Apache-2.0",
+      "version": "3.53.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.53.0.tgz",
+      "integrity": "sha512-YanQOVUXGjm63GCZVRYPlPMl6niaWtVjE2C0+0lpCrJQYaUIrvKh27Ff40JLi3U0F89hmsYOO7yPQOPTbc9NBg==",
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -738,11 +829,12 @@
       }
     },
     "node_modules/@aws-sdk/middleware-user-agent": {
-      "version": "3.52.0",
-      "license": "Apache-2.0",
+      "version": "3.53.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.53.0.tgz",
+      "integrity": "sha512-ClKxpFXoHLhdnDxyDRRVNaFYQnfylps7rk1wfbRLWb+FWQwKWBvLq5c5ZPvznBU8BvftDSkFtrY+7OLMlj6qxA==",
       "dependencies": {
-        "@aws-sdk/protocol-http": "3.52.0",
-        "@aws-sdk/types": "3.52.0",
+        "@aws-sdk/protocol-http": "3.53.0",
+        "@aws-sdk/types": "3.53.0",
         "tslib": "^2.3.0"
       },
       "engines": {
@@ -750,12 +842,13 @@
       }
     },
     "node_modules/@aws-sdk/node-config-provider": {
-      "version": "3.52.0",
-      "license": "Apache-2.0",
+      "version": "3.53.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.53.0.tgz",
+      "integrity": "sha512-l00gDzU7n2WSIBHZPVW8/t6L0UD6qwtre5kuGKiv8ZkZKynPg9VV39IB/JZ7swp2uydbXuqxgDxFvqImvY3IyA==",
       "dependencies": {
-        "@aws-sdk/property-provider": "3.52.0",
+        "@aws-sdk/property-provider": "3.53.0",
         "@aws-sdk/shared-ini-file-loader": "3.52.0",
-        "@aws-sdk/types": "3.52.0",
+        "@aws-sdk/types": "3.53.0",
         "tslib": "^2.3.0"
       },
       "engines": {
@@ -763,13 +856,14 @@
       }
     },
     "node_modules/@aws-sdk/node-http-handler": {
-      "version": "3.52.0",
-      "license": "Apache-2.0",
+      "version": "3.53.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.53.0.tgz",
+      "integrity": "sha512-YqovPyn75gNzDSvPWQUTAEbwhr8PBdp1MQz65bB8p+qOlzQi1jGCyj1uHqG7qwVIlis9+bAfqpAqNDuYpdGsNg==",
       "dependencies": {
-        "@aws-sdk/abort-controller": "3.52.0",
-        "@aws-sdk/protocol-http": "3.52.0",
-        "@aws-sdk/querystring-builder": "3.52.0",
-        "@aws-sdk/types": "3.52.0",
+        "@aws-sdk/abort-controller": "3.53.0",
+        "@aws-sdk/protocol-http": "3.53.0",
+        "@aws-sdk/querystring-builder": "3.53.0",
+        "@aws-sdk/types": "3.53.0",
         "tslib": "^2.3.0"
       },
       "engines": {
@@ -777,10 +871,11 @@
       }
     },
     "node_modules/@aws-sdk/property-provider": {
-      "version": "3.52.0",
-      "license": "Apache-2.0",
+      "version": "3.53.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.53.0.tgz",
+      "integrity": "sha512-qrVFYcOV/Da7/ozW2bDLDz0JQP0NLIn6/eNUwT2fqKVw9MWcrLf6xtyAJhCwckdUVOWS2HoBSyvEopa4mdh9Sw==",
       "dependencies": {
-        "@aws-sdk/types": "3.52.0",
+        "@aws-sdk/types": "3.53.0",
         "tslib": "^2.3.0"
       },
       "engines": {
@@ -788,10 +883,11 @@
       }
     },
     "node_modules/@aws-sdk/protocol-http": {
-      "version": "3.52.0",
-      "license": "Apache-2.0",
+      "version": "3.53.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.53.0.tgz",
+      "integrity": "sha512-lKOXq2FjQH2i/ztJOKHoNgJ9Kpaprhb6/lsKMjHuePr/YDEzp62nEuJKbVx5rA9C8Rxuuj2hE8vXhQ6dyUIsjg==",
       "dependencies": {
-        "@aws-sdk/types": "3.52.0",
+        "@aws-sdk/types": "3.53.0",
         "tslib": "^2.3.0"
       },
       "engines": {
@@ -799,10 +895,11 @@
       }
     },
     "node_modules/@aws-sdk/querystring-builder": {
-      "version": "3.52.0",
-      "license": "Apache-2.0",
+      "version": "3.53.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.53.0.tgz",
+      "integrity": "sha512-oliOrup52985pSKOjHbbm7t3bGL0HTPs9UODhBuDpHE7l0pdWE1hv9YiU3FF5NUIF25VwbL83GYmL9R52GxZhA==",
       "dependencies": {
-        "@aws-sdk/types": "3.52.0",
+        "@aws-sdk/types": "3.53.0",
         "@aws-sdk/util-uri-escape": "3.52.0",
         "tslib": "^2.3.0"
       },
@@ -811,10 +908,11 @@
       }
     },
     "node_modules/@aws-sdk/querystring-parser": {
-      "version": "3.52.0",
-      "license": "Apache-2.0",
+      "version": "3.53.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.53.0.tgz",
+      "integrity": "sha512-wEkS40w/wW4eBSnf7xt+m8InZFVzjLAzRYK1yPab2qfOIShpWgxg1ndqEP0eu14MvwdEfMPW9xU6J2AiWoxWng==",
       "dependencies": {
-        "@aws-sdk/types": "3.52.0",
+        "@aws-sdk/types": "3.53.0",
         "tslib": "^2.3.0"
       },
       "engines": {
@@ -822,15 +920,17 @@
       }
     },
     "node_modules/@aws-sdk/service-error-classification": {
-      "version": "3.52.0",
-      "license": "Apache-2.0",
+      "version": "3.53.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.53.0.tgz",
+      "integrity": "sha512-l5g8QncKk0ZmzQL7mWyQ6n5xWkd1XQJuoOfLZPBas9SJAyz7wanV5P3CG9PX6s1GVHWLC+2MafpIQ6+aH1x5cQ==",
       "engines": {
         "node": ">= 12.0.0"
       }
     },
     "node_modules/@aws-sdk/shared-ini-file-loader": {
       "version": "3.52.0",
-      "license": "Apache-2.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.52.0.tgz",
+      "integrity": "sha512-tALb8u8IVcI4pT7yFZpl4O6kgeY5EAXyphZoRPgQSCDhmEyFUIi/sXbCN8HQiHjnHdWfXdaNE1YsZcW3GpcuoQ==",
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -839,11 +939,12 @@
       }
     },
     "node_modules/@aws-sdk/signature-v4": {
-      "version": "3.52.0",
-      "license": "Apache-2.0",
+      "version": "3.53.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.53.0.tgz",
+      "integrity": "sha512-CUvCIrwiiWpJd/ldSA04RERXPsdvkuKW3+gBDIUREq4uc7co7Cml1/wbIJ0UOHAmJpDw82NDYqAUthYB1kbHrQ==",
       "dependencies": {
         "@aws-sdk/is-array-buffer": "3.52.0",
-        "@aws-sdk/types": "3.52.0",
+        "@aws-sdk/types": "3.53.0",
         "@aws-sdk/util-hex-encoding": "3.52.0",
         "@aws-sdk/util-uri-escape": "3.52.0",
         "tslib": "^2.3.0"
@@ -853,13 +954,14 @@
       }
     },
     "node_modules/@aws-sdk/signature-v4-crt": {
-      "version": "3.52.0",
-      "license": "Apache-2.0",
+      "version": "3.53.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-crt/-/signature-v4-crt-3.53.0.tgz",
+      "integrity": "sha512-xpBuMFr8o4q0KidnCxCS8V56HmMIGdEPQkf4omfDiFc/7nTD4SfAgissZXd0x/xgJE8QyJn57O7+uyToexb2OQ==",
       "peer": true,
       "dependencies": {
         "@aws-sdk/is-array-buffer": "3.52.0",
-        "@aws-sdk/querystring-parser": "3.52.0",
-        "@aws-sdk/signature-v4": "3.52.0",
+        "@aws-sdk/querystring-parser": "3.53.0",
+        "@aws-sdk/signature-v4": "3.53.0",
         "@aws-sdk/util-hex-encoding": "3.52.0",
         "@aws-sdk/util-uri-escape": "3.52.0",
         "aws-crt": "^1.9.7",
@@ -870,11 +972,12 @@
       }
     },
     "node_modules/@aws-sdk/smithy-client": {
-      "version": "3.52.0",
-      "license": "Apache-2.0",
+      "version": "3.53.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.53.0.tgz",
+      "integrity": "sha512-/mZn1/1/BXFgV5PwbGfXczbSyZFrhUEhWQzPG7x1NXLQh3kcSoHGDSONqFhqTeHWkfEXp1Tn0zUe7R4vAseFmQ==",
       "dependencies": {
-        "@aws-sdk/middleware-stack": "3.52.0",
-        "@aws-sdk/types": "3.52.0",
+        "@aws-sdk/middleware-stack": "3.53.0",
+        "@aws-sdk/types": "3.53.0",
         "tslib": "^2.3.0"
       },
       "engines": {
@@ -882,24 +985,27 @@
       }
     },
     "node_modules/@aws-sdk/types": {
-      "version": "3.52.0",
-      "license": "Apache-2.0",
+      "version": "3.53.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.53.0.tgz",
+      "integrity": "sha512-FqHfWRXdnQvfxgngDKfYpYOuQ1HmPgxaGKELx3pFaEnQdMo/dMXjfBGQcEQgP8jqU6bPLaJSfykjWjDzua8JBg==",
       "engines": {
         "node": ">= 12.0.0"
       }
     },
     "node_modules/@aws-sdk/url-parser": {
-      "version": "3.52.0",
-      "license": "Apache-2.0",
+      "version": "3.53.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.53.0.tgz",
+      "integrity": "sha512-lB0U5TkBDSdJK8h3noDkSG/P1cGnpSxOxBroMgPHA8Lrf5lmFRMvDXLXMhRDnTiqtsd/DpHDPyat91pfwLVEwA==",
       "dependencies": {
-        "@aws-sdk/querystring-parser": "3.52.0",
-        "@aws-sdk/types": "3.52.0",
+        "@aws-sdk/querystring-parser": "3.53.0",
+        "@aws-sdk/types": "3.53.0",
         "tslib": "^2.3.0"
       }
     },
     "node_modules/@aws-sdk/util-arn-parser": {
       "version": "3.52.0",
-      "license": "Apache-2.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-arn-parser/-/util-arn-parser-3.52.0.tgz",
+      "integrity": "sha512-mMsoYJ70+BGkVpdfQbu942v4fAGzx+pIL8+QnQhzUmcU0HbNkI0vYliMWfzz7ka9CHgbijUI/ANKA319zgKtvA==",
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -909,14 +1015,16 @@
     },
     "node_modules/@aws-sdk/util-base64-browser": {
       "version": "3.52.0",
-      "license": "Apache-2.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64-browser/-/util-base64-browser-3.52.0.tgz",
+      "integrity": "sha512-xjv/cQ4goWXAiGEC/AIL/GtlHg4p4RkQKs6/zxn9jOxo1OnbppLMJ0LjCtv4/JVYIVGHrx0VJ8Exyod7Ln+NeA==",
       "dependencies": {
         "tslib": "^2.3.0"
       }
     },
     "node_modules/@aws-sdk/util-base64-node": {
       "version": "3.52.0",
-      "license": "Apache-2.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64-node/-/util-base64-node-3.52.0.tgz",
+      "integrity": "sha512-V96YIXBuIiVu7Zk72Y9dly7Io9cYOT30Hjf77KAkBeizlFgT5gWklWYGcytPY8FxLuEy4dPLeHRmgwQnlDwgPA==",
       "dependencies": {
         "@aws-sdk/util-buffer-from": "3.52.0",
         "tslib": "^2.3.0"
@@ -927,14 +1035,16 @@
     },
     "node_modules/@aws-sdk/util-body-length-browser": {
       "version": "3.52.0",
-      "license": "Apache-2.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-browser/-/util-body-length-browser-3.52.0.tgz",
+      "integrity": "sha512-8omOgIGmopUtwg3XaeyvqacxrIrCsDKUVQp5n+8iLmyYt5mQM70vXbUC273GJzKDtibGDfxiN4FqSLBlo9F/oQ==",
       "dependencies": {
         "tslib": "^2.3.0"
       }
     },
     "node_modules/@aws-sdk/util-body-length-node": {
       "version": "3.52.0",
-      "license": "Apache-2.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-node/-/util-body-length-node-3.52.0.tgz",
+      "integrity": "sha512-1WWsGh0hip4y1uvOLFV2v3Nvq3W35dmW5YniCi0gQDBLc5JHES8Zka7yoCDYOfaYFUodVH5mC/jFBjGRQ3TpDw==",
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -944,7 +1054,8 @@
     },
     "node_modules/@aws-sdk/util-buffer-from": {
       "version": "3.52.0",
-      "license": "Apache-2.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-buffer-from/-/util-buffer-from-3.52.0.tgz",
+      "integrity": "sha512-hsG0lMlHjJUFoXIy59QLn6x4QU/vp/e0t3EjdD0t8aymB9iuJ43UeLjYTZdrOgtbWb8MXEF747vwg+P6n+4Lxw==",
       "dependencies": {
         "@aws-sdk/is-array-buffer": "3.52.0",
         "tslib": "^2.3.0"
@@ -955,7 +1066,8 @@
     },
     "node_modules/@aws-sdk/util-config-provider": {
       "version": "3.52.0",
-      "license": "Apache-2.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-config-provider/-/util-config-provider-3.52.0.tgz",
+      "integrity": "sha512-1wonBNkOOLJpMZnz2Kn69ToFgSoTTyGzJInir8WC5sME3zpkb5j41kTuEVbImNJhVv9MKjmGYrMeZbBVniLRPw==",
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -964,8 +1076,9 @@
       }
     },
     "node_modules/@aws-sdk/util-credentials": {
-      "version": "3.52.0",
-      "license": "Apache-2.0",
+      "version": "3.53.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-credentials/-/util-credentials-3.53.0.tgz",
+      "integrity": "sha512-XP/3mYOmSn5KpWv+PnBTP2UExXb+hx1ugbH4Gkveshdq9KBlVnpV5eVgIwSAnKBsplScfsNMJ5EOtHjz5Cvu5A==",
       "dependencies": {
         "@aws-sdk/shared-ini-file-loader": "3.52.0",
         "tslib": "^2.3.0"
@@ -975,11 +1088,12 @@
       }
     },
     "node_modules/@aws-sdk/util-defaults-mode-browser": {
-      "version": "3.52.0",
-      "license": "Apache-2.0",
+      "version": "3.53.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-browser/-/util-defaults-mode-browser-3.53.0.tgz",
+      "integrity": "sha512-ubOcZT3rkVXSTwCHeIJevgBVV5GHnejz3hd+dFY9OcuK53oMZnFPS8SfJLgGG6PHfg30P8EurKv1VhWrbuuJDw==",
       "dependencies": {
-        "@aws-sdk/property-provider": "3.52.0",
-        "@aws-sdk/types": "3.52.0",
+        "@aws-sdk/property-provider": "3.53.0",
+        "@aws-sdk/types": "3.53.0",
         "bowser": "^2.11.0",
         "tslib": "^2.3.0"
       },
@@ -988,14 +1102,15 @@
       }
     },
     "node_modules/@aws-sdk/util-defaults-mode-node": {
-      "version": "3.52.0",
-      "license": "Apache-2.0",
+      "version": "3.53.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-node/-/util-defaults-mode-node-3.53.0.tgz",
+      "integrity": "sha512-84nczaF0eZMRkZ7chJh7OZd4ekV31eWmw8LOTJ4RQeeRy+0eY8th23yKyt5TU+YgmMLrY0BVK7103BQAI/6ccQ==",
       "dependencies": {
-        "@aws-sdk/config-resolver": "3.52.0",
-        "@aws-sdk/credential-provider-imds": "3.52.0",
-        "@aws-sdk/node-config-provider": "3.52.0",
-        "@aws-sdk/property-provider": "3.52.0",
-        "@aws-sdk/types": "3.52.0",
+        "@aws-sdk/config-resolver": "3.53.0",
+        "@aws-sdk/credential-provider-imds": "3.53.0",
+        "@aws-sdk/node-config-provider": "3.53.0",
+        "@aws-sdk/property-provider": "3.53.0",
+        "@aws-sdk/types": "3.53.0",
         "tslib": "^2.3.0"
       },
       "engines": {
@@ -1004,7 +1119,8 @@
     },
     "node_modules/@aws-sdk/util-hex-encoding": {
       "version": "3.52.0",
-      "license": "Apache-2.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.52.0.tgz",
+      "integrity": "sha512-YYMZg8odn/hBURgL/w82ay2mvPqXHMdujlSndT1ddUSTRoZX67N3hfYYf36nOalDOjNcanIvFHe4Fe8nw+8JiA==",
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -1014,8 +1130,30 @@
     },
     "node_modules/@aws-sdk/util-locate-window": {
       "version": "3.52.0",
-      "license": "Apache-2.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.52.0.tgz",
+      "integrity": "sha512-l10U2cLko6070A9DYLJG4NMtwYH8JBG2J/E+RH8uY3lad2o6fGEIkJU0jQbWbUeHYLG3IWuCxT47V4gxYrFj7g==",
       "dependencies": {
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-stream-browser": {
+      "version": "3.53.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-stream-browser/-/util-stream-browser-3.53.0.tgz",
+      "integrity": "sha512-oh+PVTeo7nvkuXwlrAy6TErTpzTRrtxaL+2ErTFiLFPPFKK2/0X0E12zoNB0DMaY48sRdkJmrlLbOtxGDS1rNg==",
+      "dependencies": {
+        "@aws-sdk/types": "3.53.0",
+        "tslib": "^2.3.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-stream-node": {
+      "version": "3.53.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-stream-node/-/util-stream-node-3.53.0.tgz",
+      "integrity": "sha512-Hubb2cvn2idlNsHkJ5v46wW+cvodLySGJCqTat5kUAoOxR20ZFG3P3R6InU85PAh54zZTRvURuD0UM0uPtIQYQ==",
+      "dependencies": {
+        "@aws-sdk/types": "3.53.0",
         "tslib": "^2.3.0"
       },
       "engines": {
@@ -1024,7 +1162,8 @@
     },
     "node_modules/@aws-sdk/util-uri-escape": {
       "version": "3.52.0",
-      "license": "Apache-2.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.52.0.tgz",
+      "integrity": "sha512-W9zw5tE8syjg17jiCYtyF99F0FgDIekQdLg+tQGobw9EtCxlUdg48UYhifPfnjvVyADRX2ntclHF9NmhusOQaQ==",
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -1033,20 +1172,22 @@
       }
     },
     "node_modules/@aws-sdk/util-user-agent-browser": {
-      "version": "3.52.0",
-      "license": "Apache-2.0",
+      "version": "3.53.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.53.0.tgz",
+      "integrity": "sha512-fJsxzjo4UMv2o6KYSvw8cwfDhAQiao3X+iY1lGNVKrcY2bnI4zW5pWYge94oIJXMyFjjg6k6Ek+JIvGLMFY0XA==",
       "dependencies": {
-        "@aws-sdk/types": "3.52.0",
+        "@aws-sdk/types": "3.53.0",
         "bowser": "^2.11.0",
         "tslib": "^2.3.0"
       }
     },
     "node_modules/@aws-sdk/util-user-agent-node": {
-      "version": "3.52.0",
-      "license": "Apache-2.0",
+      "version": "3.53.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.53.0.tgz",
+      "integrity": "sha512-YbrqMpTi+ArL9qG+NIXPInmnjGwYu0lohiH5uyEMHAHolqg4vqdKBlXyZ7Pjls2Nka7px2UUfX/Ba2RIssBBMQ==",
       "dependencies": {
-        "@aws-sdk/node-config-provider": "3.52.0",
-        "@aws-sdk/types": "3.52.0",
+        "@aws-sdk/node-config-provider": "3.53.0",
+        "@aws-sdk/types": "3.53.0",
         "tslib": "^2.3.0"
       },
       "engines": {
@@ -1055,14 +1196,16 @@
     },
     "node_modules/@aws-sdk/util-utf8-browser": {
       "version": "3.52.0",
-      "license": "Apache-2.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.52.0.tgz",
+      "integrity": "sha512-LuOMa9ajWu5fQuYkmvTlQZfHaITkSle+tM/vhbU4JquRN44VUKACjRGT7UEhoU3lCL1BD0JFGMQGHI+5Mmuwfg==",
       "dependencies": {
         "tslib": "^2.3.0"
       }
     },
     "node_modules/@aws-sdk/util-utf8-node": {
       "version": "3.52.0",
-      "license": "Apache-2.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-node/-/util-utf8-node-3.52.0.tgz",
+      "integrity": "sha512-fujr7zeobZ2y5nnOnQZrCPPc+lCAhtNF/LEVslsQfd+AQ0bYWiosrKNetodQVWlfh10E2+i6/5g+1SBJ5kjsLw==",
       "dependencies": {
         "@aws-sdk/util-buffer-from": "3.52.0",
         "tslib": "^2.3.0"
@@ -1072,11 +1215,12 @@
       }
     },
     "node_modules/@aws-sdk/util-waiter": {
-      "version": "3.52.0",
-      "license": "Apache-2.0",
+      "version": "3.53.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-waiter/-/util-waiter-3.53.0.tgz",
+      "integrity": "sha512-WyiyHOzmiapbbwB8dtu7axRqu9u5+Mnp1/+k2Ia7cm0UMUTKLjdixPsaM89HNre3EMa8WHrDBnwyVmo/Khbq3w==",
       "dependencies": {
-        "@aws-sdk/abort-controller": "3.52.0",
-        "@aws-sdk/types": "3.52.0",
+        "@aws-sdk/abort-controller": "3.53.0",
+        "@aws-sdk/types": "3.53.0",
         "tslib": "^2.3.0"
       },
       "engines": {
@@ -2762,7 +2906,8 @@
     },
     "node_modules/@httptoolkit/websocket-stream": {
       "version": "6.0.0",
-      "license": "BSD-2-Clause",
+      "resolved": "https://registry.npmjs.org/@httptoolkit/websocket-stream/-/websocket-stream-6.0.0.tgz",
+      "integrity": "sha512-EC8m9JbhpGX2okfvLakqrmy4Le0VyNKR7b3IdvFZR/BfFO4ruh/XceBvXhCFHkykchnFxuOSlRwFiqNSXlwcGA==",
       "peer": true,
       "dependencies": {
         "@types/ws": "*",
@@ -2777,12 +2922,14 @@
     },
     "node_modules/@httptoolkit/websocket-stream/node_modules/isarray": {
       "version": "1.0.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
       "peer": true
     },
     "node_modules/@httptoolkit/websocket-stream/node_modules/readable-stream": {
       "version": "2.3.7",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+      "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
       "peer": true,
       "dependencies": {
         "core-util-is": "~1.0.0",
@@ -2796,7 +2943,8 @@
     },
     "node_modules/@httptoolkit/websocket-stream/node_modules/string_decoder": {
       "version": "1.1.1",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
       "peer": true,
       "dependencies": {
         "safe-buffer": "~5.1.0"
@@ -4002,8 +4150,9 @@
       "license": "MIT"
     },
     "node_modules/@types/ws": {
-      "version": "8.5.0",
-      "license": "MIT",
+      "version": "8.5.2",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.5.2.tgz",
+      "integrity": "sha512-VXI82ykONr5tacHEojnErTQk+KQSoYbW1NB6iz6wUwrNd+BqfkfggQNoNdCqhJSzbNumShPERbM+Pc5zpfhlbw==",
       "peer": true,
       "dependencies": {
         "@types/node": "*"
@@ -4549,7 +4698,8 @@
     },
     "node_modules/ansi": {
       "version": "0.3.1",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/ansi/-/ansi-0.3.1.tgz",
+      "integrity": "sha1-DELU+xcWDVqa8eSEus4cZpIsGyE=",
       "peer": true
     },
     "node_modules/ansi-colors": {
@@ -4852,8 +5002,9 @@
     },
     "node_modules/aws-crt": {
       "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/aws-crt/-/aws-crt-1.11.0.tgz",
+      "integrity": "sha512-qIBDRLOKRFuPTjkOAt3Al5zbcR6YyjfEl3TUc0R/xZ64aDxWGGXDStfDpkGCLSgV7jH+o7KQ47U9PM3URiFNFg==",
       "hasInstallScript": true,
-      "license": "Apache-2.0",
       "peer": true,
       "dependencies": {
         "@httptoolkit/websocket-stream": "^6.0.0",
@@ -4868,7 +5019,8 @@
     },
     "node_modules/aws-crt/node_modules/crypto-js": {
       "version": "4.1.1",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-4.1.1.tgz",
+      "integrity": "sha512-o2JlM7ydqd3Qk9CA0L4NL6mTzU2sdx96a+oOfPu8Mkl/PK51vSyoi8/rQ8NknZtk44vq15lmhAj9CIAGwgeWKw==",
       "peer": true
     },
     "node_modules/axe-core": {
@@ -4881,7 +5033,8 @@
     },
     "node_modules/axios": {
       "version": "0.24.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.24.0.tgz",
+      "integrity": "sha512-Q6cWsys88HoPgAaFAVUb0WpPk0O8iTeisR9IMqy9G8AbO4NlpVknrnQS03zzF9PGAWgO3cgletO3VjV/P7VztA==",
       "peer": true,
       "dependencies": {
         "follow-redirects": "^1.14.4"
@@ -5001,11 +5154,15 @@
     },
     "node_modules/binary": {
       "version": "0.3.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/binary/-/binary-0.3.0.tgz",
+      "integrity": "sha1-n2BVO8XOjDOG87VTz/R0Yq3sqnk=",
       "peer": true,
       "dependencies": {
         "buffers": "~0.1.1",
         "chainsaw": "~0.1.0"
+      },
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/binary-extensions": {
@@ -5051,7 +5208,8 @@
     },
     "node_modules/bluebird": {
       "version": "3.4.7",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.4.7.tgz",
+      "integrity": "sha1-9y12C+Cbf3bQjtj66Ysomo0F+rM=",
       "peer": true
     },
     "node_modules/bn.js": {
@@ -5095,7 +5253,8 @@
     },
     "node_modules/bowser": {
       "version": "2.11.0",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.11.0.tgz",
+      "integrity": "sha512-AlcaJBi/pqqJBIQ8U9Mcpc9i8Aqxn88Skv5d+xBX006BY5u8N3mGLHa5Lgppa7L/HfwgwLgZ6NYs+Ag6uUmJRA=="
     },
     "node_modules/brace-expansion": {
       "version": "1.1.11",
@@ -5239,7 +5398,8 @@
     },
     "node_modules/buffer-indexof-polyfill": {
       "version": "1.0.2",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/buffer-indexof-polyfill/-/buffer-indexof-polyfill-1.0.2.tgz",
+      "integrity": "sha512-I7wzHwA3t1/lwXQh+A5PbNvJxgfo5r3xulgpYDB5zckTu/Z9oUK9biouBKQUjEqzaz3HnAT6TYoovmE+GqSf7A==",
       "peer": true,
       "engines": {
         "node": ">=0.10"
@@ -5247,7 +5407,8 @@
     },
     "node_modules/buffer-shims": {
       "version": "1.0.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz",
+      "integrity": "sha1-mXjOMXOIxkmth5MCjDR37wRKi1E=",
       "peer": true
     },
     "node_modules/buffer-writer": {
@@ -5263,6 +5424,8 @@
     },
     "node_modules/buffers": {
       "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/buffers/-/buffers-0.1.1.tgz",
+      "integrity": "sha1-skV5w77U1tOWru5tmorn9Ugqt7s=",
       "peer": true,
       "engines": {
         "node": ">=0.2.0"
@@ -5663,10 +5826,14 @@
     },
     "node_modules/chainsaw": {
       "version": "0.1.0",
-      "license": "MIT/X11",
+      "resolved": "https://registry.npmjs.org/chainsaw/-/chainsaw-0.1.0.tgz",
+      "integrity": "sha1-XqtQsor+WAdNDVgpE4iCi15fvJg=",
       "peer": true,
       "dependencies": {
         "traverse": ">=0.3.0 <0.4"
+      },
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/chalk": {
@@ -5728,7 +5895,8 @@
     },
     "node_modules/chownr": {
       "version": "2.0.0",
-      "license": "ISC",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
+      "integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==",
       "peer": true,
       "engines": {
         "node": ">=10"
@@ -5832,7 +6000,8 @@
     },
     "node_modules/cliui": {
       "version": "3.2.0",
-      "license": "ISC",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
+      "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
       "peer": true,
       "dependencies": {
         "string-width": "^1.0.1",
@@ -5842,7 +6011,8 @@
     },
     "node_modules/cliui/node_modules/ansi-regex": {
       "version": "2.1.1",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
       "peer": true,
       "engines": {
         "node": ">=0.10.0"
@@ -5850,7 +6020,8 @@
     },
     "node_modules/cliui/node_modules/is-fullwidth-code-point": {
       "version": "1.0.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+      "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
       "peer": true,
       "dependencies": {
         "number-is-nan": "^1.0.0"
@@ -5861,7 +6032,8 @@
     },
     "node_modules/cliui/node_modules/string-width": {
       "version": "1.0.2",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+      "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
       "peer": true,
       "dependencies": {
         "code-point-at": "^1.0.0",
@@ -5874,7 +6046,8 @@
     },
     "node_modules/cliui/node_modules/strip-ansi": {
       "version": "3.0.1",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+      "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
       "peer": true,
       "dependencies": {
         "ansi-regex": "^2.0.0"
@@ -5899,7 +6072,8 @@
     },
     "node_modules/cmake-js": {
       "version": "6.3.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/cmake-js/-/cmake-js-6.3.0.tgz",
+      "integrity": "sha512-1uqTOmFt6BIqKlrX+39/aewU/JVhyZWDqwAL+6psToUwxj3yWPJiwxiZFmV0XdcoWmqGs7peZTxTbJtAcH8hxw==",
       "peer": true,
       "dependencies": {
         "axios": "^0.21.1",
@@ -5927,7 +6101,8 @@
     },
     "node_modules/cmake-js/node_modules/are-we-there-yet": {
       "version": "1.0.6",
-      "license": "ISC",
+      "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.0.6.tgz",
+      "integrity": "sha1-otKMkxAqpsyWJFomy5VN4G7FPww=",
       "peer": true,
       "dependencies": {
         "delegates": "^1.0.0",
@@ -5936,7 +6111,8 @@
     },
     "node_modules/cmake-js/node_modules/axios": {
       "version": "0.21.4",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
+      "integrity": "sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==",
       "peer": true,
       "dependencies": {
         "follow-redirects": "^1.14.0"
@@ -5944,12 +6120,14 @@
     },
     "node_modules/cmake-js/node_modules/chownr": {
       "version": "1.1.4",
-      "license": "ISC",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
       "peer": true
     },
     "node_modules/cmake-js/node_modules/fs-extra": {
       "version": "5.0.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-5.0.0.tgz",
+      "integrity": "sha512-66Pm4RYbjzdyeuqudYqhFiNBbCIuI9kgRqLPSHIlXHidW8NIQtVdkM1yeZ4lXwuhbTETv3EUGMNHAAw6hiundQ==",
       "peer": true,
       "dependencies": {
         "graceful-fs": "^4.1.2",
@@ -5959,7 +6137,8 @@
     },
     "node_modules/cmake-js/node_modules/fs-minipass": {
       "version": "1.2.7",
-      "license": "ISC",
+      "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.7.tgz",
+      "integrity": "sha512-GWSSJGFy4e9GUeCcbIkED+bgAoFyj7XF1mV8rma3QW4NIqX9Kyx79N/PF61H5udOV3aY1IaMLs6pGbH71nlCTA==",
       "peer": true,
       "dependencies": {
         "minipass": "^2.6.0"
@@ -5967,7 +6146,8 @@
     },
     "node_modules/cmake-js/node_modules/gauge": {
       "version": "1.2.7",
-      "license": "ISC",
+      "resolved": "https://registry.npmjs.org/gauge/-/gauge-1.2.7.tgz",
+      "integrity": "sha1-6c7FSD09TuDvRLYKfZnkk14TbZM=",
       "peer": true,
       "dependencies": {
         "ansi": "^0.3.0",
@@ -5979,12 +6159,14 @@
     },
     "node_modules/cmake-js/node_modules/isarray": {
       "version": "1.0.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
       "peer": true
     },
     "node_modules/cmake-js/node_modules/jsonfile": {
       "version": "4.0.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+      "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
       "peer": true,
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
@@ -5992,7 +6174,8 @@
     },
     "node_modules/cmake-js/node_modules/minipass": {
       "version": "2.9.0",
-      "license": "ISC",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.9.0.tgz",
+      "integrity": "sha512-wxfUjg9WebH+CUDX/CdbRlh5SmfZiy/hpkxaRI16Y9W56Pa75sWgd/rvFilSgrauD9NyFymP/+JFV3KwzIsJeg==",
       "peer": true,
       "dependencies": {
         "safe-buffer": "^5.1.2",
@@ -6001,7 +6184,8 @@
     },
     "node_modules/cmake-js/node_modules/minizlib": {
       "version": "1.3.3",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-1.3.3.tgz",
+      "integrity": "sha512-6ZYMOEnmVsdCeTJVE0W9ZD+pVnE8h9Hma/iOwwRDsdQoePpoX56/8B6z3P9VNwppJuBKNRuFDRNRqRWexT9G9Q==",
       "peer": true,
       "dependencies": {
         "minipass": "^2.9.0"
@@ -6009,7 +6193,8 @@
     },
     "node_modules/cmake-js/node_modules/npmlog": {
       "version": "1.2.1",
-      "license": "ISC",
+      "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-1.2.1.tgz",
+      "integrity": "sha1-KOe+YZYJtT960d0wChDWTXFiaLY=",
       "peer": true,
       "dependencies": {
         "ansi": "~0.3.0",
@@ -6019,7 +6204,8 @@
     },
     "node_modules/cmake-js/node_modules/readable-stream": {
       "version": "2.3.7",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+      "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
       "peer": true,
       "dependencies": {
         "core-util-is": "~1.0.0",
@@ -6033,7 +6219,8 @@
     },
     "node_modules/cmake-js/node_modules/semver": {
       "version": "5.7.1",
-      "license": "ISC",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
       "peer": true,
       "bin": {
         "semver": "bin/semver"
@@ -6041,7 +6228,8 @@
     },
     "node_modules/cmake-js/node_modules/string_decoder": {
       "version": "1.1.1",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
       "peer": true,
       "dependencies": {
         "safe-buffer": "~5.1.0"
@@ -6049,7 +6237,8 @@
     },
     "node_modules/cmake-js/node_modules/tar": {
       "version": "4.4.19",
-      "license": "ISC",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.19.tgz",
+      "integrity": "sha512-a20gEsvHnWe0ygBY8JbxoM4w3SJdhc7ZAuxkLqh+nvNQN2IOt0B5lLgM490X5Hl8FF0dl0tOf2ewFYAlIFgzVA==",
       "peer": true,
       "dependencies": {
         "chownr": "^1.1.4",
@@ -6066,6 +6255,8 @@
     },
     "node_modules/cmake-js/node_modules/tar/node_modules/safe-buffer": {
       "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
       "funding": [
         {
           "type": "github",
@@ -6080,12 +6271,12 @@
           "url": "https://feross.org/support"
         }
       ],
-      "license": "MIT",
       "peer": true
     },
     "node_modules/cmake-js/node_modules/universalify": {
       "version": "0.1.2",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
       "peer": true,
       "engines": {
         "node": ">= 4.0.0"
@@ -6093,7 +6284,8 @@
     },
     "node_modules/cmake-js/node_modules/which": {
       "version": "1.3.1",
-      "license": "ISC",
+      "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+      "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
       "peer": true,
       "dependencies": {
         "isexe": "^2.0.0"
@@ -6104,7 +6296,8 @@
     },
     "node_modules/cmake-js/node_modules/yallist": {
       "version": "3.1.1",
-      "license": "ISC",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "peer": true
     },
     "node_modules/coa": {
@@ -6240,7 +6433,8 @@
     },
     "node_modules/commist": {
       "version": "1.1.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/commist/-/commist-1.1.0.tgz",
+      "integrity": "sha512-rraC8NXWOEjhADbZe9QBNzLAN5Q3fsTPQtBV+fEVj6xKIgDgNiEVE6ZNfHpZOqfQ21YUzfVNUXLOEZquYvQPPg==",
       "peer": true,
       "dependencies": {
         "leven": "^2.1.0",
@@ -7185,7 +7379,8 @@
     },
     "node_modules/duplexer2": {
       "version": "0.1.4",
-      "license": "BSD-3-Clause",
+      "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.1.4.tgz",
+      "integrity": "sha1-ixLauHjA1p4+eJEFFmKjL8a93ME=",
       "peer": true,
       "dependencies": {
         "readable-stream": "^2.0.2"
@@ -7193,12 +7388,14 @@
     },
     "node_modules/duplexer2/node_modules/isarray": {
       "version": "1.0.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
       "peer": true
     },
     "node_modules/duplexer2/node_modules/readable-stream": {
       "version": "2.3.7",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+      "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
       "peer": true,
       "dependencies": {
         "core-util-is": "~1.0.0",
@@ -7212,7 +7409,8 @@
     },
     "node_modules/duplexer2/node_modules/string_decoder": {
       "version": "1.1.1",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
       "peer": true,
       "dependencies": {
         "safe-buffer": "~5.1.0"
@@ -7220,7 +7418,8 @@
     },
     "node_modules/duplexify": {
       "version": "3.7.1",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.7.1.tgz",
+      "integrity": "sha512-07z8uv2wMyS51kKhD1KsdXJg5WQ6t93RneqRxUHnskXVtlYYkLqM0gqStQZ3pj073g687jPCHrqNfCzawLYh5g==",
       "peer": true,
       "dependencies": {
         "end-of-stream": "^1.0.0",
@@ -7231,12 +7430,14 @@
     },
     "node_modules/duplexify/node_modules/isarray": {
       "version": "1.0.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
       "peer": true
     },
     "node_modules/duplexify/node_modules/readable-stream": {
       "version": "2.3.7",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+      "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
       "peer": true,
       "dependencies": {
         "core-util-is": "~1.0.0",
@@ -7250,7 +7451,8 @@
     },
     "node_modules/duplexify/node_modules/string_decoder": {
       "version": "1.1.1",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
       "peer": true,
       "dependencies": {
         "safe-buffer": "~5.1.0"
@@ -8495,7 +8697,8 @@
     },
     "node_modules/fast-xml-parser": {
       "version": "3.19.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-3.19.0.tgz",
+      "integrity": "sha512-4pXwmBplsCPv8FOY1WRakF970TjNGnGnfbOnLqjlYvMiF1SR3yOHyxMR/YCXpPTOspNF5gwudqktIP4VsWkvBg==",
       "bin": {
         "xml2js": "cli.js"
       },
@@ -8506,7 +8709,8 @@
     },
     "node_modules/fastestsmallesttextencoderdecoder": {
       "version": "1.0.22",
-      "license": "CC0-1.0",
+      "resolved": "https://registry.npmjs.org/fastestsmallesttextencoderdecoder/-/fastestsmallesttextencoderdecoder-1.0.22.tgz",
+      "integrity": "sha512-Pb8d48e+oIuY4MaM64Cd7OW1gt4nxCHs7/ddPPZ/Ic3sg8yVGM7O9wDvZ7us6ScaUupzM+pfBolwtYhN1IxBIw==",
       "peer": true
     },
     "node_modules/fastq": {
@@ -8777,7 +8981,8 @@
     },
     "node_modules/fs-minipass": {
       "version": "2.1.0",
-      "license": "ISC",
+      "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-2.1.0.tgz",
+      "integrity": "sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==",
       "peer": true,
       "dependencies": {
         "minipass": "^3.0.0"
@@ -8803,7 +9008,8 @@
     },
     "node_modules/fstream": {
       "version": "1.0.12",
-      "license": "ISC",
+      "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.12.tgz",
+      "integrity": "sha512-WvJ193OHa0GHPEL+AycEJgxvBEwyfRkN1vhjca23OaPVMCaLCXTd5qAu82AjTcgP1UJmytkOKb63Ypde7raDIg==",
       "peer": true,
       "dependencies": {
         "graceful-fs": "^4.1.2",
@@ -8817,7 +9023,8 @@
     },
     "node_modules/fstream/node_modules/rimraf": {
       "version": "2.7.1",
-      "license": "ISC",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+      "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
       "peer": true,
       "dependencies": {
         "glob": "^7.1.3"
@@ -9312,7 +9519,8 @@
     },
     "node_modules/help-me": {
       "version": "3.0.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/help-me/-/help-me-3.0.0.tgz",
+      "integrity": "sha512-hx73jClhyk910sidBB7ERlnhMlFsJJIBqSVMFDwPN8o2v9nmp5KgLq1Xz1Bf1fCMMZ6mPrX159iG0VLy/fPMtQ==",
       "peer": true,
       "dependencies": {
         "glob": "^7.1.6",
@@ -9575,7 +9783,8 @@
     },
     "node_modules/invert-kv": {
       "version": "1.0.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
+      "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY=",
       "peer": true,
       "engines": {
         "node": ">=0.10.0"
@@ -10314,7 +10523,8 @@
     },
     "node_modules/is-iojs": {
       "version": "1.1.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/is-iojs/-/is-iojs-1.1.0.tgz",
+      "integrity": "sha1-TBEDO11dlNbqs3dd7cm+fQCDJfE=",
       "peer": true
     },
     "node_modules/is-ip": {
@@ -10588,7 +10798,8 @@
     },
     "node_modules/isomorphic-ws": {
       "version": "4.0.1",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/isomorphic-ws/-/isomorphic-ws-4.0.1.tgz",
+      "integrity": "sha512-BhBvN2MBpWTaSHdWRb/bwdZJ1WaehQ2L1KngkCkfLUGF0mAWAT1sQUQacEmQ0jXkFw/czDXPNQSL5u2/Krsz1w==",
       "peer": true,
       "peerDependencies": {
         "ws": "*"
@@ -10844,7 +11055,8 @@
     },
     "node_modules/js-sdsl": {
       "version": "2.1.4",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/js-sdsl/-/js-sdsl-2.1.4.tgz",
+      "integrity": "sha512-/Ew+CJWHNddr7sjwgxaVeIORIH4AMVC9dy0hPf540ZGMVgS9d3ajwuVdyhDt6/QUvT8ATjR3yuYBKsS79F+H4A==",
       "peer": true
     },
     "node_modules/js-sha3": {
@@ -10986,7 +11198,8 @@
     },
     "node_modules/lcid": {
       "version": "1.0.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
+      "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
       "peer": true,
       "dependencies": {
         "invert-kv": "^1.0.0"
@@ -10997,7 +11210,8 @@
     },
     "node_modules/leven": {
       "version": "2.1.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/leven/-/leven-2.1.0.tgz",
+      "integrity": "sha1-wuep93IJTe6dNCAq6KzORoeHVYA=",
       "peer": true,
       "engines": {
         "node": ">=0.10.0"
@@ -11059,7 +11273,8 @@
     },
     "node_modules/listenercount": {
       "version": "1.0.1",
-      "license": "ISC",
+      "resolved": "https://registry.npmjs.org/listenercount/-/listenercount-1.0.1.tgz",
+      "integrity": "sha1-hMinKrWcRyUyFIDJdeZQg0LnCTc=",
       "peer": true
     },
     "node_modules/load-json-file": {
@@ -11184,17 +11399,20 @@
     },
     "node_modules/lodash.pad": {
       "version": "4.5.1",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/lodash.pad/-/lodash.pad-4.5.1.tgz",
+      "integrity": "sha1-QzCUmoM6fI2iLMIPaibE1Z3runA=",
       "peer": true
     },
     "node_modules/lodash.padend": {
       "version": "4.6.1",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/lodash.padend/-/lodash.padend-4.6.1.tgz",
+      "integrity": "sha1-U8y6BH0G4VjTEfRdpiX05J5vFm4=",
       "peer": true
     },
     "node_modules/lodash.padstart": {
       "version": "4.6.1",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/lodash.padstart/-/lodash.padstart-4.6.1.tgz",
+      "integrity": "sha1-0uPuv/DZ05rVD1y9G1KnvOa7YRs=",
       "peer": true
     },
     "node_modules/lodash.template": {
@@ -11473,7 +11691,8 @@
     },
     "node_modules/memory-stream": {
       "version": "0.0.3",
-      "license": "MMIT",
+      "resolved": "https://registry.npmjs.org/memory-stream/-/memory-stream-0.0.3.tgz",
+      "integrity": "sha1-6+jdHDuLw4wOeUHp3dWuvmtN6D8=",
       "peer": true,
       "dependencies": {
         "readable-stream": "~1.0.26-2"
@@ -11481,12 +11700,14 @@
     },
     "node_modules/memory-stream/node_modules/isarray": {
       "version": "0.0.1",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+      "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
       "peer": true
     },
     "node_modules/memory-stream/node_modules/readable-stream": {
       "version": "1.0.34",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+      "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
       "peer": true,
       "dependencies": {
         "core-util-is": "~1.0.0",
@@ -11497,7 +11718,8 @@
     },
     "node_modules/memory-stream/node_modules/string_decoder": {
       "version": "0.10.31",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+      "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
       "peer": true
     },
     "node_modules/memorystream": {
@@ -11894,7 +12116,8 @@
     },
     "node_modules/minipass": {
       "version": "3.1.6",
-      "license": "ISC",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.1.6.tgz",
+      "integrity": "sha512-rty5kpw9/z8SX9dmxblFA6edItUmwJgMeYDZRrwlIVN27i8gysGbznJwUggw2V/FVqFSDdWy040ZPS811DYAqQ==",
       "peer": true,
       "dependencies": {
         "yallist": "^4.0.0"
@@ -11905,7 +12128,8 @@
     },
     "node_modules/minizlib": {
       "version": "2.1.2",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-2.1.2.tgz",
+      "integrity": "sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==",
       "peer": true,
       "dependencies": {
         "minipass": "^3.0.0",
@@ -12240,7 +12464,8 @@
     },
     "node_modules/mqtt": {
       "version": "4.3.6",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/mqtt/-/mqtt-4.3.6.tgz",
+      "integrity": "sha512-1dgQbkbh1Bba9iAGDNIrhSZ4nLDjbhmNHjOEvsmKI1Bb+2orj0gHwjqUKJ5CKUMKBYbkQYRM1fy+N1/2iZOj5w==",
       "peer": true,
       "dependencies": {
         "commist": "^1.0.0",
@@ -12272,7 +12497,8 @@
     },
     "node_modules/mqtt-packet": {
       "version": "6.10.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/mqtt-packet/-/mqtt-packet-6.10.0.tgz",
+      "integrity": "sha512-ja8+mFKIHdB1Tpl6vac+sktqy3gA8t9Mduom1BA75cI+R9AHnZOiaBQwpGiWnaVJLDGRdNhQmFaAqd7tkKSMGA==",
       "peer": true,
       "dependencies": {
         "bl": "^4.0.2",
@@ -12282,7 +12508,8 @@
     },
     "node_modules/mqtt-packet/node_modules/bl": {
       "version": "4.1.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
       "peer": true,
       "dependencies": {
         "buffer": "^5.5.0",
@@ -12292,6 +12519,8 @@
     },
     "node_modules/mqtt-packet/node_modules/buffer": {
       "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
       "funding": [
         {
           "type": "github",
@@ -12306,7 +12535,6 @@
           "url": "https://feross.org/support"
         }
       ],
-      "license": "MIT",
       "peer": true,
       "dependencies": {
         "base64-js": "^1.3.1",
@@ -12315,7 +12543,8 @@
     },
     "node_modules/mqtt/node_modules/duplexify": {
       "version": "4.1.2",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-4.1.2.tgz",
+      "integrity": "sha512-fz3OjcNCHmRP12MJoZMPglx8m4rrFP8rovnk4vT8Fs+aonZoCwGg10dSsQsfP/E62eZcPTMSMP6686fu9Qlqtw==",
       "peer": true,
       "dependencies": {
         "end-of-stream": "^1.4.1",
@@ -12904,8 +13133,9 @@
       }
     },
     "node_modules/number-allocator": {
-      "version": "1.0.9",
-      "license": "MIT",
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/number-allocator/-/number-allocator-1.0.10.tgz",
+      "integrity": "sha512-K4AvNGKo9lP6HqsZyfSr9KDaqnwFzW203inhQEOwFrmFaYevpdX4VNwdOLk197aHujzbT//z6pCBrCOUYSM5iw==",
       "peer": true,
       "dependencies": {
         "debug": "^4.3.1",
@@ -13772,7 +14002,8 @@
     },
     "node_modules/os-locale": {
       "version": "1.4.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
+      "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
       "peer": true,
       "dependencies": {
         "lcid": "^1.0.0"
@@ -15456,7 +15687,8 @@
     },
     "node_modules/reinterval": {
       "version": "1.1.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/reinterval/-/reinterval-1.1.0.tgz",
+      "integrity": "sha1-M2Hs+jymwYKDOA3Qu5VG85D17Oc=",
       "peer": true
     },
     "node_modules/release-zalgo": {
@@ -15607,7 +15839,8 @@
     },
     "node_modules/rfdc": {
       "version": "1.3.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.3.0.tgz",
+      "integrity": "sha512-V2hovdzFbOi77/WajaSMXk2OLm+xNIeQdMMuB7icj7bk6zi2F8GGAxigcnDFpJHbNyNcgyJDiP+8nOrY5cZGrA==",
       "peer": true
     },
     "node_modules/rgb-regex": {
@@ -16309,7 +16542,8 @@
     },
     "node_modules/split2": {
       "version": "3.2.2",
-      "license": "ISC",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-3.2.2.tgz",
+      "integrity": "sha512-9NThjpgZnifTkJpzTZ7Eue85S49QwpNhZTq6GRJwObb6jnLFNGB7Qm73V5HewTROPyxD0C29xqmaI68bQtV+hg==",
       "peer": true,
       "dependencies": {
         "readable-stream": "^3.0.0"
@@ -16317,7 +16551,8 @@
     },
     "node_modules/splitargs": {
       "version": "0.0.7",
-      "license": "ISC",
+      "resolved": "https://registry.npmjs.org/splitargs/-/splitargs-0.0.7.tgz",
+      "integrity": "sha1-/p965lc3GzOxDLgNoUPPgknPazs=",
       "peer": true
     },
     "node_modules/sprintf-js": {
@@ -16496,7 +16731,8 @@
     },
     "node_modules/stream-shift": {
       "version": "1.0.1",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.1.tgz",
+      "integrity": "sha512-AiisoFqQ0vbGcZgQPY1cdP2I76glaVA/RauYR4G4thNFgkTqr90yXTo4LYX60Jl+sIlPNHHdGSwo01AvbKUSVQ==",
       "peer": true
     },
     "node_modules/stream-to-it": {
@@ -16980,7 +17216,8 @@
     },
     "node_modules/tar": {
       "version": "6.1.11",
-      "license": "ISC",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-6.1.11.tgz",
+      "integrity": "sha512-an/KZQzQUkZCkuoAA64hM92X0Urb6VpRhAFllDzz44U2mcD5scmT3zBc4VgVpkugF580+DQn8eAFSyoQt0tznA==",
       "peer": true,
       "dependencies": {
         "chownr": "^2.0.0",
@@ -17060,7 +17297,8 @@
     },
     "node_modules/tar/node_modules/mkdirp": {
       "version": "1.0.4",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+      "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
       "peer": true,
       "bin": {
         "mkdirp": "bin/cmd.js"
@@ -17329,8 +17567,12 @@
     },
     "node_modules/traverse": {
       "version": "0.3.9",
-      "license": "MIT/X11",
-      "peer": true
+      "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.3.9.tgz",
+      "integrity": "sha1-cXuPIgzAu3tE5AUUwisui7xw2Lk=",
+      "peer": true,
+      "engines": {
+        "node": "*"
+      }
     },
     "node_modules/trim-newlines": {
       "version": "4.0.2",
@@ -17700,7 +17942,8 @@
     },
     "node_modules/unzipper": {
       "version": "0.8.14",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/unzipper/-/unzipper-0.8.14.tgz",
+      "integrity": "sha512-8rFtE7EP5ssOwGpN2dt1Q4njl0N1hUXJ7sSPz0leU2hRdq6+pra57z4YPBlVqm40vcgv6ooKZEAx48fMTv9x4w==",
       "peer": true,
       "dependencies": {
         "big-integer": "^1.6.17",
@@ -17716,17 +17959,20 @@
     },
     "node_modules/unzipper/node_modules/isarray": {
       "version": "1.0.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
       "peer": true
     },
     "node_modules/unzipper/node_modules/process-nextick-args": {
       "version": "1.0.7",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+      "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
       "peer": true
     },
     "node_modules/unzipper/node_modules/readable-stream": {
       "version": "2.1.5",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.5.tgz",
+      "integrity": "sha1-ZvqLcg4UOLNkaB8q0aY8YYRIydA=",
       "peer": true,
       "dependencies": {
         "buffer-shims": "^1.0.0",
@@ -17740,7 +17986,8 @@
     },
     "node_modules/unzipper/node_modules/string_decoder": {
       "version": "0.10.31",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+      "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
       "peer": true
     },
     "node_modules/uri-js": {
@@ -17752,7 +17999,8 @@
     },
     "node_modules/url-join": {
       "version": "0.0.1",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/url-join/-/url-join-0.0.1.tgz",
+      "integrity": "sha1-HbSK1CLTQCRpqH99l73r/k+x48g=",
       "peer": true
     },
     "node_modules/use-subscription": {
@@ -18164,7 +18412,8 @@
     },
     "node_modules/window-size": {
       "version": "0.1.4",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.4.tgz",
+      "integrity": "sha1-+OGqHuWlPsW/FR/6CXQqatdpeHY=",
       "peer": true,
       "bin": {
         "window-size": "cli.js"
@@ -18188,7 +18437,8 @@
     },
     "node_modules/wrap-ansi": {
       "version": "2.1.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+      "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
       "peer": true,
       "dependencies": {
         "string-width": "^1.0.1",
@@ -18200,7 +18450,8 @@
     },
     "node_modules/wrap-ansi/node_modules/ansi-regex": {
       "version": "2.1.1",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
       "peer": true,
       "engines": {
         "node": ">=0.10.0"
@@ -18208,7 +18459,8 @@
     },
     "node_modules/wrap-ansi/node_modules/is-fullwidth-code-point": {
       "version": "1.0.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+      "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
       "peer": true,
       "dependencies": {
         "number-is-nan": "^1.0.0"
@@ -18219,7 +18471,8 @@
     },
     "node_modules/wrap-ansi/node_modules/string-width": {
       "version": "1.0.2",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+      "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
       "peer": true,
       "dependencies": {
         "code-point-at": "^1.0.0",
@@ -18232,7 +18485,8 @@
     },
     "node_modules/wrap-ansi/node_modules/strip-ansi": {
       "version": "3.0.1",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+      "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
       "peer": true,
       "dependencies": {
         "ansi-regex": "^2.0.0"
@@ -18292,7 +18546,8 @@
     },
     "node_modules/y18n": {
       "version": "3.2.2",
-      "license": "ISC",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.2.tgz",
+      "integrity": "sha512-uGZHXkHnhF0XeeAPgnKfPv1bgKAYyVvmNL1xlKsPYZPaIHxGti2hHqvOCQv71XMsLxu1QjergkqogUnms5D3YQ==",
       "peer": true
     },
     "node_modules/yaeti": {
@@ -18316,7 +18571,8 @@
     },
     "node_modules/yargs": {
       "version": "3.32.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.32.0.tgz",
+      "integrity": "sha1-AwiOnr+edWtpdRYR0qXvWRSCyZU=",
       "peer": true,
       "dependencies": {
         "camelcase": "^2.0.1",
@@ -18362,7 +18618,8 @@
     },
     "node_modules/yargs/node_modules/ansi-regex": {
       "version": "2.1.1",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
       "peer": true,
       "engines": {
         "node": ">=0.10.0"
@@ -18370,7 +18627,8 @@
     },
     "node_modules/yargs/node_modules/camelcase": {
       "version": "2.1.1",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
+      "integrity": "sha1-fB0W1nmhu+WcoCys7PsBHiAfWh8=",
       "peer": true,
       "engines": {
         "node": ">=0.10.0"
@@ -18378,7 +18636,8 @@
     },
     "node_modules/yargs/node_modules/decamelize": {
       "version": "1.2.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
       "peer": true,
       "engines": {
         "node": ">=0.10.0"
@@ -18386,7 +18645,8 @@
     },
     "node_modules/yargs/node_modules/is-fullwidth-code-point": {
       "version": "1.0.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+      "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
       "peer": true,
       "dependencies": {
         "number-is-nan": "^1.0.0"
@@ -18397,7 +18657,8 @@
     },
     "node_modules/yargs/node_modules/string-width": {
       "version": "1.0.2",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+      "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
       "peer": true,
       "dependencies": {
         "code-point-at": "^1.0.0",
@@ -18410,7 +18671,8 @@
     },
     "node_modules/yargs/node_modules/strip-ansi": {
       "version": "3.0.1",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+      "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
       "peer": true,
       "dependencies": {
         "ansi-regex": "^2.0.0"
@@ -18463,7 +18725,7 @@
       "version": "5.3.0",
       "license": "(Apache-2.0 OR MIT)",
       "dependencies": {
-        "@aws-sdk/client-s3": "^3.28.0",
+        "@aws-sdk/client-s3": "^3.53.1",
         "@cfworker/json-schema": "^1.8.3",
         "@google-cloud/precise-date": "^2.0.4",
         "@ipld/car": "^3.1.4",
@@ -18842,7 +19104,7 @@
     },
     "packages/client": {
       "name": "web3.storage",
-      "version": "3.5.5",
+      "version": "3.5.6",
       "license": "(Apache-2.0 OR MIT)",
       "dependencies": {
         "@ipld/car": "^3.1.4",
@@ -20143,6 +20405,8 @@
     },
     "@aws-crypto/crc32": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/crc32/-/crc32-2.0.0.tgz",
+      "integrity": "sha512-TvE1r2CUueyXOuHdEigYjIZVesInd9KN+K/TFFNfkkxRThiNxO6i4ZqqAVMoEjAamZZ1AA8WXJkjCz7YShHPQA==",
       "requires": {
         "@aws-crypto/util": "^2.0.0",
         "@aws-sdk/types": "^3.1.0",
@@ -20150,23 +20414,68 @@
       },
       "dependencies": {
         "tslib": {
-          "version": "1.14.1"
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        }
+      }
+    },
+    "@aws-crypto/crc32c": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/crc32c/-/crc32c-2.0.0.tgz",
+      "integrity": "sha512-vF0eMdMHx3O3MoOXUfBZry8Y4ZDtcuskjjKgJz8YfIDjLStxTZrYXk+kZqtl6A0uCmmiN/Eb/JbC/CndTV1MHg==",
+      "requires": {
+        "@aws-crypto/util": "^2.0.0",
+        "@aws-sdk/types": "^3.1.0",
+        "tslib": "^1.11.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
         }
       }
     },
     "@aws-crypto/ie11-detection": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/ie11-detection/-/ie11-detection-2.0.0.tgz",
+      "integrity": "sha512-pkVXf/dq6PITJ0jzYZ69VhL8VFOFoPZLZqtU/12SGnzYuJOOGNfF41q9GxdI1yqC8R13Rq3jOLKDFpUJFT5eTA==",
       "requires": {
         "tslib": "^1.11.1"
       },
       "dependencies": {
         "tslib": {
-          "version": "1.14.1"
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        }
+      }
+    },
+    "@aws-crypto/sha1-browser": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha1-browser/-/sha1-browser-2.0.0.tgz",
+      "integrity": "sha512-3fIVRjPFY8EG5HWXR+ZJZMdWNRpwbxGzJ9IH9q93FpbgCH8u8GHRi46mZXp3cYD7gealmyqpm3ThZwLKJjWJhA==",
+      "requires": {
+        "@aws-crypto/ie11-detection": "^2.0.0",
+        "@aws-crypto/supports-web-crypto": "^2.0.0",
+        "@aws-sdk/types": "^3.1.0",
+        "@aws-sdk/util-locate-window": "^3.0.0",
+        "@aws-sdk/util-utf8-browser": "^3.0.0",
+        "tslib": "^1.11.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
         }
       }
     },
     "@aws-crypto/sha256-browser": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-2.0.0.tgz",
+      "integrity": "sha512-rYXOQ8BFOaqMEHJrLHul/25ckWH6GTJtdLSajhlqGMx0PmSueAuvboCuZCTqEKlxR8CQOwRarxYMZZSYlhRA1A==",
       "requires": {
         "@aws-crypto/ie11-detection": "^2.0.0",
         "@aws-crypto/sha256-js": "^2.0.0",
@@ -20179,12 +20488,16 @@
       },
       "dependencies": {
         "tslib": {
-          "version": "1.14.1"
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
         }
       }
     },
     "@aws-crypto/sha256-js": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-2.0.0.tgz",
+      "integrity": "sha512-VZY+mCY4Nmrs5WGfitmNqXzaE873fcIZDu54cbaDaaamsaTOP1DBImV9F4pICc3EHjQXujyE8jig+PFCaew9ig==",
       "requires": {
         "@aws-crypto/util": "^2.0.0",
         "@aws-sdk/types": "^3.1.0",
@@ -20192,23 +20505,31 @@
       },
       "dependencies": {
         "tslib": {
-          "version": "1.14.1"
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
         }
       }
     },
     "@aws-crypto/supports-web-crypto": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-2.0.0.tgz",
+      "integrity": "sha512-Ge7WQ3E0OC7FHYprsZV3h0QIcpdyJLvIeg+uTuHqRYm8D6qCFJoiC+edSzSyFiHtZf+NOQDJ1q46qxjtzIY2nA==",
       "requires": {
         "tslib": "^1.11.1"
       },
       "dependencies": {
         "tslib": {
-          "version": "1.14.1"
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
         }
       }
     },
     "@aws-crypto/util": {
       "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-2.0.1.tgz",
+      "integrity": "sha512-JJmFFwvbm08lULw4Nm5QOLg8+lAQeC8aCXK5xrtxntYzYXCGfHwUJ4Is3770Q7HmICsXthGQ+ZsDL7C2uH3yBQ==",
       "requires": {
         "@aws-sdk/types": "^3.1.0",
         "@aws-sdk/util-utf8-browser": "^3.0.0",
@@ -20216,78 +20537,91 @@
       },
       "dependencies": {
         "tslib": {
-          "version": "1.14.1"
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
         }
       }
     },
     "@aws-sdk/abort-controller": {
-      "version": "3.52.0",
+      "version": "3.53.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.53.0.tgz",
+      "integrity": "sha512-Xe7IX2mpf/qOjh1LrPnJ1UtiDw3cBlmy8n+Q2xSP5vaS/9IH0OMdQUveC9MV9HSgzICX+xzbPyUuSKc+4tufBQ==",
       "requires": {
-        "@aws-sdk/types": "3.52.0",
+        "@aws-sdk/types": "3.53.0",
         "tslib": "^2.3.0"
       }
     },
     "@aws-sdk/chunked-blob-reader": {
       "version": "3.52.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/chunked-blob-reader/-/chunked-blob-reader-3.52.0.tgz",
+      "integrity": "sha512-BAZhriHHfvnGOd0P9xcnGu8DGyxOa0lgmEw+Tc6nZpXJzx0P+1Sd76q5gE5d/IZ0r5VTB6rfwwKUoG6iShNCwQ==",
       "requires": {
         "tslib": "^2.3.0"
       }
     },
     "@aws-sdk/chunked-blob-reader-native": {
       "version": "3.52.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/chunked-blob-reader-native/-/chunked-blob-reader-native-3.52.0.tgz",
+      "integrity": "sha512-/hVzC0Q12/mWRMBBQD3v82xsLSxZ4RwG6N44XP7MuJoHy4ui4T7D9RSuvBpzzr/4fqF0w9M7XYv6aM4BD2pFIQ==",
       "requires": {
         "@aws-sdk/util-base64-browser": "3.52.0",
         "tslib": "^2.3.0"
       }
     },
     "@aws-sdk/client-s3": {
-      "version": "3.52.0",
+      "version": "3.53.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.53.1.tgz",
+      "integrity": "sha512-uAhjR/TAuXNct6BL/shVg2f/6Zg1EZoXTG8KIywfmLitiUF0PvYwfwSPtNohkz6czgTs/rtirAZHAQKi8jjieA==",
       "requires": {
+        "@aws-crypto/sha1-browser": "2.0.0",
         "@aws-crypto/sha256-browser": "2.0.0",
         "@aws-crypto/sha256-js": "2.0.0",
-        "@aws-sdk/client-sts": "3.52.0",
-        "@aws-sdk/config-resolver": "3.52.0",
-        "@aws-sdk/credential-provider-node": "3.52.0",
-        "@aws-sdk/eventstream-serde-browser": "3.52.0",
-        "@aws-sdk/eventstream-serde-config-resolver": "3.52.0",
-        "@aws-sdk/eventstream-serde-node": "3.52.0",
-        "@aws-sdk/fetch-http-handler": "3.52.0",
-        "@aws-sdk/hash-blob-browser": "3.52.0",
-        "@aws-sdk/hash-node": "3.52.0",
-        "@aws-sdk/hash-stream-node": "3.52.0",
-        "@aws-sdk/invalid-dependency": "3.52.0",
-        "@aws-sdk/md5-js": "3.52.0",
-        "@aws-sdk/middleware-apply-body-checksum": "3.52.0",
-        "@aws-sdk/middleware-bucket-endpoint": "3.52.0",
-        "@aws-sdk/middleware-content-length": "3.52.0",
-        "@aws-sdk/middleware-expect-continue": "3.52.0",
-        "@aws-sdk/middleware-host-header": "3.52.0",
-        "@aws-sdk/middleware-location-constraint": "3.52.0",
-        "@aws-sdk/middleware-logger": "3.52.0",
-        "@aws-sdk/middleware-retry": "3.52.0",
-        "@aws-sdk/middleware-sdk-s3": "3.52.0",
-        "@aws-sdk/middleware-serde": "3.52.0",
-        "@aws-sdk/middleware-signing": "3.52.0",
-        "@aws-sdk/middleware-ssec": "3.52.0",
-        "@aws-sdk/middleware-stack": "3.52.0",
-        "@aws-sdk/middleware-user-agent": "3.52.0",
-        "@aws-sdk/node-config-provider": "3.52.0",
-        "@aws-sdk/node-http-handler": "3.52.0",
-        "@aws-sdk/protocol-http": "3.52.0",
-        "@aws-sdk/smithy-client": "3.52.0",
-        "@aws-sdk/types": "3.52.0",
-        "@aws-sdk/url-parser": "3.52.0",
+        "@aws-sdk/client-sts": "3.53.0",
+        "@aws-sdk/config-resolver": "3.53.0",
+        "@aws-sdk/credential-provider-node": "3.53.0",
+        "@aws-sdk/eventstream-serde-browser": "3.53.0",
+        "@aws-sdk/eventstream-serde-config-resolver": "3.53.0",
+        "@aws-sdk/eventstream-serde-node": "3.53.0",
+        "@aws-sdk/fetch-http-handler": "3.53.0",
+        "@aws-sdk/hash-blob-browser": "3.53.0",
+        "@aws-sdk/hash-node": "3.53.0",
+        "@aws-sdk/hash-stream-node": "3.53.1",
+        "@aws-sdk/invalid-dependency": "3.53.0",
+        "@aws-sdk/md5-js": "3.53.0",
+        "@aws-sdk/middleware-bucket-endpoint": "3.53.0",
+        "@aws-sdk/middleware-content-length": "3.53.0",
+        "@aws-sdk/middleware-expect-continue": "3.53.0",
+        "@aws-sdk/middleware-flexible-checksums": "3.53.0",
+        "@aws-sdk/middleware-host-header": "3.53.0",
+        "@aws-sdk/middleware-location-constraint": "3.53.0",
+        "@aws-sdk/middleware-logger": "3.53.0",
+        "@aws-sdk/middleware-retry": "3.53.0",
+        "@aws-sdk/middleware-sdk-s3": "3.53.0",
+        "@aws-sdk/middleware-serde": "3.53.0",
+        "@aws-sdk/middleware-signing": "3.53.0",
+        "@aws-sdk/middleware-ssec": "3.53.0",
+        "@aws-sdk/middleware-stack": "3.53.0",
+        "@aws-sdk/middleware-user-agent": "3.53.0",
+        "@aws-sdk/node-config-provider": "3.53.0",
+        "@aws-sdk/node-http-handler": "3.53.0",
+        "@aws-sdk/protocol-http": "3.53.0",
+        "@aws-sdk/smithy-client": "3.53.0",
+        "@aws-sdk/types": "3.53.0",
+        "@aws-sdk/url-parser": "3.53.0",
         "@aws-sdk/util-base64-browser": "3.52.0",
         "@aws-sdk/util-base64-node": "3.52.0",
         "@aws-sdk/util-body-length-browser": "3.52.0",
         "@aws-sdk/util-body-length-node": "3.52.0",
-        "@aws-sdk/util-defaults-mode-browser": "3.52.0",
-        "@aws-sdk/util-defaults-mode-node": "3.52.0",
-        "@aws-sdk/util-user-agent-browser": "3.52.0",
-        "@aws-sdk/util-user-agent-node": "3.52.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.53.0",
+        "@aws-sdk/util-defaults-mode-node": "3.53.0",
+        "@aws-sdk/util-stream-browser": "3.53.0",
+        "@aws-sdk/util-stream-node": "3.53.0",
+        "@aws-sdk/util-user-agent-browser": "3.53.0",
+        "@aws-sdk/util-user-agent-node": "3.53.0",
         "@aws-sdk/util-utf8-browser": "3.52.0",
         "@aws-sdk/util-utf8-node": "3.52.0",
-        "@aws-sdk/util-waiter": "3.52.0",
+        "@aws-sdk/util-waiter": "3.53.0",
         "@aws-sdk/xml-builder": "3.52.0",
         "entities": "2.2.0",
         "fast-xml-parser": "3.19.0",
@@ -20295,73 +20629,77 @@
       }
     },
     "@aws-sdk/client-sso": {
-      "version": "3.52.0",
+      "version": "3.53.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.53.0.tgz",
+      "integrity": "sha512-X32YHHc5MO7xO4W3Ly8DeryieeEiDOsnl6ypBkfML7loO3M0ckvvL+HnNUR1J+HYyseEV7V93BsF/A1z5HmINQ==",
       "requires": {
         "@aws-crypto/sha256-browser": "2.0.0",
         "@aws-crypto/sha256-js": "2.0.0",
-        "@aws-sdk/config-resolver": "3.52.0",
-        "@aws-sdk/fetch-http-handler": "3.52.0",
-        "@aws-sdk/hash-node": "3.52.0",
-        "@aws-sdk/invalid-dependency": "3.52.0",
-        "@aws-sdk/middleware-content-length": "3.52.0",
-        "@aws-sdk/middleware-host-header": "3.52.0",
-        "@aws-sdk/middleware-logger": "3.52.0",
-        "@aws-sdk/middleware-retry": "3.52.0",
-        "@aws-sdk/middleware-serde": "3.52.0",
-        "@aws-sdk/middleware-stack": "3.52.0",
-        "@aws-sdk/middleware-user-agent": "3.52.0",
-        "@aws-sdk/node-config-provider": "3.52.0",
-        "@aws-sdk/node-http-handler": "3.52.0",
-        "@aws-sdk/protocol-http": "3.52.0",
-        "@aws-sdk/smithy-client": "3.52.0",
-        "@aws-sdk/types": "3.52.0",
-        "@aws-sdk/url-parser": "3.52.0",
+        "@aws-sdk/config-resolver": "3.53.0",
+        "@aws-sdk/fetch-http-handler": "3.53.0",
+        "@aws-sdk/hash-node": "3.53.0",
+        "@aws-sdk/invalid-dependency": "3.53.0",
+        "@aws-sdk/middleware-content-length": "3.53.0",
+        "@aws-sdk/middleware-host-header": "3.53.0",
+        "@aws-sdk/middleware-logger": "3.53.0",
+        "@aws-sdk/middleware-retry": "3.53.0",
+        "@aws-sdk/middleware-serde": "3.53.0",
+        "@aws-sdk/middleware-stack": "3.53.0",
+        "@aws-sdk/middleware-user-agent": "3.53.0",
+        "@aws-sdk/node-config-provider": "3.53.0",
+        "@aws-sdk/node-http-handler": "3.53.0",
+        "@aws-sdk/protocol-http": "3.53.0",
+        "@aws-sdk/smithy-client": "3.53.0",
+        "@aws-sdk/types": "3.53.0",
+        "@aws-sdk/url-parser": "3.53.0",
         "@aws-sdk/util-base64-browser": "3.52.0",
         "@aws-sdk/util-base64-node": "3.52.0",
         "@aws-sdk/util-body-length-browser": "3.52.0",
         "@aws-sdk/util-body-length-node": "3.52.0",
-        "@aws-sdk/util-defaults-mode-browser": "3.52.0",
-        "@aws-sdk/util-defaults-mode-node": "3.52.0",
-        "@aws-sdk/util-user-agent-browser": "3.52.0",
-        "@aws-sdk/util-user-agent-node": "3.52.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.53.0",
+        "@aws-sdk/util-defaults-mode-node": "3.53.0",
+        "@aws-sdk/util-user-agent-browser": "3.53.0",
+        "@aws-sdk/util-user-agent-node": "3.53.0",
         "@aws-sdk/util-utf8-browser": "3.52.0",
         "@aws-sdk/util-utf8-node": "3.52.0",
         "tslib": "^2.3.0"
       }
     },
     "@aws-sdk/client-sts": {
-      "version": "3.52.0",
+      "version": "3.53.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.53.0.tgz",
+      "integrity": "sha512-MNG+Pmw/zZQ0kboZtsc8UEGM9pn8abjStDN0Yk67fwFAZMqz8sUHDtFXpa3gSXMrFqBwT+jMFXmIxqiq7XuAeA==",
       "requires": {
         "@aws-crypto/sha256-browser": "2.0.0",
         "@aws-crypto/sha256-js": "2.0.0",
-        "@aws-sdk/config-resolver": "3.52.0",
-        "@aws-sdk/credential-provider-node": "3.52.0",
-        "@aws-sdk/fetch-http-handler": "3.52.0",
-        "@aws-sdk/hash-node": "3.52.0",
-        "@aws-sdk/invalid-dependency": "3.52.0",
-        "@aws-sdk/middleware-content-length": "3.52.0",
-        "@aws-sdk/middleware-host-header": "3.52.0",
-        "@aws-sdk/middleware-logger": "3.52.0",
-        "@aws-sdk/middleware-retry": "3.52.0",
-        "@aws-sdk/middleware-sdk-sts": "3.52.0",
-        "@aws-sdk/middleware-serde": "3.52.0",
-        "@aws-sdk/middleware-signing": "3.52.0",
-        "@aws-sdk/middleware-stack": "3.52.0",
-        "@aws-sdk/middleware-user-agent": "3.52.0",
-        "@aws-sdk/node-config-provider": "3.52.0",
-        "@aws-sdk/node-http-handler": "3.52.0",
-        "@aws-sdk/protocol-http": "3.52.0",
-        "@aws-sdk/smithy-client": "3.52.0",
-        "@aws-sdk/types": "3.52.0",
-        "@aws-sdk/url-parser": "3.52.0",
+        "@aws-sdk/config-resolver": "3.53.0",
+        "@aws-sdk/credential-provider-node": "3.53.0",
+        "@aws-sdk/fetch-http-handler": "3.53.0",
+        "@aws-sdk/hash-node": "3.53.0",
+        "@aws-sdk/invalid-dependency": "3.53.0",
+        "@aws-sdk/middleware-content-length": "3.53.0",
+        "@aws-sdk/middleware-host-header": "3.53.0",
+        "@aws-sdk/middleware-logger": "3.53.0",
+        "@aws-sdk/middleware-retry": "3.53.0",
+        "@aws-sdk/middleware-sdk-sts": "3.53.0",
+        "@aws-sdk/middleware-serde": "3.53.0",
+        "@aws-sdk/middleware-signing": "3.53.0",
+        "@aws-sdk/middleware-stack": "3.53.0",
+        "@aws-sdk/middleware-user-agent": "3.53.0",
+        "@aws-sdk/node-config-provider": "3.53.0",
+        "@aws-sdk/node-http-handler": "3.53.0",
+        "@aws-sdk/protocol-http": "3.53.0",
+        "@aws-sdk/smithy-client": "3.53.0",
+        "@aws-sdk/types": "3.53.0",
+        "@aws-sdk/url-parser": "3.53.0",
         "@aws-sdk/util-base64-browser": "3.52.0",
         "@aws-sdk/util-base64-node": "3.52.0",
         "@aws-sdk/util-body-length-browser": "3.52.0",
         "@aws-sdk/util-body-length-node": "3.52.0",
-        "@aws-sdk/util-defaults-mode-browser": "3.52.0",
-        "@aws-sdk/util-defaults-mode-node": "3.52.0",
-        "@aws-sdk/util-user-agent-browser": "3.52.0",
-        "@aws-sdk/util-user-agent-node": "3.52.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.53.0",
+        "@aws-sdk/util-defaults-mode-node": "3.53.0",
+        "@aws-sdk/util-user-agent-browser": "3.53.0",
+        "@aws-sdk/util-user-agent-node": "3.53.0",
         "@aws-sdk/util-utf8-browser": "3.52.0",
         "@aws-sdk/util-utf8-node": "3.52.0",
         "entities": "2.2.0",
@@ -20370,398 +20708,492 @@
       }
     },
     "@aws-sdk/config-resolver": {
-      "version": "3.52.0",
+      "version": "3.53.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.53.0.tgz",
+      "integrity": "sha512-wAqP/xNx49H1dutHWHjhKduaKtAcDg2KoH25W6peW2qXZ6OfpVcxRIBbJE4Z0yGOmFFaxw0OeH3h2ptP7tdhGQ==",
       "requires": {
-        "@aws-sdk/signature-v4": "3.52.0",
-        "@aws-sdk/types": "3.52.0",
+        "@aws-sdk/signature-v4": "3.53.0",
+        "@aws-sdk/types": "3.53.0",
         "@aws-sdk/util-config-provider": "3.52.0",
         "tslib": "^2.3.0"
       }
     },
     "@aws-sdk/credential-provider-env": {
-      "version": "3.52.0",
+      "version": "3.53.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.53.0.tgz",
+      "integrity": "sha512-ocqZ4w7y7eay2M+uUBAD6NkhikUPoajEFX1/7iMvEFMmS5MyzjuolHPNK7Hh8lFmPyoflxaMXJVKO8C1MguA/A==",
       "requires": {
-        "@aws-sdk/property-provider": "3.52.0",
-        "@aws-sdk/types": "3.52.0",
+        "@aws-sdk/property-provider": "3.53.0",
+        "@aws-sdk/types": "3.53.0",
         "tslib": "^2.3.0"
       }
     },
     "@aws-sdk/credential-provider-imds": {
-      "version": "3.52.0",
+      "version": "3.53.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.53.0.tgz",
+      "integrity": "sha512-aKc8POSqCi58566KhF1p8Sxt7LHehMnshyfQzNAOB7xshSxuWg41rxafnQU4Soq9Tz7q5bwkauR2CEUihv/TRg==",
       "requires": {
-        "@aws-sdk/node-config-provider": "3.52.0",
-        "@aws-sdk/property-provider": "3.52.0",
-        "@aws-sdk/types": "3.52.0",
-        "@aws-sdk/url-parser": "3.52.0",
+        "@aws-sdk/node-config-provider": "3.53.0",
+        "@aws-sdk/property-provider": "3.53.0",
+        "@aws-sdk/types": "3.53.0",
+        "@aws-sdk/url-parser": "3.53.0",
         "tslib": "^2.3.0"
       }
     },
     "@aws-sdk/credential-provider-ini": {
-      "version": "3.52.0",
+      "version": "3.53.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.53.0.tgz",
+      "integrity": "sha512-g+UoJ1ikDrfpI1wHAhlrcBtX4OHxoLV6vakirpG27hhFwuMih565Q/Sjn3o5hLT8PBlWxwT2YeRuxCjtaL3cDA==",
       "requires": {
-        "@aws-sdk/credential-provider-env": "3.52.0",
-        "@aws-sdk/credential-provider-imds": "3.52.0",
-        "@aws-sdk/credential-provider-sso": "3.52.0",
-        "@aws-sdk/credential-provider-web-identity": "3.52.0",
-        "@aws-sdk/property-provider": "3.52.0",
+        "@aws-sdk/credential-provider-env": "3.53.0",
+        "@aws-sdk/credential-provider-imds": "3.53.0",
+        "@aws-sdk/credential-provider-sso": "3.53.0",
+        "@aws-sdk/credential-provider-web-identity": "3.53.0",
+        "@aws-sdk/property-provider": "3.53.0",
         "@aws-sdk/shared-ini-file-loader": "3.52.0",
-        "@aws-sdk/types": "3.52.0",
-        "@aws-sdk/util-credentials": "3.52.0",
+        "@aws-sdk/types": "3.53.0",
+        "@aws-sdk/util-credentials": "3.53.0",
         "tslib": "^2.3.0"
       }
     },
     "@aws-sdk/credential-provider-node": {
-      "version": "3.52.0",
+      "version": "3.53.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.53.0.tgz",
+      "integrity": "sha512-sy0NeuJHOBhe7XwxCX2y+YZAB4CqcHveyXJfT6mv7eY6bYQskkMTCPp2D586hSH3c6cfIsmvLSxNhNJApj1Atw==",
       "requires": {
-        "@aws-sdk/credential-provider-env": "3.52.0",
-        "@aws-sdk/credential-provider-imds": "3.52.0",
-        "@aws-sdk/credential-provider-ini": "3.52.0",
-        "@aws-sdk/credential-provider-process": "3.52.0",
-        "@aws-sdk/credential-provider-sso": "3.52.0",
-        "@aws-sdk/credential-provider-web-identity": "3.52.0",
-        "@aws-sdk/property-provider": "3.52.0",
+        "@aws-sdk/credential-provider-env": "3.53.0",
+        "@aws-sdk/credential-provider-imds": "3.53.0",
+        "@aws-sdk/credential-provider-ini": "3.53.0",
+        "@aws-sdk/credential-provider-process": "3.53.0",
+        "@aws-sdk/credential-provider-sso": "3.53.0",
+        "@aws-sdk/credential-provider-web-identity": "3.53.0",
+        "@aws-sdk/property-provider": "3.53.0",
         "@aws-sdk/shared-ini-file-loader": "3.52.0",
-        "@aws-sdk/types": "3.52.0",
-        "@aws-sdk/util-credentials": "3.52.0",
+        "@aws-sdk/types": "3.53.0",
+        "@aws-sdk/util-credentials": "3.53.0",
         "tslib": "^2.3.0"
       }
     },
     "@aws-sdk/credential-provider-process": {
-      "version": "3.52.0",
+      "version": "3.53.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.53.0.tgz",
+      "integrity": "sha512-nazHndueCa4y5jUM58OHSysb52E953r3VhmpCs0qIv1ZH5Ijs3kT/usbUq7Yms7pcpaUmpu00VZTc6IfOOC0GA==",
       "requires": {
-        "@aws-sdk/property-provider": "3.52.0",
+        "@aws-sdk/property-provider": "3.53.0",
         "@aws-sdk/shared-ini-file-loader": "3.52.0",
-        "@aws-sdk/types": "3.52.0",
-        "@aws-sdk/util-credentials": "3.52.0",
+        "@aws-sdk/types": "3.53.0",
+        "@aws-sdk/util-credentials": "3.53.0",
         "tslib": "^2.3.0"
       }
     },
     "@aws-sdk/credential-provider-sso": {
-      "version": "3.52.0",
+      "version": "3.53.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.53.0.tgz",
+      "integrity": "sha512-EongClNxdVw+O4y+S0mZFjNeLHv1ssdAnBM/9L1PfR6sH06eikVmU6isEN2quwoKBy9HRVPaIVF075Q8QIpipg==",
       "requires": {
-        "@aws-sdk/client-sso": "3.52.0",
-        "@aws-sdk/property-provider": "3.52.0",
+        "@aws-sdk/client-sso": "3.53.0",
+        "@aws-sdk/property-provider": "3.53.0",
         "@aws-sdk/shared-ini-file-loader": "3.52.0",
-        "@aws-sdk/types": "3.52.0",
-        "@aws-sdk/util-credentials": "3.52.0",
+        "@aws-sdk/types": "3.53.0",
+        "@aws-sdk/util-credentials": "3.53.0",
         "tslib": "^2.3.0"
       }
     },
     "@aws-sdk/credential-provider-web-identity": {
-      "version": "3.52.0",
+      "version": "3.53.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.53.0.tgz",
+      "integrity": "sha512-YbysBkX3mbomHJZULxk/3jyQ7NWn6rZ68IDY28bmp8cNWajWeGzDxKmR4Y+c8gNiN2ziWjUZWfHcnZC056/79Q==",
       "requires": {
-        "@aws-sdk/property-provider": "3.52.0",
-        "@aws-sdk/types": "3.52.0",
+        "@aws-sdk/property-provider": "3.53.0",
+        "@aws-sdk/types": "3.53.0",
         "tslib": "^2.3.0"
       }
     },
     "@aws-sdk/eventstream-marshaller": {
-      "version": "3.52.0",
+      "version": "3.53.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-marshaller/-/eventstream-marshaller-3.53.0.tgz",
+      "integrity": "sha512-Vt8OjC0hgF0rNcGPbMEROnM5SHODzRdQsG9Y+M2suWDkUqFoh8+6m4v9c/ej3iudAEydZDLcnpV9yGv/CTqceg==",
       "requires": {
         "@aws-crypto/crc32": "2.0.0",
-        "@aws-sdk/types": "3.52.0",
+        "@aws-sdk/types": "3.53.0",
         "@aws-sdk/util-hex-encoding": "3.52.0",
         "tslib": "^2.3.0"
       }
     },
     "@aws-sdk/eventstream-serde-browser": {
-      "version": "3.52.0",
+      "version": "3.53.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-browser/-/eventstream-serde-browser-3.53.0.tgz",
+      "integrity": "sha512-B+nAlXet/NSEIzaN4fZYGwoFHBYtURuXUE+Ru4EaWyC8+vBEdeO4Vs9o/8mlZSHGiUn41QYYqiZvd+OKweTtBA==",
       "requires": {
-        "@aws-sdk/eventstream-marshaller": "3.52.0",
-        "@aws-sdk/eventstream-serde-universal": "3.52.0",
-        "@aws-sdk/types": "3.52.0",
+        "@aws-sdk/eventstream-marshaller": "3.53.0",
+        "@aws-sdk/eventstream-serde-universal": "3.53.0",
+        "@aws-sdk/types": "3.53.0",
         "tslib": "^2.3.0"
       }
     },
     "@aws-sdk/eventstream-serde-config-resolver": {
-      "version": "3.52.0",
+      "version": "3.53.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-config-resolver/-/eventstream-serde-config-resolver-3.53.0.tgz",
+      "integrity": "sha512-4O66c1aSgfdWfbr2pUJTONReVwA4oWQ/fRMhcAMhacqbPko5+3v0Iy/vOiVCm6Isa4K2kVpOUN0L+64niE7jag==",
       "requires": {
-        "@aws-sdk/types": "3.52.0",
+        "@aws-sdk/types": "3.53.0",
         "tslib": "^2.3.0"
       }
     },
     "@aws-sdk/eventstream-serde-node": {
-      "version": "3.52.0",
+      "version": "3.53.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-node/-/eventstream-serde-node-3.53.0.tgz",
+      "integrity": "sha512-92rlY8M8+nU4mUm3j4gtJiv9HY2fGTGLSIGLukOXAUf7xuJ220L+9ZInS4ToiRgq+dOSt8cFPCxRVpQtNesBfA==",
       "requires": {
-        "@aws-sdk/eventstream-marshaller": "3.52.0",
-        "@aws-sdk/eventstream-serde-universal": "3.52.0",
-        "@aws-sdk/types": "3.52.0",
+        "@aws-sdk/eventstream-marshaller": "3.53.0",
+        "@aws-sdk/eventstream-serde-universal": "3.53.0",
+        "@aws-sdk/types": "3.53.0",
         "tslib": "^2.3.0"
       }
     },
     "@aws-sdk/eventstream-serde-universal": {
-      "version": "3.52.0",
+      "version": "3.53.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-universal/-/eventstream-serde-universal-3.53.0.tgz",
+      "integrity": "sha512-Y3OjTAKhDyz2UyLE0ATmDD3RFyBfJLWeBQkpJu7qICI0XYN2tmV1mCkQUtkT3e4s+UxnuUOa55YQpdUsQUWIDA==",
       "requires": {
-        "@aws-sdk/eventstream-marshaller": "3.52.0",
-        "@aws-sdk/types": "3.52.0",
+        "@aws-sdk/eventstream-marshaller": "3.53.0",
+        "@aws-sdk/types": "3.53.0",
         "tslib": "^2.3.0"
       }
     },
     "@aws-sdk/fetch-http-handler": {
-      "version": "3.52.0",
+      "version": "3.53.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.53.0.tgz",
+      "integrity": "sha512-0CcEYarIAVAoGzu1ClO2xDq30Jii6AevDFJYR7M9yojqAMvwjP31DY4/qfPc2nCpSAd9dASR6vcx6r/RoIynVg==",
       "requires": {
-        "@aws-sdk/protocol-http": "3.52.0",
-        "@aws-sdk/querystring-builder": "3.52.0",
-        "@aws-sdk/types": "3.52.0",
+        "@aws-sdk/protocol-http": "3.53.0",
+        "@aws-sdk/querystring-builder": "3.53.0",
+        "@aws-sdk/types": "3.53.0",
         "@aws-sdk/util-base64-browser": "3.52.0",
         "tslib": "^2.3.0"
       }
     },
     "@aws-sdk/hash-blob-browser": {
-      "version": "3.52.0",
+      "version": "3.53.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/hash-blob-browser/-/hash-blob-browser-3.53.0.tgz",
+      "integrity": "sha512-A3xa0o1W9/tALw0/yoXyBKfxsMlzi1BvzEgCFUU2y914yBo62FiIf1E+BX42m9MfPJ87SD+l3O5QcptMVWvarw==",
       "requires": {
         "@aws-sdk/chunked-blob-reader": "3.52.0",
         "@aws-sdk/chunked-blob-reader-native": "3.52.0",
-        "@aws-sdk/types": "3.52.0",
+        "@aws-sdk/types": "3.53.0",
         "tslib": "^2.3.0"
       }
     },
     "@aws-sdk/hash-node": {
-      "version": "3.52.0",
+      "version": "3.53.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.53.0.tgz",
+      "integrity": "sha512-0xK5PSUUVOPttvCLWrrUTmrKe7Fz6njPdBYvB3ESk1whXL+TY3syJj4em63Sq6yFyeuXdqyTzqfcs9fU2puWkA==",
       "requires": {
-        "@aws-sdk/types": "3.52.0",
+        "@aws-sdk/types": "3.53.0",
         "@aws-sdk/util-buffer-from": "3.52.0",
         "tslib": "^2.3.0"
       }
     },
     "@aws-sdk/hash-stream-node": {
-      "version": "3.52.0",
+      "version": "3.53.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/hash-stream-node/-/hash-stream-node-3.53.1.tgz",
+      "integrity": "sha512-y7pUc6EtkG3TscZR9dpR/BCauP/lRepU+Td43Oe9VUhD6l3lS3TuIHUwB7PEU7NeSU9iqWuflBVK/IBWXrfH3w==",
       "requires": {
-        "@aws-sdk/types": "3.52.0",
+        "@aws-sdk/types": "3.53.0",
         "tslib": "^2.3.0"
       }
     },
     "@aws-sdk/invalid-dependency": {
-      "version": "3.52.0",
+      "version": "3.53.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-3.53.0.tgz",
+      "integrity": "sha512-qp2qRFa1a/AjZRCe6MZCpbaXo5t4enGAtch/83fuH4rRkzVOctYox1gyTGTliHk28rjMREtSgZDQZojp5/5M5w==",
       "requires": {
-        "@aws-sdk/types": "3.52.0",
+        "@aws-sdk/types": "3.53.0",
         "tslib": "^2.3.0"
       }
     },
     "@aws-sdk/is-array-buffer": {
       "version": "3.52.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.52.0.tgz",
+      "integrity": "sha512-5Pe9QKrOeSZb9Z8gtlx9CDMfxH8EiNdClBfXBbc6CiUM7y6l7UintYHkm133zM5XTqtMRYY1jaD8svVAoRPApA==",
       "requires": {
         "tslib": "^2.3.0"
       }
     },
     "@aws-sdk/md5-js": {
-      "version": "3.52.0",
+      "version": "3.53.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/md5-js/-/md5-js-3.53.0.tgz",
+      "integrity": "sha512-+XbYdbxgWniyC7E4kqHC0z0Qsud/EMv9RuKghWLr7IwbUjfR7zix5+AVw3XR+FWrKrDAlyRBhyzG+60STliuiA==",
       "requires": {
-        "@aws-sdk/types": "3.52.0",
+        "@aws-sdk/types": "3.53.0",
         "@aws-sdk/util-utf8-browser": "3.52.0",
         "@aws-sdk/util-utf8-node": "3.52.0",
         "tslib": "^2.3.0"
       }
     },
-    "@aws-sdk/middleware-apply-body-checksum": {
-      "version": "3.52.0",
-      "requires": {
-        "@aws-sdk/is-array-buffer": "3.52.0",
-        "@aws-sdk/protocol-http": "3.52.0",
-        "@aws-sdk/types": "3.52.0",
-        "tslib": "^2.3.0"
-      }
-    },
     "@aws-sdk/middleware-bucket-endpoint": {
-      "version": "3.52.0",
+      "version": "3.53.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-bucket-endpoint/-/middleware-bucket-endpoint-3.53.0.tgz",
+      "integrity": "sha512-q88eevXUkUWp6e/vHGnpt8/8TjscbfW6CWGpexj3DFWt3WZhEhExcoGwwszoL4FQfMFWBL+11EKNZm2orHqDwg==",
       "requires": {
-        "@aws-sdk/protocol-http": "3.52.0",
-        "@aws-sdk/types": "3.52.0",
+        "@aws-sdk/protocol-http": "3.53.0",
+        "@aws-sdk/types": "3.53.0",
         "@aws-sdk/util-arn-parser": "3.52.0",
         "@aws-sdk/util-config-provider": "3.52.0",
         "tslib": "^2.3.0"
       }
     },
     "@aws-sdk/middleware-content-length": {
-      "version": "3.52.0",
+      "version": "3.53.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.53.0.tgz",
+      "integrity": "sha512-CXANhpL2MAE2tPKmu0cOf4Fd99useIj5kgX6UA+HWg/ZbJ4qBg6Q4W/nYVt+OuukeqwEEbpt3wv0lKQ8k/vINQ==",
       "requires": {
-        "@aws-sdk/protocol-http": "3.52.0",
-        "@aws-sdk/types": "3.52.0",
+        "@aws-sdk/protocol-http": "3.53.0",
+        "@aws-sdk/types": "3.53.0",
         "tslib": "^2.3.0"
       }
     },
     "@aws-sdk/middleware-expect-continue": {
-      "version": "3.52.0",
+      "version": "3.53.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-expect-continue/-/middleware-expect-continue-3.53.0.tgz",
+      "integrity": "sha512-aMKtfOX9b1yx0ER0QspN2jOR/Q1ucRYEaR46yOUPjdcMHHnGxuk3kimsyGqgFm2+pPJdi9FRd9S2eC/tNjYn8w==",
       "requires": {
-        "@aws-sdk/middleware-header-default": "3.52.0",
-        "@aws-sdk/protocol-http": "3.52.0",
-        "@aws-sdk/types": "3.52.0",
+        "@aws-sdk/middleware-header-default": "3.53.0",
+        "@aws-sdk/protocol-http": "3.53.0",
+        "@aws-sdk/types": "3.53.0",
+        "tslib": "^2.3.0"
+      }
+    },
+    "@aws-sdk/middleware-flexible-checksums": {
+      "version": "3.53.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-flexible-checksums/-/middleware-flexible-checksums-3.53.0.tgz",
+      "integrity": "sha512-g069Es0Sy3So2HRz+UAwaubFKkGuxwhEf6OS9pmovY2+2yfZBOLoQmf7jS50RgbxJcUDoI7uuKZrp0BcdLDgEg==",
+      "requires": {
+        "@aws-crypto/crc32": "2.0.0",
+        "@aws-crypto/crc32c": "2.0.0",
+        "@aws-sdk/is-array-buffer": "3.52.0",
+        "@aws-sdk/protocol-http": "3.53.0",
+        "@aws-sdk/types": "3.53.0",
         "tslib": "^2.3.0"
       }
     },
     "@aws-sdk/middleware-header-default": {
-      "version": "3.52.0",
+      "version": "3.53.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-header-default/-/middleware-header-default-3.53.0.tgz",
+      "integrity": "sha512-eQLFdNBzydZoocnj7YDVO+AJZ3YhuImZ1GXzGsF9FN8IdSjuE4gwB8BQhG6vuUg3GVe+sI+7VUJT6h55OaDBXw==",
       "requires": {
-        "@aws-sdk/protocol-http": "3.52.0",
-        "@aws-sdk/types": "3.52.0",
+        "@aws-sdk/protocol-http": "3.53.0",
+        "@aws-sdk/types": "3.53.0",
         "tslib": "^2.3.0"
       }
     },
     "@aws-sdk/middleware-host-header": {
-      "version": "3.52.0",
+      "version": "3.53.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.53.0.tgz",
+      "integrity": "sha512-w5qMAUgy52fvJGqzqruNJhv4BtkanE4I368zWiysmwXXL5xmpKs8TpkGqcSQw4g2wKS8MR2Yxh21LukHlsgAJw==",
       "requires": {
-        "@aws-sdk/protocol-http": "3.52.0",
-        "@aws-sdk/types": "3.52.0",
+        "@aws-sdk/protocol-http": "3.53.0",
+        "@aws-sdk/types": "3.53.0",
         "tslib": "^2.3.0"
       }
     },
     "@aws-sdk/middleware-location-constraint": {
-      "version": "3.52.0",
+      "version": "3.53.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-location-constraint/-/middleware-location-constraint-3.53.0.tgz",
+      "integrity": "sha512-HtBy8L3XNbovHLVh6wtIIThsbdTsX+jv09M9Cmmu80eM1WXw5Uu6lJX6FdIQXfMXBTZjnmHRL+72CxEtsets8g==",
       "requires": {
-        "@aws-sdk/types": "3.52.0",
+        "@aws-sdk/types": "3.53.0",
         "tslib": "^2.3.0"
       }
     },
     "@aws-sdk/middleware-logger": {
-      "version": "3.52.0",
+      "version": "3.53.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.53.0.tgz",
+      "integrity": "sha512-jMME8OOyPHliHhVD3FaBQ+4X+FDCQovw6CYGqPdqP0JUuhR8E1LWKHV1+xRpkpOICKwBnIXrgD8/0NQo/+Z84A==",
       "requires": {
-        "@aws-sdk/types": "3.52.0",
+        "@aws-sdk/types": "3.53.0",
         "tslib": "^2.3.0"
       }
     },
     "@aws-sdk/middleware-retry": {
-      "version": "3.52.0",
+      "version": "3.53.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.53.0.tgz",
+      "integrity": "sha512-TKEdTLP//SjasunU3/yX7avXMxhIEDoSOaiwj77zEpPGF2NWcR99UFfqNLeJsRPCyzYScYo1JSuxIwgXHNIhyQ==",
       "requires": {
-        "@aws-sdk/protocol-http": "3.52.0",
-        "@aws-sdk/service-error-classification": "3.52.0",
-        "@aws-sdk/types": "3.52.0",
+        "@aws-sdk/protocol-http": "3.53.0",
+        "@aws-sdk/service-error-classification": "3.53.0",
+        "@aws-sdk/types": "3.53.0",
         "tslib": "^2.3.0",
         "uuid": "^8.3.2"
       }
     },
     "@aws-sdk/middleware-sdk-s3": {
-      "version": "3.52.0",
+      "version": "3.53.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.53.0.tgz",
+      "integrity": "sha512-cq2NFixf5HBctPaUUMjV97M++q18e/WDrM61lN7eMHfdXW+TlYv4tVF9y9MaE7dpoNp7G0ORLsz05JdVdUI33g==",
       "requires": {
-        "@aws-sdk/protocol-http": "3.52.0",
-        "@aws-sdk/signature-v4": "3.52.0",
-        "@aws-sdk/types": "3.52.0",
+        "@aws-sdk/protocol-http": "3.53.0",
+        "@aws-sdk/signature-v4": "3.53.0",
+        "@aws-sdk/types": "3.53.0",
         "@aws-sdk/util-arn-parser": "3.52.0",
         "tslib": "^2.3.0"
       }
     },
     "@aws-sdk/middleware-sdk-sts": {
-      "version": "3.52.0",
+      "version": "3.53.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.53.0.tgz",
+      "integrity": "sha512-b9AUXYqA5jaUTpWu7wPZz43RQnmy1WGPFVHd8CvcUzFdMzwJlQeH4wq+sEdZ1KtIsz6n6TmY7vobzrScgq3ftg==",
       "requires": {
-        "@aws-sdk/middleware-signing": "3.52.0",
-        "@aws-sdk/property-provider": "3.52.0",
-        "@aws-sdk/protocol-http": "3.52.0",
-        "@aws-sdk/signature-v4": "3.52.0",
-        "@aws-sdk/types": "3.52.0",
+        "@aws-sdk/middleware-signing": "3.53.0",
+        "@aws-sdk/property-provider": "3.53.0",
+        "@aws-sdk/protocol-http": "3.53.0",
+        "@aws-sdk/signature-v4": "3.53.0",
+        "@aws-sdk/types": "3.53.0",
         "tslib": "^2.3.0"
       }
     },
     "@aws-sdk/middleware-serde": {
-      "version": "3.52.0",
+      "version": "3.53.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.53.0.tgz",
+      "integrity": "sha512-jPoou51ULWN2PpvWkDF3wLKnTezyM33NBdF89mvfnI4++Za0/NpuL12636YqWLXt2CK87u8cA2Q+7Opob7KocA==",
       "requires": {
-        "@aws-sdk/types": "3.52.0",
+        "@aws-sdk/types": "3.53.0",
         "tslib": "^2.3.0"
       }
     },
     "@aws-sdk/middleware-signing": {
-      "version": "3.52.0",
+      "version": "3.53.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.53.0.tgz",
+      "integrity": "sha512-r3g2ytin1YbhXCDedMfR7ZSlt1B39GWA0+J04ZZzUdevtnS2VnkFNhsanO5os/WOpVUV7iqk/ncJgSpn9LI2DA==",
       "requires": {
-        "@aws-sdk/property-provider": "3.52.0",
-        "@aws-sdk/protocol-http": "3.52.0",
-        "@aws-sdk/signature-v4": "3.52.0",
-        "@aws-sdk/types": "3.52.0",
+        "@aws-sdk/property-provider": "3.53.0",
+        "@aws-sdk/protocol-http": "3.53.0",
+        "@aws-sdk/signature-v4": "3.53.0",
+        "@aws-sdk/types": "3.53.0",
         "tslib": "^2.3.0"
       }
     },
     "@aws-sdk/middleware-ssec": {
-      "version": "3.52.0",
+      "version": "3.53.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-ssec/-/middleware-ssec-3.53.0.tgz",
+      "integrity": "sha512-2p2QT3PNepUC5MwT+t0l9bf7MlRHw6DN6CLg4Dptgr3SFR2k8LjUp2S7dJqg4qrhXRiiO7lTZK57PaPPR90dFw==",
       "requires": {
-        "@aws-sdk/types": "3.52.0",
+        "@aws-sdk/types": "3.53.0",
         "tslib": "^2.3.0"
       }
     },
     "@aws-sdk/middleware-stack": {
-      "version": "3.52.0",
+      "version": "3.53.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.53.0.tgz",
+      "integrity": "sha512-YanQOVUXGjm63GCZVRYPlPMl6niaWtVjE2C0+0lpCrJQYaUIrvKh27Ff40JLi3U0F89hmsYOO7yPQOPTbc9NBg==",
       "requires": {
         "tslib": "^2.3.0"
       }
     },
     "@aws-sdk/middleware-user-agent": {
-      "version": "3.52.0",
+      "version": "3.53.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.53.0.tgz",
+      "integrity": "sha512-ClKxpFXoHLhdnDxyDRRVNaFYQnfylps7rk1wfbRLWb+FWQwKWBvLq5c5ZPvznBU8BvftDSkFtrY+7OLMlj6qxA==",
       "requires": {
-        "@aws-sdk/protocol-http": "3.52.0",
-        "@aws-sdk/types": "3.52.0",
+        "@aws-sdk/protocol-http": "3.53.0",
+        "@aws-sdk/types": "3.53.0",
         "tslib": "^2.3.0"
       }
     },
     "@aws-sdk/node-config-provider": {
-      "version": "3.52.0",
+      "version": "3.53.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.53.0.tgz",
+      "integrity": "sha512-l00gDzU7n2WSIBHZPVW8/t6L0UD6qwtre5kuGKiv8ZkZKynPg9VV39IB/JZ7swp2uydbXuqxgDxFvqImvY3IyA==",
       "requires": {
-        "@aws-sdk/property-provider": "3.52.0",
+        "@aws-sdk/property-provider": "3.53.0",
         "@aws-sdk/shared-ini-file-loader": "3.52.0",
-        "@aws-sdk/types": "3.52.0",
+        "@aws-sdk/types": "3.53.0",
         "tslib": "^2.3.0"
       }
     },
     "@aws-sdk/node-http-handler": {
-      "version": "3.52.0",
+      "version": "3.53.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.53.0.tgz",
+      "integrity": "sha512-YqovPyn75gNzDSvPWQUTAEbwhr8PBdp1MQz65bB8p+qOlzQi1jGCyj1uHqG7qwVIlis9+bAfqpAqNDuYpdGsNg==",
       "requires": {
-        "@aws-sdk/abort-controller": "3.52.0",
-        "@aws-sdk/protocol-http": "3.52.0",
-        "@aws-sdk/querystring-builder": "3.52.0",
-        "@aws-sdk/types": "3.52.0",
+        "@aws-sdk/abort-controller": "3.53.0",
+        "@aws-sdk/protocol-http": "3.53.0",
+        "@aws-sdk/querystring-builder": "3.53.0",
+        "@aws-sdk/types": "3.53.0",
         "tslib": "^2.3.0"
       }
     },
     "@aws-sdk/property-provider": {
-      "version": "3.52.0",
+      "version": "3.53.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.53.0.tgz",
+      "integrity": "sha512-qrVFYcOV/Da7/ozW2bDLDz0JQP0NLIn6/eNUwT2fqKVw9MWcrLf6xtyAJhCwckdUVOWS2HoBSyvEopa4mdh9Sw==",
       "requires": {
-        "@aws-sdk/types": "3.52.0",
+        "@aws-sdk/types": "3.53.0",
         "tslib": "^2.3.0"
       }
     },
     "@aws-sdk/protocol-http": {
-      "version": "3.52.0",
+      "version": "3.53.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.53.0.tgz",
+      "integrity": "sha512-lKOXq2FjQH2i/ztJOKHoNgJ9Kpaprhb6/lsKMjHuePr/YDEzp62nEuJKbVx5rA9C8Rxuuj2hE8vXhQ6dyUIsjg==",
       "requires": {
-        "@aws-sdk/types": "3.52.0",
+        "@aws-sdk/types": "3.53.0",
         "tslib": "^2.3.0"
       }
     },
     "@aws-sdk/querystring-builder": {
-      "version": "3.52.0",
+      "version": "3.53.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.53.0.tgz",
+      "integrity": "sha512-oliOrup52985pSKOjHbbm7t3bGL0HTPs9UODhBuDpHE7l0pdWE1hv9YiU3FF5NUIF25VwbL83GYmL9R52GxZhA==",
       "requires": {
-        "@aws-sdk/types": "3.52.0",
+        "@aws-sdk/types": "3.53.0",
         "@aws-sdk/util-uri-escape": "3.52.0",
         "tslib": "^2.3.0"
       }
     },
     "@aws-sdk/querystring-parser": {
-      "version": "3.52.0",
+      "version": "3.53.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.53.0.tgz",
+      "integrity": "sha512-wEkS40w/wW4eBSnf7xt+m8InZFVzjLAzRYK1yPab2qfOIShpWgxg1ndqEP0eu14MvwdEfMPW9xU6J2AiWoxWng==",
       "requires": {
-        "@aws-sdk/types": "3.52.0",
+        "@aws-sdk/types": "3.53.0",
         "tslib": "^2.3.0"
       }
     },
     "@aws-sdk/service-error-classification": {
-      "version": "3.52.0"
+      "version": "3.53.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.53.0.tgz",
+      "integrity": "sha512-l5g8QncKk0ZmzQL7mWyQ6n5xWkd1XQJuoOfLZPBas9SJAyz7wanV5P3CG9PX6s1GVHWLC+2MafpIQ6+aH1x5cQ=="
     },
     "@aws-sdk/shared-ini-file-loader": {
       "version": "3.52.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.52.0.tgz",
+      "integrity": "sha512-tALb8u8IVcI4pT7yFZpl4O6kgeY5EAXyphZoRPgQSCDhmEyFUIi/sXbCN8HQiHjnHdWfXdaNE1YsZcW3GpcuoQ==",
       "requires": {
         "tslib": "^2.3.0"
       }
     },
     "@aws-sdk/signature-v4": {
-      "version": "3.52.0",
+      "version": "3.53.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.53.0.tgz",
+      "integrity": "sha512-CUvCIrwiiWpJd/ldSA04RERXPsdvkuKW3+gBDIUREq4uc7co7Cml1/wbIJ0UOHAmJpDw82NDYqAUthYB1kbHrQ==",
       "requires": {
         "@aws-sdk/is-array-buffer": "3.52.0",
-        "@aws-sdk/types": "3.52.0",
+        "@aws-sdk/types": "3.53.0",
         "@aws-sdk/util-hex-encoding": "3.52.0",
         "@aws-sdk/util-uri-escape": "3.52.0",
         "tslib": "^2.3.0"
       }
     },
     "@aws-sdk/signature-v4-crt": {
-      "version": "3.52.0",
+      "version": "3.53.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-crt/-/signature-v4-crt-3.53.0.tgz",
+      "integrity": "sha512-xpBuMFr8o4q0KidnCxCS8V56HmMIGdEPQkf4omfDiFc/7nTD4SfAgissZXd0x/xgJE8QyJn57O7+uyToexb2OQ==",
       "peer": true,
       "requires": {
         "@aws-sdk/is-array-buffer": "3.52.0",
-        "@aws-sdk/querystring-parser": "3.52.0",
-        "@aws-sdk/signature-v4": "3.52.0",
+        "@aws-sdk/querystring-parser": "3.53.0",
+        "@aws-sdk/signature-v4": "3.53.0",
         "@aws-sdk/util-hex-encoding": "3.52.0",
         "@aws-sdk/util-uri-escape": "3.52.0",
         "aws-crt": "^1.9.7",
@@ -20769,38 +21201,50 @@
       }
     },
     "@aws-sdk/smithy-client": {
-      "version": "3.52.0",
+      "version": "3.53.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.53.0.tgz",
+      "integrity": "sha512-/mZn1/1/BXFgV5PwbGfXczbSyZFrhUEhWQzPG7x1NXLQh3kcSoHGDSONqFhqTeHWkfEXp1Tn0zUe7R4vAseFmQ==",
       "requires": {
-        "@aws-sdk/middleware-stack": "3.52.0",
-        "@aws-sdk/types": "3.52.0",
+        "@aws-sdk/middleware-stack": "3.53.0",
+        "@aws-sdk/types": "3.53.0",
         "tslib": "^2.3.0"
       }
     },
     "@aws-sdk/types": {
-      "version": "3.52.0"
+      "version": "3.53.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.53.0.tgz",
+      "integrity": "sha512-FqHfWRXdnQvfxgngDKfYpYOuQ1HmPgxaGKELx3pFaEnQdMo/dMXjfBGQcEQgP8jqU6bPLaJSfykjWjDzua8JBg=="
     },
     "@aws-sdk/url-parser": {
-      "version": "3.52.0",
+      "version": "3.53.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.53.0.tgz",
+      "integrity": "sha512-lB0U5TkBDSdJK8h3noDkSG/P1cGnpSxOxBroMgPHA8Lrf5lmFRMvDXLXMhRDnTiqtsd/DpHDPyat91pfwLVEwA==",
       "requires": {
-        "@aws-sdk/querystring-parser": "3.52.0",
-        "@aws-sdk/types": "3.52.0",
+        "@aws-sdk/querystring-parser": "3.53.0",
+        "@aws-sdk/types": "3.53.0",
         "tslib": "^2.3.0"
       }
     },
     "@aws-sdk/util-arn-parser": {
       "version": "3.52.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-arn-parser/-/util-arn-parser-3.52.0.tgz",
+      "integrity": "sha512-mMsoYJ70+BGkVpdfQbu942v4fAGzx+pIL8+QnQhzUmcU0HbNkI0vYliMWfzz7ka9CHgbijUI/ANKA319zgKtvA==",
       "requires": {
         "tslib": "^2.3.0"
       }
     },
     "@aws-sdk/util-base64-browser": {
       "version": "3.52.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64-browser/-/util-base64-browser-3.52.0.tgz",
+      "integrity": "sha512-xjv/cQ4goWXAiGEC/AIL/GtlHg4p4RkQKs6/zxn9jOxo1OnbppLMJ0LjCtv4/JVYIVGHrx0VJ8Exyod7Ln+NeA==",
       "requires": {
         "tslib": "^2.3.0"
       }
     },
     "@aws-sdk/util-base64-node": {
       "version": "3.52.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64-node/-/util-base64-node-3.52.0.tgz",
+      "integrity": "sha512-V96YIXBuIiVu7Zk72Y9dly7Io9cYOT30Hjf77KAkBeizlFgT5gWklWYGcytPY8FxLuEy4dPLeHRmgwQnlDwgPA==",
       "requires": {
         "@aws-sdk/util-buffer-from": "3.52.0",
         "tslib": "^2.3.0"
@@ -20808,18 +21252,24 @@
     },
     "@aws-sdk/util-body-length-browser": {
       "version": "3.52.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-browser/-/util-body-length-browser-3.52.0.tgz",
+      "integrity": "sha512-8omOgIGmopUtwg3XaeyvqacxrIrCsDKUVQp5n+8iLmyYt5mQM70vXbUC273GJzKDtibGDfxiN4FqSLBlo9F/oQ==",
       "requires": {
         "tslib": "^2.3.0"
       }
     },
     "@aws-sdk/util-body-length-node": {
       "version": "3.52.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-node/-/util-body-length-node-3.52.0.tgz",
+      "integrity": "sha512-1WWsGh0hip4y1uvOLFV2v3Nvq3W35dmW5YniCi0gQDBLc5JHES8Zka7yoCDYOfaYFUodVH5mC/jFBjGRQ3TpDw==",
       "requires": {
         "tslib": "^2.3.0"
       }
     },
     "@aws-sdk/util-buffer-from": {
       "version": "3.52.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-buffer-from/-/util-buffer-from-3.52.0.tgz",
+      "integrity": "sha512-hsG0lMlHjJUFoXIy59QLn6x4QU/vp/e0t3EjdD0t8aymB9iuJ43UeLjYTZdrOgtbWb8MXEF747vwg+P6n+4Lxw==",
       "requires": {
         "@aws-sdk/is-array-buffer": "3.52.0",
         "tslib": "^2.3.0"
@@ -20827,89 +21277,131 @@
     },
     "@aws-sdk/util-config-provider": {
       "version": "3.52.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-config-provider/-/util-config-provider-3.52.0.tgz",
+      "integrity": "sha512-1wonBNkOOLJpMZnz2Kn69ToFgSoTTyGzJInir8WC5sME3zpkb5j41kTuEVbImNJhVv9MKjmGYrMeZbBVniLRPw==",
       "requires": {
         "tslib": "^2.3.0"
       }
     },
     "@aws-sdk/util-credentials": {
-      "version": "3.52.0",
+      "version": "3.53.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-credentials/-/util-credentials-3.53.0.tgz",
+      "integrity": "sha512-XP/3mYOmSn5KpWv+PnBTP2UExXb+hx1ugbH4Gkveshdq9KBlVnpV5eVgIwSAnKBsplScfsNMJ5EOtHjz5Cvu5A==",
       "requires": {
         "@aws-sdk/shared-ini-file-loader": "3.52.0",
         "tslib": "^2.3.0"
       }
     },
     "@aws-sdk/util-defaults-mode-browser": {
-      "version": "3.52.0",
+      "version": "3.53.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-browser/-/util-defaults-mode-browser-3.53.0.tgz",
+      "integrity": "sha512-ubOcZT3rkVXSTwCHeIJevgBVV5GHnejz3hd+dFY9OcuK53oMZnFPS8SfJLgGG6PHfg30P8EurKv1VhWrbuuJDw==",
       "requires": {
-        "@aws-sdk/property-provider": "3.52.0",
-        "@aws-sdk/types": "3.52.0",
+        "@aws-sdk/property-provider": "3.53.0",
+        "@aws-sdk/types": "3.53.0",
         "bowser": "^2.11.0",
         "tslib": "^2.3.0"
       }
     },
     "@aws-sdk/util-defaults-mode-node": {
-      "version": "3.52.0",
+      "version": "3.53.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-node/-/util-defaults-mode-node-3.53.0.tgz",
+      "integrity": "sha512-84nczaF0eZMRkZ7chJh7OZd4ekV31eWmw8LOTJ4RQeeRy+0eY8th23yKyt5TU+YgmMLrY0BVK7103BQAI/6ccQ==",
       "requires": {
-        "@aws-sdk/config-resolver": "3.52.0",
-        "@aws-sdk/credential-provider-imds": "3.52.0",
-        "@aws-sdk/node-config-provider": "3.52.0",
-        "@aws-sdk/property-provider": "3.52.0",
-        "@aws-sdk/types": "3.52.0",
+        "@aws-sdk/config-resolver": "3.53.0",
+        "@aws-sdk/credential-provider-imds": "3.53.0",
+        "@aws-sdk/node-config-provider": "3.53.0",
+        "@aws-sdk/property-provider": "3.53.0",
+        "@aws-sdk/types": "3.53.0",
         "tslib": "^2.3.0"
       }
     },
     "@aws-sdk/util-hex-encoding": {
       "version": "3.52.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.52.0.tgz",
+      "integrity": "sha512-YYMZg8odn/hBURgL/w82ay2mvPqXHMdujlSndT1ddUSTRoZX67N3hfYYf36nOalDOjNcanIvFHe4Fe8nw+8JiA==",
       "requires": {
         "tslib": "^2.3.0"
       }
     },
     "@aws-sdk/util-locate-window": {
       "version": "3.52.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.52.0.tgz",
+      "integrity": "sha512-l10U2cLko6070A9DYLJG4NMtwYH8JBG2J/E+RH8uY3lad2o6fGEIkJU0jQbWbUeHYLG3IWuCxT47V4gxYrFj7g==",
       "requires": {
+        "tslib": "^2.3.0"
+      }
+    },
+    "@aws-sdk/util-stream-browser": {
+      "version": "3.53.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-stream-browser/-/util-stream-browser-3.53.0.tgz",
+      "integrity": "sha512-oh+PVTeo7nvkuXwlrAy6TErTpzTRrtxaL+2ErTFiLFPPFKK2/0X0E12zoNB0DMaY48sRdkJmrlLbOtxGDS1rNg==",
+      "requires": {
+        "@aws-sdk/types": "3.53.0",
+        "tslib": "^2.3.0"
+      }
+    },
+    "@aws-sdk/util-stream-node": {
+      "version": "3.53.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-stream-node/-/util-stream-node-3.53.0.tgz",
+      "integrity": "sha512-Hubb2cvn2idlNsHkJ5v46wW+cvodLySGJCqTat5kUAoOxR20ZFG3P3R6InU85PAh54zZTRvURuD0UM0uPtIQYQ==",
+      "requires": {
+        "@aws-sdk/types": "3.53.0",
         "tslib": "^2.3.0"
       }
     },
     "@aws-sdk/util-uri-escape": {
       "version": "3.52.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.52.0.tgz",
+      "integrity": "sha512-W9zw5tE8syjg17jiCYtyF99F0FgDIekQdLg+tQGobw9EtCxlUdg48UYhifPfnjvVyADRX2ntclHF9NmhusOQaQ==",
       "requires": {
         "tslib": "^2.3.0"
       }
     },
     "@aws-sdk/util-user-agent-browser": {
-      "version": "3.52.0",
+      "version": "3.53.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.53.0.tgz",
+      "integrity": "sha512-fJsxzjo4UMv2o6KYSvw8cwfDhAQiao3X+iY1lGNVKrcY2bnI4zW5pWYge94oIJXMyFjjg6k6Ek+JIvGLMFY0XA==",
       "requires": {
-        "@aws-sdk/types": "3.52.0",
+        "@aws-sdk/types": "3.53.0",
         "bowser": "^2.11.0",
         "tslib": "^2.3.0"
       }
     },
     "@aws-sdk/util-user-agent-node": {
-      "version": "3.52.0",
+      "version": "3.53.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.53.0.tgz",
+      "integrity": "sha512-YbrqMpTi+ArL9qG+NIXPInmnjGwYu0lohiH5uyEMHAHolqg4vqdKBlXyZ7Pjls2Nka7px2UUfX/Ba2RIssBBMQ==",
       "requires": {
-        "@aws-sdk/node-config-provider": "3.52.0",
-        "@aws-sdk/types": "3.52.0",
+        "@aws-sdk/node-config-provider": "3.53.0",
+        "@aws-sdk/types": "3.53.0",
         "tslib": "^2.3.0"
       }
     },
     "@aws-sdk/util-utf8-browser": {
       "version": "3.52.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.52.0.tgz",
+      "integrity": "sha512-LuOMa9ajWu5fQuYkmvTlQZfHaITkSle+tM/vhbU4JquRN44VUKACjRGT7UEhoU3lCL1BD0JFGMQGHI+5Mmuwfg==",
       "requires": {
         "tslib": "^2.3.0"
       }
     },
     "@aws-sdk/util-utf8-node": {
       "version": "3.52.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-node/-/util-utf8-node-3.52.0.tgz",
+      "integrity": "sha512-fujr7zeobZ2y5nnOnQZrCPPc+lCAhtNF/LEVslsQfd+AQ0bYWiosrKNetodQVWlfh10E2+i6/5g+1SBJ5kjsLw==",
       "requires": {
         "@aws-sdk/util-buffer-from": "3.52.0",
         "tslib": "^2.3.0"
       }
     },
     "@aws-sdk/util-waiter": {
-      "version": "3.52.0",
+      "version": "3.53.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-waiter/-/util-waiter-3.53.0.tgz",
+      "integrity": "sha512-WyiyHOzmiapbbwB8dtu7axRqu9u5+Mnp1/+k2Ia7cm0UMUTKLjdixPsaM89HNre3EMa8WHrDBnwyVmo/Khbq3w==",
       "requires": {
-        "@aws-sdk/abort-controller": "3.52.0",
-        "@aws-sdk/types": "3.52.0",
+        "@aws-sdk/abort-controller": "3.53.0",
+        "@aws-sdk/types": "3.53.0",
         "tslib": "^2.3.0"
       }
     },
@@ -21924,6 +22416,8 @@
     },
     "@httptoolkit/websocket-stream": {
       "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@httptoolkit/websocket-stream/-/websocket-stream-6.0.0.tgz",
+      "integrity": "sha512-EC8m9JbhpGX2okfvLakqrmy4Le0VyNKR7b3IdvFZR/BfFO4ruh/XceBvXhCFHkykchnFxuOSlRwFiqNSXlwcGA==",
       "peer": true,
       "requires": {
         "@types/ws": "*",
@@ -21938,10 +22432,14 @@
       "dependencies": {
         "isarray": {
           "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
           "peer": true
         },
         "readable-stream": {
           "version": "2.3.7",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+          "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
           "peer": true,
           "requires": {
             "core-util-is": "~1.0.0",
@@ -21955,6 +22453,8 @@
         },
         "string_decoder": {
           "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
           "peer": true,
           "requires": {
             "safe-buffer": "~5.1.0"
@@ -22772,7 +23272,9 @@
       "dev": true
     },
     "@types/ws": {
-      "version": "8.5.0",
+      "version": "8.5.2",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.5.2.tgz",
+      "integrity": "sha512-VXI82ykONr5tacHEojnErTQk+KQSoYbW1NB6iz6wUwrNd+BqfkfggQNoNdCqhJSzbNumShPERbM+Pc5zpfhlbw==",
       "peer": true,
       "requires": {
         "@types/node": "*"
@@ -22908,7 +23410,7 @@
     "@web3-storage/api": {
       "version": "file:packages/api",
       "requires": {
-        "@aws-sdk/client-s3": "^3.28.0",
+        "@aws-sdk/client-s3": "^3.53.1",
         "@cfworker/json-schema": "^1.8.3",
         "@google-cloud/precise-date": "^2.0.4",
         "@ipld/car": "^3.1.4",
@@ -24193,6 +24695,8 @@
     },
     "ansi": {
       "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/ansi/-/ansi-0.3.1.tgz",
+      "integrity": "sha1-DELU+xcWDVqa8eSEus4cZpIsGyE=",
       "peer": true
     },
     "ansi-colors": {
@@ -24384,6 +24888,8 @@
     },
     "aws-crt": {
       "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/aws-crt/-/aws-crt-1.11.0.tgz",
+      "integrity": "sha512-qIBDRLOKRFuPTjkOAt3Al5zbcR6YyjfEl3TUc0R/xZ64aDxWGGXDStfDpkGCLSgV7jH+o7KQ47U9PM3URiFNFg==",
       "peer": true,
       "requires": {
         "@httptoolkit/websocket-stream": "^6.0.0",
@@ -24398,6 +24904,8 @@
       "dependencies": {
         "crypto-js": {
           "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-4.1.1.tgz",
+          "integrity": "sha512-o2JlM7ydqd3Qk9CA0L4NL6mTzU2sdx96a+oOfPu8Mkl/PK51vSyoi8/rQ8NknZtk44vq15lmhAj9CIAGwgeWKw==",
           "peer": true
         }
       }
@@ -24408,6 +24916,8 @@
     },
     "axios": {
       "version": "0.24.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.24.0.tgz",
+      "integrity": "sha512-Q6cWsys88HoPgAaFAVUb0WpPk0O8iTeisR9IMqy9G8AbO4NlpVknrnQS03zzF9PGAWgO3cgletO3VjV/P7VztA==",
       "peer": true,
       "requires": {
         "follow-redirects": "^1.14.4"
@@ -24479,6 +24989,8 @@
     },
     "binary": {
       "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/binary/-/binary-0.3.0.tgz",
+      "integrity": "sha1-n2BVO8XOjDOG87VTz/R0Yq3sqnk=",
       "peer": true,
       "requires": {
         "buffers": "~0.1.1",
@@ -24520,6 +25032,8 @@
     },
     "bluebird": {
       "version": "3.4.7",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.4.7.tgz",
+      "integrity": "sha1-9y12C+Cbf3bQjtj66Ysomo0F+rM=",
       "peer": true
     },
     "bn.js": {
@@ -24556,7 +25070,9 @@
       "dev": true
     },
     "bowser": {
-      "version": "2.11.0"
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.11.0.tgz",
+      "integrity": "sha512-AlcaJBi/pqqJBIQ8U9Mcpc9i8Aqxn88Skv5d+xBX006BY5u8N3mGLHa5Lgppa7L/HfwgwLgZ6NYs+Ag6uUmJRA=="
     },
     "brace-expansion": {
       "version": "1.1.11",
@@ -24653,10 +25169,14 @@
     },
     "buffer-indexof-polyfill": {
       "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/buffer-indexof-polyfill/-/buffer-indexof-polyfill-1.0.2.tgz",
+      "integrity": "sha512-I7wzHwA3t1/lwXQh+A5PbNvJxgfo5r3xulgpYDB5zckTu/Z9oUK9biouBKQUjEqzaz3HnAT6TYoovmE+GqSf7A==",
       "peer": true
     },
     "buffer-shims": {
       "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz",
+      "integrity": "sha1-mXjOMXOIxkmth5MCjDR37wRKi1E=",
       "peer": true
     },
     "buffer-writer": {
@@ -24667,6 +25187,8 @@
     },
     "buffers": {
       "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/buffers/-/buffers-0.1.1.tgz",
+      "integrity": "sha1-skV5w77U1tOWru5tmorn9Ugqt7s=",
       "peer": true
     },
     "bufferutil": {
@@ -24922,6 +25444,8 @@
     },
     "chainsaw": {
       "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/chainsaw/-/chainsaw-0.1.0.tgz",
+      "integrity": "sha1-XqtQsor+WAdNDVgpE4iCi15fvJg=",
       "peer": true,
       "requires": {
         "traverse": ">=0.3.0 <0.4"
@@ -24958,6 +25482,8 @@
     },
     "chownr": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
+      "integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==",
       "peer": true
     },
     "chrome-trace-event": {
@@ -25020,6 +25546,8 @@
     },
     "cliui": {
       "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
+      "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
       "peer": true,
       "requires": {
         "string-width": "^1.0.1",
@@ -25029,10 +25557,14 @@
       "dependencies": {
         "ansi-regex": {
           "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
           "peer": true
         },
         "is-fullwidth-code-point": {
           "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "peer": true,
           "requires": {
             "number-is-nan": "^1.0.0"
@@ -25040,6 +25572,8 @@
         },
         "string-width": {
           "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "peer": true,
           "requires": {
             "code-point-at": "^1.0.0",
@@ -25049,6 +25583,8 @@
         },
         "strip-ansi": {
           "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "peer": true,
           "requires": {
             "ansi-regex": "^2.0.0"
@@ -25064,6 +25600,8 @@
     },
     "cmake-js": {
       "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/cmake-js/-/cmake-js-6.3.0.tgz",
+      "integrity": "sha512-1uqTOmFt6BIqKlrX+39/aewU/JVhyZWDqwAL+6psToUwxj3yWPJiwxiZFmV0XdcoWmqGs7peZTxTbJtAcH8hxw==",
       "peer": true,
       "requires": {
         "axios": "^0.21.1",
@@ -25085,6 +25623,8 @@
       "dependencies": {
         "are-we-there-yet": {
           "version": "1.0.6",
+          "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.0.6.tgz",
+          "integrity": "sha1-otKMkxAqpsyWJFomy5VN4G7FPww=",
           "peer": true,
           "requires": {
             "delegates": "^1.0.0",
@@ -25093,6 +25633,8 @@
         },
         "axios": {
           "version": "0.21.4",
+          "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
+          "integrity": "sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==",
           "peer": true,
           "requires": {
             "follow-redirects": "^1.14.0"
@@ -25100,10 +25642,14 @@
         },
         "chownr": {
           "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+          "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
           "peer": true
         },
         "fs-extra": {
           "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-5.0.0.tgz",
+          "integrity": "sha512-66Pm4RYbjzdyeuqudYqhFiNBbCIuI9kgRqLPSHIlXHidW8NIQtVdkM1yeZ4lXwuhbTETv3EUGMNHAAw6hiundQ==",
           "peer": true,
           "requires": {
             "graceful-fs": "^4.1.2",
@@ -25113,6 +25659,8 @@
         },
         "fs-minipass": {
           "version": "1.2.7",
+          "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.7.tgz",
+          "integrity": "sha512-GWSSJGFy4e9GUeCcbIkED+bgAoFyj7XF1mV8rma3QW4NIqX9Kyx79N/PF61H5udOV3aY1IaMLs6pGbH71nlCTA==",
           "peer": true,
           "requires": {
             "minipass": "^2.6.0"
@@ -25120,6 +25668,8 @@
         },
         "gauge": {
           "version": "1.2.7",
+          "resolved": "https://registry.npmjs.org/gauge/-/gauge-1.2.7.tgz",
+          "integrity": "sha1-6c7FSD09TuDvRLYKfZnkk14TbZM=",
           "peer": true,
           "requires": {
             "ansi": "^0.3.0",
@@ -25131,10 +25681,14 @@
         },
         "isarray": {
           "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
           "peer": true
         },
         "jsonfile": {
           "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+          "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
           "peer": true,
           "requires": {
             "graceful-fs": "^4.1.6"
@@ -25142,6 +25696,8 @@
         },
         "minipass": {
           "version": "2.9.0",
+          "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.9.0.tgz",
+          "integrity": "sha512-wxfUjg9WebH+CUDX/CdbRlh5SmfZiy/hpkxaRI16Y9W56Pa75sWgd/rvFilSgrauD9NyFymP/+JFV3KwzIsJeg==",
           "peer": true,
           "requires": {
             "safe-buffer": "^5.1.2",
@@ -25150,6 +25706,8 @@
         },
         "minizlib": {
           "version": "1.3.3",
+          "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-1.3.3.tgz",
+          "integrity": "sha512-6ZYMOEnmVsdCeTJVE0W9ZD+pVnE8h9Hma/iOwwRDsdQoePpoX56/8B6z3P9VNwppJuBKNRuFDRNRqRWexT9G9Q==",
           "peer": true,
           "requires": {
             "minipass": "^2.9.0"
@@ -25157,6 +25715,8 @@
         },
         "npmlog": {
           "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-1.2.1.tgz",
+          "integrity": "sha1-KOe+YZYJtT960d0wChDWTXFiaLY=",
           "peer": true,
           "requires": {
             "ansi": "~0.3.0",
@@ -25166,6 +25726,8 @@
         },
         "readable-stream": {
           "version": "2.3.7",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+          "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
           "peer": true,
           "requires": {
             "core-util-is": "~1.0.0",
@@ -25179,10 +25741,14 @@
         },
         "semver": {
           "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
           "peer": true
         },
         "string_decoder": {
           "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
           "peer": true,
           "requires": {
             "safe-buffer": "~5.1.0"
@@ -25190,6 +25756,8 @@
         },
         "tar": {
           "version": "4.4.19",
+          "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.19.tgz",
+          "integrity": "sha512-a20gEsvHnWe0ygBY8JbxoM4w3SJdhc7ZAuxkLqh+nvNQN2IOt0B5lLgM490X5Hl8FF0dl0tOf2ewFYAlIFgzVA==",
           "peer": true,
           "requires": {
             "chownr": "^1.1.4",
@@ -25203,16 +25771,22 @@
           "dependencies": {
             "safe-buffer": {
               "version": "5.2.1",
+              "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+              "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
               "peer": true
             }
           }
         },
         "universalify": {
           "version": "0.1.2",
+          "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+          "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
           "peer": true
         },
         "which": {
           "version": "1.3.1",
+          "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+          "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
           "peer": true,
           "requires": {
             "isexe": "^2.0.0"
@@ -25220,6 +25794,8 @@
         },
         "yallist": {
           "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+          "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
           "peer": true
         }
       }
@@ -25310,6 +25886,8 @@
     },
     "commist": {
       "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/commist/-/commist-1.1.0.tgz",
+      "integrity": "sha512-rraC8NXWOEjhADbZe9QBNzLAN5Q3fsTPQtBV+fEVj6xKIgDgNiEVE6ZNfHpZOqfQ21YUzfVNUXLOEZquYvQPPg==",
       "peer": true,
       "requires": {
         "leven": "^2.1.0",
@@ -25903,6 +26481,8 @@
     },
     "duplexer2": {
       "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.1.4.tgz",
+      "integrity": "sha1-ixLauHjA1p4+eJEFFmKjL8a93ME=",
       "peer": true,
       "requires": {
         "readable-stream": "^2.0.2"
@@ -25910,10 +26490,14 @@
       "dependencies": {
         "isarray": {
           "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
           "peer": true
         },
         "readable-stream": {
           "version": "2.3.7",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+          "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
           "peer": true,
           "requires": {
             "core-util-is": "~1.0.0",
@@ -25927,6 +26511,8 @@
         },
         "string_decoder": {
           "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
           "peer": true,
           "requires": {
             "safe-buffer": "~5.1.0"
@@ -25936,6 +26522,8 @@
     },
     "duplexify": {
       "version": "3.7.1",
+      "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.7.1.tgz",
+      "integrity": "sha512-07z8uv2wMyS51kKhD1KsdXJg5WQ6t93RneqRxUHnskXVtlYYkLqM0gqStQZ3pj073g687jPCHrqNfCzawLYh5g==",
       "peer": true,
       "requires": {
         "end-of-stream": "^1.0.0",
@@ -25946,10 +26534,14 @@
       "dependencies": {
         "isarray": {
           "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
           "peer": true
         },
         "readable-stream": {
           "version": "2.3.7",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+          "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
           "peer": true,
           "requires": {
             "core-util-is": "~1.0.0",
@@ -25963,6 +26555,8 @@
         },
         "string_decoder": {
           "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
           "peer": true,
           "requires": {
             "safe-buffer": "~5.1.0"
@@ -26821,10 +27415,14 @@
       "dev": true
     },
     "fast-xml-parser": {
-      "version": "3.19.0"
+      "version": "3.19.0",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-3.19.0.tgz",
+      "integrity": "sha512-4pXwmBplsCPv8FOY1WRakF970TjNGnGnfbOnLqjlYvMiF1SR3yOHyxMR/YCXpPTOspNF5gwudqktIP4VsWkvBg=="
     },
     "fastestsmallesttextencoderdecoder": {
       "version": "1.0.22",
+      "resolved": "https://registry.npmjs.org/fastestsmallesttextencoderdecoder/-/fastestsmallesttextencoderdecoder-1.0.22.tgz",
+      "integrity": "sha512-Pb8d48e+oIuY4MaM64Cd7OW1gt4nxCHs7/ddPPZ/Ic3sg8yVGM7O9wDvZ7us6ScaUupzM+pfBolwtYhN1IxBIw==",
       "peer": true
     },
     "fastq": {
@@ -26989,6 +27587,8 @@
     },
     "fs-minipass": {
       "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-2.1.0.tgz",
+      "integrity": "sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==",
       "peer": true,
       "requires": {
         "minipass": "^3.0.0"
@@ -27003,6 +27603,8 @@
     },
     "fstream": {
       "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.12.tgz",
+      "integrity": "sha512-WvJ193OHa0GHPEL+AycEJgxvBEwyfRkN1vhjca23OaPVMCaLCXTd5qAu82AjTcgP1UJmytkOKb63Ypde7raDIg==",
       "peer": true,
       "requires": {
         "graceful-fs": "^4.1.2",
@@ -27013,6 +27615,8 @@
       "dependencies": {
         "rimraf": {
           "version": "2.7.1",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+          "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
           "peer": true,
           "requires": {
             "glob": "^7.1.3"
@@ -27320,6 +27924,8 @@
     },
     "help-me": {
       "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/help-me/-/help-me-3.0.0.tgz",
+      "integrity": "sha512-hx73jClhyk910sidBB7ERlnhMlFsJJIBqSVMFDwPN8o2v9nmp5KgLq1Xz1Bf1fCMMZ6mPrX159iG0VLy/fPMtQ==",
       "peer": true,
       "requires": {
         "glob": "^7.1.6",
@@ -27489,6 +28095,8 @@
     },
     "invert-kv": {
       "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
+      "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY=",
       "peer": true
     },
     "ip": {
@@ -27956,6 +28564,8 @@
     },
     "is-iojs": {
       "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-iojs/-/is-iojs-1.1.0.tgz",
+      "integrity": "sha1-TBEDO11dlNbqs3dd7cm+fQCDJfE=",
       "peer": true
     },
     "is-ip": {
@@ -28101,6 +28711,8 @@
     },
     "isomorphic-ws": {
       "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/isomorphic-ws/-/isomorphic-ws-4.0.1.tgz",
+      "integrity": "sha512-BhBvN2MBpWTaSHdWRb/bwdZJ1WaehQ2L1KngkCkfLUGF0mAWAT1sQUQacEmQ0jXkFw/czDXPNQSL5u2/Krsz1w==",
       "peer": true,
       "requires": {}
     },
@@ -28282,6 +28894,8 @@
     },
     "js-sdsl": {
       "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/js-sdsl/-/js-sdsl-2.1.4.tgz",
+      "integrity": "sha512-/Ew+CJWHNddr7sjwgxaVeIORIH4AMVC9dy0hPf540ZGMVgS9d3ajwuVdyhDt6/QUvT8ATjR3yuYBKsS79F+H4A==",
       "peer": true
     },
     "js-sha3": {
@@ -28374,6 +28988,8 @@
     },
     "lcid": {
       "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
+      "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
       "peer": true,
       "requires": {
         "invert-kv": "^1.0.0"
@@ -28381,6 +28997,8 @@
     },
     "leven": {
       "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/leven/-/leven-2.1.0.tgz",
+      "integrity": "sha1-wuep93IJTe6dNCAq6KzORoeHVYA=",
       "peer": true
     },
     "levn": {
@@ -28424,6 +29042,8 @@
     },
     "listenercount": {
       "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/listenercount/-/listenercount-1.0.1.tgz",
+      "integrity": "sha1-hMinKrWcRyUyFIDJdeZQg0LnCTc=",
       "peer": true
     },
     "load-json-file": {
@@ -28516,14 +29136,20 @@
     },
     "lodash.pad": {
       "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/lodash.pad/-/lodash.pad-4.5.1.tgz",
+      "integrity": "sha1-QzCUmoM6fI2iLMIPaibE1Z3runA=",
       "peer": true
     },
     "lodash.padend": {
       "version": "4.6.1",
+      "resolved": "https://registry.npmjs.org/lodash.padend/-/lodash.padend-4.6.1.tgz",
+      "integrity": "sha1-U8y6BH0G4VjTEfRdpiX05J5vFm4=",
       "peer": true
     },
     "lodash.padstart": {
       "version": "4.6.1",
+      "resolved": "https://registry.npmjs.org/lodash.padstart/-/lodash.padstart-4.6.1.tgz",
+      "integrity": "sha1-0uPuv/DZ05rVD1y9G1KnvOa7YRs=",
       "peer": true
     },
     "lodash.template": {
@@ -28715,6 +29341,8 @@
     },
     "memory-stream": {
       "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/memory-stream/-/memory-stream-0.0.3.tgz",
+      "integrity": "sha1-6+jdHDuLw4wOeUHp3dWuvmtN6D8=",
       "peer": true,
       "requires": {
         "readable-stream": "~1.0.26-2"
@@ -28722,10 +29350,14 @@
       "dependencies": {
         "isarray": {
           "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
           "peer": true
         },
         "readable-stream": {
           "version": "1.0.34",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+          "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
           "peer": true,
           "requires": {
             "core-util-is": "~1.0.0",
@@ -28736,6 +29368,8 @@
         },
         "string_decoder": {
           "version": "0.10.31",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
           "peer": true
         }
       }
@@ -28966,6 +29600,8 @@
     },
     "minipass": {
       "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.1.6.tgz",
+      "integrity": "sha512-rty5kpw9/z8SX9dmxblFA6edItUmwJgMeYDZRrwlIVN27i8gysGbznJwUggw2V/FVqFSDdWy040ZPS811DYAqQ==",
       "peer": true,
       "requires": {
         "yallist": "^4.0.0"
@@ -28973,6 +29609,8 @@
     },
     "minizlib": {
       "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-2.1.2.tgz",
+      "integrity": "sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==",
       "peer": true,
       "requires": {
         "minipass": "^3.0.0",
@@ -29179,6 +29817,8 @@
     },
     "mqtt": {
       "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/mqtt/-/mqtt-4.3.6.tgz",
+      "integrity": "sha512-1dgQbkbh1Bba9iAGDNIrhSZ4nLDjbhmNHjOEvsmKI1Bb+2orj0gHwjqUKJ5CKUMKBYbkQYRM1fy+N1/2iZOj5w==",
       "peer": true,
       "requires": {
         "commist": "^1.0.0",
@@ -29202,6 +29842,8 @@
       "dependencies": {
         "duplexify": {
           "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-4.1.2.tgz",
+          "integrity": "sha512-fz3OjcNCHmRP12MJoZMPglx8m4rrFP8rovnk4vT8Fs+aonZoCwGg10dSsQsfP/E62eZcPTMSMP6686fu9Qlqtw==",
           "peer": true,
           "requires": {
             "end-of-stream": "^1.4.1",
@@ -29214,6 +29856,8 @@
     },
     "mqtt-packet": {
       "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/mqtt-packet/-/mqtt-packet-6.10.0.tgz",
+      "integrity": "sha512-ja8+mFKIHdB1Tpl6vac+sktqy3gA8t9Mduom1BA75cI+R9AHnZOiaBQwpGiWnaVJLDGRdNhQmFaAqd7tkKSMGA==",
       "peer": true,
       "requires": {
         "bl": "^4.0.2",
@@ -29223,6 +29867,8 @@
       "dependencies": {
         "bl": {
           "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+          "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
           "peer": true,
           "requires": {
             "buffer": "^5.5.0",
@@ -29232,6 +29878,8 @@
         },
         "buffer": {
           "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+          "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
           "peer": true,
           "requires": {
             "base64-js": "^1.3.1",
@@ -29624,7 +30272,9 @@
       }
     },
     "number-allocator": {
-      "version": "1.0.9",
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/number-allocator/-/number-allocator-1.0.10.tgz",
+      "integrity": "sha512-K4AvNGKo9lP6HqsZyfSr9KDaqnwFzW203inhQEOwFrmFaYevpdX4VNwdOLk197aHujzbT//z6pCBrCOUYSM5iw==",
       "peer": true,
       "requires": {
         "debug": "^4.3.1",
@@ -30163,6 +30813,8 @@
     },
     "os-locale": {
       "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
+      "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
       "peer": true,
       "requires": {
         "lcid": "^1.0.0"
@@ -31193,6 +31845,8 @@
     },
     "reinterval": {
       "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/reinterval/-/reinterval-1.1.0.tgz",
+      "integrity": "sha1-M2Hs+jymwYKDOA3Qu5VG85D17Oc=",
       "peer": true
     },
     "release-zalgo": {
@@ -31281,6 +31935,8 @@
     },
     "rfdc": {
       "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.3.0.tgz",
+      "integrity": "sha512-V2hovdzFbOi77/WajaSMXk2OLm+xNIeQdMMuB7icj7bk6zi2F8GGAxigcnDFpJHbNyNcgyJDiP+8nOrY5cZGrA==",
       "peer": true
     },
     "rgb-regex": {
@@ -31751,6 +32407,8 @@
     },
     "split2": {
       "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-3.2.2.tgz",
+      "integrity": "sha512-9NThjpgZnifTkJpzTZ7Eue85S49QwpNhZTq6GRJwObb6jnLFNGB7Qm73V5HewTROPyxD0C29xqmaI68bQtV+hg==",
       "peer": true,
       "requires": {
         "readable-stream": "^3.0.0"
@@ -31758,6 +32416,8 @@
     },
     "splitargs": {
       "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/splitargs/-/splitargs-0.0.7.tgz",
+      "integrity": "sha1-/p965lc3GzOxDLgNoUPPgknPazs=",
       "peer": true
     },
     "sprintf-js": {
@@ -31869,6 +32529,8 @@
     },
     "stream-shift": {
       "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.1.tgz",
+      "integrity": "sha512-AiisoFqQ0vbGcZgQPY1cdP2I76glaVA/RauYR4G4thNFgkTqr90yXTo4LYX60Jl+sIlPNHHdGSwo01AvbKUSVQ==",
       "peer": true
     },
     "stream-to-it": {
@@ -32184,6 +32846,8 @@
     },
     "tar": {
       "version": "6.1.11",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-6.1.11.tgz",
+      "integrity": "sha512-an/KZQzQUkZCkuoAA64hM92X0Urb6VpRhAFllDzz44U2mcD5scmT3zBc4VgVpkugF580+DQn8eAFSyoQt0tznA==",
       "peer": true,
       "requires": {
         "chownr": "^2.0.0",
@@ -32196,6 +32860,8 @@
       "dependencies": {
         "mkdirp": {
           "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+          "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
           "peer": true
         }
       }
@@ -32404,6 +33070,8 @@
     },
     "traverse": {
       "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.3.9.tgz",
+      "integrity": "sha1-cXuPIgzAu3tE5AUUwisui7xw2Lk=",
       "peer": true
     },
     "trim-newlines": {
@@ -32624,6 +33292,8 @@
     },
     "unzipper": {
       "version": "0.8.14",
+      "resolved": "https://registry.npmjs.org/unzipper/-/unzipper-0.8.14.tgz",
+      "integrity": "sha512-8rFtE7EP5ssOwGpN2dt1Q4njl0N1hUXJ7sSPz0leU2hRdq6+pra57z4YPBlVqm40vcgv6ooKZEAx48fMTv9x4w==",
       "peer": true,
       "requires": {
         "big-integer": "^1.6.17",
@@ -32639,14 +33309,20 @@
       "dependencies": {
         "isarray": {
           "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
           "peer": true
         },
         "process-nextick-args": {
           "version": "1.0.7",
+          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+          "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
           "peer": true
         },
         "readable-stream": {
           "version": "2.1.5",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.5.tgz",
+          "integrity": "sha1-ZvqLcg4UOLNkaB8q0aY8YYRIydA=",
           "peer": true,
           "requires": {
             "buffer-shims": "^1.0.0",
@@ -32660,6 +33336,8 @@
         },
         "string_decoder": {
           "version": "0.10.31",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
           "peer": true
         }
       }
@@ -32672,6 +33350,8 @@
     },
     "url-join": {
       "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/url-join/-/url-join-0.0.1.tgz",
+      "integrity": "sha1-HbSK1CLTQCRpqH99l73r/k+x48g=",
       "peer": true
     },
     "use-subscription": {
@@ -33004,6 +33684,8 @@
     },
     "window-size": {
       "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.4.tgz",
+      "integrity": "sha1-+OGqHuWlPsW/FR/6CXQqatdpeHY=",
       "peer": true
     },
     "word-wrap": {
@@ -33016,6 +33698,8 @@
     },
     "wrap-ansi": {
       "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+      "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
       "peer": true,
       "requires": {
         "string-width": "^1.0.1",
@@ -33024,10 +33708,14 @@
       "dependencies": {
         "ansi-regex": {
           "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
           "peer": true
         },
         "is-fullwidth-code-point": {
           "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "peer": true,
           "requires": {
             "number-is-nan": "^1.0.0"
@@ -33035,6 +33723,8 @@
         },
         "string-width": {
           "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "peer": true,
           "requires": {
             "code-point-at": "^1.0.0",
@@ -33044,6 +33734,8 @@
         },
         "strip-ansi": {
           "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "peer": true,
           "requires": {
             "ansi-regex": "^2.0.0"
@@ -33077,6 +33769,8 @@
     },
     "y18n": {
       "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.2.tgz",
+      "integrity": "sha512-uGZHXkHnhF0XeeAPgnKfPv1bgKAYyVvmNL1xlKsPYZPaIHxGti2hHqvOCQv71XMsLxu1QjergkqogUnms5D3YQ==",
       "peer": true
     },
     "yaeti": {
@@ -33091,6 +33785,8 @@
     },
     "yargs": {
       "version": "3.32.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.32.0.tgz",
+      "integrity": "sha1-AwiOnr+edWtpdRYR0qXvWRSCyZU=",
       "peer": true,
       "requires": {
         "camelcase": "^2.0.1",
@@ -33104,18 +33800,26 @@
       "dependencies": {
         "ansi-regex": {
           "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
           "peer": true
         },
         "camelcase": {
           "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
+          "integrity": "sha1-fB0W1nmhu+WcoCys7PsBHiAfWh8=",
           "peer": true
         },
         "decamelize": {
           "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+          "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
           "peer": true
         },
         "is-fullwidth-code-point": {
           "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "peer": true,
           "requires": {
             "number-is-nan": "^1.0.0"
@@ -33123,6 +33827,8 @@
         },
         "string-width": {
           "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "peer": true,
           "requires": {
             "code-point-at": "^1.0.0",
@@ -33132,6 +33838,8 @@
         },
         "strip-ansi": {
           "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "peer": true,
           "requires": {
             "ansi-regex": "^2.0.0"

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -50,7 +50,7 @@
     "websocket": "^1.0.34"
   },
   "dependencies": {
-    "@aws-sdk/client-s3": "^3.28.0",
+    "@aws-sdk/client-s3": "^3.53.1",
     "@cfworker/json-schema": "^1.8.3",
     "@google-cloud/precise-date": "^2.0.4",
     "@ipld/car": "^3.1.4",

--- a/packages/api/src/env.js
+++ b/packages/api/src/env.js
@@ -121,6 +121,7 @@ export function envAll (req, env, ctx) {
     env.s3BucketRegion = env.S3_BUCKET_REGION
 
     env.s3Client = new S3Client({
+      // logger: console, // use me to get some debug info on what the client is up to
       endpoint: env.S3_BUCKET_ENDPOINT,
       forcePathStyle: !!env.S3_BUCKET_ENDPOINT, // Force path if endpoint provided
       region: env.S3_BUCKET_REGION,
@@ -129,5 +130,17 @@ export function envAll (req, env, ctx) {
         secretAccessKey: env.S3_SECRET_ACCESS_KEY_ID
       }
     })
+    if (env.ENV === 'dev') {
+      // show me what s3 sdk is up to.
+      env.s3Client.middlewareStack.add(
+        (next, context) => async (args) => {
+          console.log('s3 request headers', args.request.headers)
+          return next(args)
+        },
+        {
+          step: 'finalizeRequest'
+        }
+      )
+    }
   }
 }


### PR DESCRIPTION
add `x-amz-checksum-sha256` header on s3 object put requests.

This is nice as we reuse our existing sha256 hash of the car as an integrity check. AWS will calculate the sha256 of the body it receives and send us a 400 BadDigest error if they dont match, to avoid storing CARs that had bits flipped in transit.

It was necessary to update to the latest version of the aws-sdk as support for sha256 integrity checking was not supported in the older one.

Some debug logging is left in for the s3 client in dev mode, as it was an absolute pain to figure out what it was doing otherwise.

see: #1036
see: https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutObject.html#AmazonS3-PutObject-request-header-ChecksumSHA256

License: (Apache-2.0 AND MIT)
Signed-off-by: Oli Evans <oli@tableflip.io>