### PR TITLE
fix: pin status syncing

### DIFF
--- a/packages/api/src/utils/pin.js
+++ b/packages/api/src/utils/pin.js
@@ -1,5 +1,5 @@
 /**
- * @typedef {import('@nftstorage/ipfs-cluster').TrackerStatus} TrackerStatus
+ * @typedef {import('@nftstorage/ipfs-cluster').API.TrackerStatus} TrackerStatus
  * @typedef {'Undefined'
  *  | 'ClusterError'
  *  | 'PinError'

--- a/packages/cron/test/mocks/cluster/get_pins#@cid.js
+++ b/packages/cron/test/mocks/cluster/get_pins#@cid.js
@@ -10,8 +10,9 @@ module.exports = async ({ params }) => {
       cid: { '/': params.cid },
       name: 'test-pin-name',
       peer_map: {
-        'test-peer-id': {
+        'test-cluster-peer-id': {
           peername: 'test-peer-name',
+          ipfs_peer_id: 'test-peer-id',
           status: 'pinned',
           timestamp: new Date().toISOString()
         }


### PR DESCRIPTION
When the DB was updated to use the IPFS node peer ID instead of the Cluster node peer ID the pin status syncing stopped working.