### PR TITLE
fix: tmp workaround for lack of ipfs peer id on status response

### DIFF
--- a/packages/api/src/utils/pin.js
+++ b/packages/api/src/utils/pin.js
@@ -98,12 +98,19 @@ export function toPins (peerMap) {
   // Note: `clusterPeerId` is an internal id, and is only used for cluster admin.
   // The `ipfsPeerId` which we rename to `peerId` can be  used to connect to the underlying ipfs node
   // that stores a given pin, by passing it to `ipfs swarm connect <peerid>`.
-  return Object.entries(peerMap).map(([clusterPeerId, { peerName, status, ipfsPeerId: peerId }]) => {
+  const toPins Object.entries(peerMap).map(([clusterPeerId, { peerName, status, ipfsPeerId: peerId }]) => {
     return {
       status: toPinStatusEnum(status),
       location: { peerId, peerName }
     }
   })
+  
+  const filteredToPins = toPins.filter(pin => pin.location?.peerId)
+  if (toPins.length !== filteredToPins.length) {
+    console.log('Dropping pins that do not have "peerId" on it', toPins.filter(pin => !!pin.location?.peerId))
+  }
+
+  return filteredToPins
 }
 
 /**

--- a/packages/api/src/utils/pin.js
+++ b/packages/api/src/utils/pin.js
@@ -98,13 +98,13 @@ export function toPins (peerMap) {
   // Note: `clusterPeerId` is an internal id, and is only used for cluster admin.
   // The `ipfsPeerId` which we rename to `peerId` can be  used to connect to the underlying ipfs node
   // that stores a given pin, by passing it to `ipfs swarm connect <peerid>`.
-  const toPins Object.entries(peerMap).map(([clusterPeerId, { peerName, status, ipfsPeerId: peerId }]) => {
+  const toPins = Object.entries(peerMap).map(([clusterPeerId, { peerName, status, ipfsPeerId: peerId }]) => {
     return {
       status: toPinStatusEnum(status),
       location: { peerId, peerName }
     }
   })
-  
+
   const filteredToPins = toPins.filter(pin => pin.location?.peerId)
   if (toPins.length !== filteredToPins.length) {
     console.log('Dropping pins that do not have "peerId" on it', toPins.filter(pin => !!pin.location?.peerId))


### PR DESCRIPTION
While we don't fix https://github.com/web3-storage/web3.storage/issues/1089 this was added to production