### PR TITLE
fix: store IPFS peer IDs

### DIFF
--- a/packages/api/src/utils/pin.js
+++ b/packages/api/src/utils/pin.js
@@ -59,7 +59,7 @@ export function toPinStatusEnum (trackerStatus) {
  *
  * @param {string} cid cid to be looked for
  * @param {import('@nftstorage/ipfs-cluster').Cluster} cluster
- * @param {import('@nftstorage/ipfs-cluster').StatusResponse['peerMap']} [peerMap] Optional list of peers, if not provided the fuctions queries the cluster.
+ * @param {import('@nftstorage/ipfs-cluster').API.StatusResponse['peerMap']} [peerMap] Optional list of peers, if not provided the fuctions queries the cluster.
  * @return {Promise.<import('@web3-storage/db/db-client-types').PinUpsertInput[]>}
  */
 export async function getPins (cid, cluster, peerMap) {
@@ -81,36 +81,27 @@ export async function getPins (cid, cluster, peerMap) {
  *
  * @param {string} cid cid to be looked for
  * @param {import('@nftstorage/ipfs-cluster').Cluster} cluster
- * @param {import('@nftstorage/ipfs-cluster').StatusResponse['peerMap']} [peerMap] Optional list of peers, if not provided the fuctions queries the cluster.
+ * @param {import('@nftstorage/ipfs-cluster').API.StatusResponse['peerMap']} [peerMap] Optional list of peers, if not provided the function queries the cluster.
  * @return {Promise.<import('@web3-storage/db/db-client-types').PinUpsertInput[]>}
  */
-export async function getOKpins (cid, cluster, peerMap) {
+async function getOKpins (cid, cluster, peerMap) {
   const pins = await getPins(cid, cluster, peerMap)
 
   return pins.filter(p => PIN_OK_STATUS.includes(p.status))
 }
 
 /**
- * @param {import('@nftstorage/ipfs-cluster').StatusResponse['peerMap']} peerMap
+ * @param {import('@nftstorage/ipfs-cluster').API.StatusResponse['peerMap']} peerMap
  * @return {Array.<import('@web3-storage/db/db-client-types').PinUpsertInput>}
  */
-export function toPins (peerMap) {
-  // Note: `clusterPeerId` is an internal id, and is only used for cluster admin.
-  // The `ipfsPeerId` which we rename to `peerId` can be  used to connect to the underlying ipfs node
+function toPins (peerMap) {
+  // Note: `peerId` is the ID of the Cluster node, and is only used for cluster
+  // admin. The `ipfsPeerId` can be  used to connect to the underlying ipfs node
   // that stores a given pin, by passing it to `ipfs swarm connect <peerid>`.
-  const toPins = Object.entries(peerMap).map(([clusterPeerId, { peerName, status, ipfsPeerId: peerId }]) => {
-    return {
-      status: toPinStatusEnum(status),
-      location: { peerId, peerName }
-    }
-  })
-
-  const filteredToPins = toPins.filter(pin => pin.location?.peerId)
-  if (toPins.length !== filteredToPins.length) {
-    console.log('Dropping pins that do not have "peerId" on it', toPins.filter(pin => !!pin.location?.peerId))
-  }
-
-  return filteredToPins
+  return Object.entries(peerMap).map(([peerId, { peerName, ipfsPeerId, status }]) => ({
+    status: toPinStatusEnum(status),
+    location: { peerId, peerName, ipfsPeerId }
+  }))
 }
 
 /**

--- a/packages/api/test/car.spec.js
+++ b/packages/api/test/car.spec.js
@@ -9,6 +9,7 @@ import { endpoint, clusterApi, clusterApiAuthHeader } from './scripts/constants.
 import { createCar } from './scripts/car.js'
 import { MAX_BLOCK_SIZE } from '../src/constants.js'
 import { getTestJWT } from './scripts/helpers.js'
+import { PIN_OK_STATUS } from '../src/utils/pin.js'
 
 describe('POST /car', () => {
   it('should add posted CARs to Cluster', async () => {
@@ -41,8 +42,8 @@ describe('POST /car', () => {
 
     const statusRes = await fetch(new URL(`status/${cid}`, endpoint))
     const status = await statusRes.json()
-    const pinned = status.pins.find(pin => pin.status === 'Pinned')
-    assert(pinned, 'CID is Pinned')
+    const pinInfo = status.pins.find(pin => PIN_OK_STATUS.includes(pin.status))
+    assert(pinInfo, `status is one of ${PIN_OK_STATUS}`)
 
     const clusterPeersRes = await fetch(new URL('peers', clusterApi), {
       headers: {
@@ -51,7 +52,7 @@ describe('POST /car', () => {
     })
     const clusterPeers = await clusterPeersRes.json()
     // assert that peerId from the status belongs to one of the cluster ipfs nodes.
-    assert(clusterPeers.some(peer => peer.ipfs.id === pinned.peerId))
+    assert(clusterPeers.some(peer => peer.ipfs.id === pinInfo.peerId))
   })
 
   it('should throw for blocks bigger than the maximum permitted size', async () => {

--- a/packages/api/test/fixtures/init-data.sql
+++ b/packages/api/test/fixtures/init-data.sql
@@ -51,8 +51,8 @@ VALUES (3, 'bafybeifnfkzjeohjf2dch2iqqpef3bfjylwxlcjws2msvdfyze5bvdprfm', 'bafyb
        (3, 'bafybeica6klnrhlrbx6z24icefykpbwyypouglnypvnwb5esdm6yzcie3q', 'bafybeica6klnrhlrbx6z24icefykpbwyypouglnypvnwb5esdm6yzcie3q', 'Car', '2021-07-14T19:27:14.934572Z', '2021-07-14T19:27:14.934572Z'),
        (3, 'bafybeiaiipiibr7aletbbrzmpklw4l5go6sodl22xs6qtcqo3lqogfogy4', 'bafybeiaiipiibr7aletbbrzmpklw4l5go6sodl22xs6qtcqo3lqogfogy4', 'Car', '2021-07-14T19:27:14.934572Z', '2021-07-14T19:27:14.934572Z');
 
-INSERT INTO pin_location (peer_id, peer_name, region)
-VALUES ('12D3KooWR1Js', 'who?', 'where?');
+INSERT INTO pin_location (peer_id, peer_name, ipfs_peer_id, region)
+VALUES ('12D3KooEL1Jc', 'who?', '12D3KooWR1Js', 'where?');
 
 INSERT INTO pin (status, content_cid, pin_location_id, inserted_at, updated_at)
 VALUES ('Pinned', 'bafybeifnfkzjeohjf2dch2iqqpef3bfjylwxlcjws2msvdfyze5bvdprfm', 1, '2021-07-14T19:27:14.934572+00:00', '2021-07-14T19:27:14.934572+00:00'),

--- a/packages/cron/src/jobs/pins.js
+++ b/packages/cron/src/jobs/pins.js
@@ -68,7 +68,7 @@ export async function updatePinStatuses ({ cluster, db }) {
         return null // Cluster could not find the content, please check later
       }
 
-      let pinInfo = Object.values(peerMap).find(i => pin.location.peerId === i.ipfsPeerId)
+      let pinInfo = peerMap[pin.location.peerId]
       if (!pinInfo) {
         log(`⚠️ ${pin.contentCid} is not tracked by our cluster!`)
         return null
@@ -94,7 +94,7 @@ export async function updatePinStatuses ({ cluster, db }) {
           return null
         }
 
-        pinInfo = Object.values(peerMap).find(i => pin.location.peerId === i.ipfsPeerId)
+        pinInfo = peerMap[pin.location.peerId]
         if (!pinInfo) {
           log(`⚠️ ${cidV0} is not tracked by our cluster!`)
           return null

--- a/packages/cron/test/mocks/cluster/get_pins#@cid.js
+++ b/packages/cron/test/mocks/cluster/get_pins#@cid.js
@@ -10,9 +10,9 @@ module.exports = async ({ params }) => {
       cid: { '/': params.cid },
       name: 'test-pin-name',
       peer_map: {
-        'test-cluster-peer-id': {
+        'test-peer-id': {
           peername: 'test-peer-name',
-          ipfs_peer_id: 'test-peer-id',
+          ipfs_peer_id: 'test-ipfs-peer-id',
           status: 'pinned',
           timestamp: new Date().toISOString()
         }

--- a/packages/db/db-client-types.ts
+++ b/packages/db/db-client-types.ts
@@ -223,6 +223,7 @@ export type UploadOutput = definitions['upload'] & {
 export type Location = {
   _id?: string
   peerId: definitions['pin_location']['peer_id']
+  ipfsPeerId?: definitions['pin_location']['ipfs_peer_id']
   peerName?: definitions['pin_location']['peer_name']
   region?: definitions['pin_location']['region']
 }

--- a/packages/db/index.js
+++ b/packages/db/index.js
@@ -11,7 +11,7 @@ const uploadQuery = `
         name,
         created:inserted_at,
         updated:updated_at,
-        content(cid, dagSize:dag_size, pins:pin(status, updated:updated_at, location:pin_location(_id:id, peerId:peer_id, peerName:peer_name, region)))
+        content(cid, dagSize:dag_size, pins:pin(status, updated:updated_at, location:pin_location(_id:id, peerId:peer_id, peerName:peer_name, ipfsPeerId:ipfs_peer_id, region)))
       `
 
 const psaPinRequestTableName = 'psa_pin_request'
@@ -26,7 +26,7 @@ const pinRequestSelect = `
   deleted:deleted_at,
   created:inserted_at,
   updated:updated_at,
-  content(cid, dagSize:dag_size, pins:pin(status, updated:updated_at, location:pin_location(_id:id::text, peerId:peer_id, peerName:peer_name, region)))`
+  content(cid, dagSize:dag_size, pins:pin(status, updated:updated_at, location:pin_location(_id:id::text, peerId:peer_id, peerName:peer_name, ipfsPeerId:ipfs_peer_id, region)))`
 
 const listPinsQuery = `
   _id:id::text,
@@ -48,6 +48,7 @@ const listPinsQuery = `
         _id:id,
         peerId:peer_id,
         peerName:peer_name,
+        ipfsPeerId:ipfs_peer_id,
         region
       )
     )
@@ -193,6 +194,7 @@ export class DBClient {
           location: {
             peer_id: pin.location.peerId,
             peer_name: pin.location.peerName,
+            ipfs_peer_id: pin.location.ipfsPeerId,
             region: pin.location.region
           }
         })),
@@ -360,7 +362,7 @@ export class DBClient {
         cid,
         dagSize:dag_size,
         created:inserted_at,
-        pins:pin(status, updated:updated_at, location:pin_location(peerId:peer_id, peerName:peer_name, region))
+        pins:pin(status, updated:updated_at, location:pin_location(peerId:peer_id, peerName:peer_name, ipfsPeerId:ipfs_peer_id, region))
       `)
       .match({ cid })
 
@@ -421,6 +423,7 @@ export class DBClient {
           location: {
             peer_id: pin.location.peerId,
             peer_name: pin.location.peerName,
+            ipfs_peer_id: pin.location.ipfsPeerId,
             region: pin.location.region
           }
         }
@@ -473,7 +476,7 @@ export class DBClient {
         status,
         created:inserted_at,
         updated:updated_at,
-        location:pin_location(id::text, peerId:peer_id, peerName:peer_name, region)
+        location:pin_location(id::text, peerId:peer_id, peerName:peer_name, ipfsPeerId:ipfs_peer_id, region)
       `)
       .match({ content_cid: cid })
 
@@ -562,7 +565,7 @@ export class DBClient {
       .from('pin_sync_request')
       .select(`
         _id:id::text,
-        pin:pin(_id:id::text, status, contentCid:content_cid, created:inserted_at, location:pin_location(_id:id::text, peerId:peer_id, peerName:peer_name, region))
+        pin:pin(_id:id::text, status, contentCid:content_cid, created:inserted_at, location:pin_location(_id:id::text, peerId:peer_id, peerName:peer_name, ipfsPeerId:ipfs_peer_id, region))
       `)
       .order(
         'inserted_at',
@@ -832,6 +835,7 @@ export class DBClient {
           location: {
             peer_id: pin.location.peerId,
             peer_name: pin.location.peerName,
+            ipfs_peer_id: pin.location.ipfsPeerId,
             region: pin.location.region
           }
         }))

--- a/packages/db/postgres/functions.sql
+++ b/packages/db/postgres/functions.sql
@@ -76,9 +76,10 @@ BEGIN
   foreach pin in array json_arr_to_json_element_array(data -> 'pins')
   loop
         -- Add to pin_location table if new
-        insert into pin_location (peer_id, peer_name, region)
+        insert into pin_location (peer_id, peer_name, ipfs_peer_id, region)
         values (pin -> 'location' ->> 'peer_id',
                 pin -> 'location' ->> 'peer_name',
+                pin -> 'location' ->> 'ipfs_peer_id',
                 pin -> 'location' ->> 'region')
         -- Force update on conflict to get result, otherwise needs a follow up select
         ON CONFLICT ( peer_id ) DO UPDATE
@@ -224,9 +225,10 @@ BEGIN
   -- DATA => content_cid, pin(status, location(peer_id, peer_name, region))
 
   -- Add to pin_location table if new
-  insert into pin_location (peer_id, peer_name, region)
+  insert into pin_location (peer_id, peer_name, ipfs_peer_id, region)
   values (data -> 'pin' -> 'location' ->> 'peer_id',
           data -> 'pin' -> 'location' ->> 'peer_name',
+          data -> 'pin' -> 'location' ->> 'ipfs_peer_id',
           data -> 'pin' -> 'location' ->> 'region')
   ON CONFLICT ( peer_id ) DO UPDATE
           SET "peer_name" = data -> 'pin' -> 'location' ->> 'peer_name',

--- a/packages/db/postgres/migrations/003-add-ipfs-peer-ids.sql
+++ b/packages/db/postgres/migrations/003-add-ipfs-peer-ids.sql
@@ -2,17 +2,6 @@
 -- the IPFS node is down)
 ALTER TABLE pin_location ADD COLUMN ipfs_peer_id TEXT;
 -- swap back cluster peer IDs in peer_id and add IPFS peer IDs to ipfs_peer_id
-UPDATE pin_location SET peer_id='12D3KooWF6uxxqZf4sXpQEbNE4BfbVJWAKWrFSKamxmWm4E9vyzd', ipfs_peer_id='12D3KooWPySxxWQjBgX9Jp6uAHQfVmdq8HG1gVvS1fRawHNSrmqW' WHERE peer_id='12D3KooWPySxxWQjBgX9Jp6uAHQfVmdq8HG1gVvS1fRawHNSrmqW';
-UPDATE pin_location SET peer_id='12D3KooWFe387JFDpgNEVCP5ARut7gRkX7YuJCXMStpkq714ziK6', ipfs_peer_id='12D3KooWR19qPPiZH4khepNjS3CLXiB7AbrbAD4ZcDjN1UjGUNE1' WHERE peer_id='12D3KooWR19qPPiZH4khepNjS3CLXiB7AbrbAD4ZcDjN1UjGUNE1';
-UPDATE pin_location SET peer_id='12D3KooWHdBjmicdXu5X57mQ65oBpfy4p3ca5p31kfJT9FSUFu3P', ipfs_peer_id='12D3KooWKytRAd2ujxhGzaLHKJuje8sVrHXvjGNvHXovpar5KaKQ' WHERE peer_id='12D3KooWKytRAd2ujxhGzaLHKJuje8sVrHXvjGNvHXovpar5KaKQ';
-UPDATE pin_location SET peer_id='12D3KooWJeRQfPbiv5U2RqQ9yK3qijbNxKarKEGLMkGrfXJuZ2Bo', ipfs_peer_id='12D3KooWEDMw7oRqQkdCJbyeqS5mUmWGwTp8JJ2tjCzTkHboF6wK' WHERE peer_id='12D3KooWEDMw7oRqQkdCJbyeqS5mUmWGwTp8JJ2tjCzTkHboF6wK';
-UPDATE pin_location SET peer_id='12D3KooWLWFUri36dmTkki6o9PwfQNwGb2gsHuKD5FdcwzCXYnwc', ipfs_peer_id='12D3KooWNuoVEfVLJvU3jWY2zLYjGUaathsecwT19jhByjnbQvkj' WHERE peer_id='12D3KooWNuoVEfVLJvU3jWY2zLYjGUaathsecwT19jhByjnbQvkj';
-UPDATE pin_location SET peer_id='12D3KooWMbibcXHwkSjgV7VZ8TMfDKi6pZvmi97P83ZwHm9LEsvV', ipfs_peer_id='12D3KooWSnniGsyAF663gvHdqhyfJMCjWJv54cGSzcPiEMAfanvU' WHERE peer_id='12D3KooWSnniGsyAF663gvHdqhyfJMCjWJv54cGSzcPiEMAfanvU';
-UPDATE pin_location SET peer_id='12D3KooWGFuccA83SpGGHb92PtM4LAQenxmCYkbB2G2BSEPa2Reo', ipfs_peer_id='12D3KooWRi18oHN1j8McxS9RMnuibcTwxu6VCTYHyLNH2R14qhTy' WHERE peer_id='12D3KooWRi18oHN1j8McxS9RMnuibcTwxu6VCTYHyLNH2R14qhTy';
-UPDATE pin_location SET peer_id='12D3KooWLf5E9SqSuA8BNmFPkokEayfKpHVyg8zT8qEm4Ruz6gk3', ipfs_peer_id='12D3KooWQYBPcvxFnnWzPGEx6JuBnrbF1FZq4jTahczuG2teEk1m' WHERE peer_id='12D3KooWQYBPcvxFnnWzPGEx6JuBnrbF1FZq4jTahczuG2teEk1m';
-UPDATE pin_location SET peer_id='12D3KooW9yCAQ2edw5N75b7t9qCGYb7uFVzkfAgp4KoyTEJKXenF', ipfs_peer_id='12D3KooWJEfH2MB4RsUoaJPogDPRWbFTi8iehsxsqrQpiJwFNDrP' WHERE peer_id='12D3KooWJEfH2MB4RsUoaJPogDPRWbFTi8iehsxsqrQpiJwFNDrP';
-
-
 -- am6
 UPDATE pin_location SET peer_id='12D3KooWF6uxxqZf4sXpQEbNE4BfbVJWAKWrFSKamxmWm4E9vyzd', ipfs_peer_id='12D3KooWPySxxWQjBgX9Jp6uAHQfVmdq8HG1gVvS1fRawHNSrmqW' WHERE peer_id='12D3KooWPySxxWQjBgX9Jp6uAHQfVmdq8HG1gVvS1fRawHNSrmqW';
 -- sv15

--- a/packages/db/postgres/migrations/003-add-ipfs-peer-ids.sql
+++ b/packages/db/postgres/migrations/003-add-ipfs-peer-ids.sql
@@ -1,0 +1,13 @@
+-- add the ipfs_peer_id column (nullable because Cluster does not report it if
+-- the IPFS node is down)
+ALTER TABLE pin_location ADD COLUMN ipfs_peer_id TEXT;
+-- swap back cluster peer IDs in peer_id and add IPFS peer IDs to ipfs_peer_id
+UPDATE pin_location SET peer_id='12D3KooWF6uxxqZf4sXpQEbNE4BfbVJWAKWrFSKamxmWm4E9vyzd', ipfs_peer_id='12D3KooWPySxxWQjBgX9Jp6uAHQfVmdq8HG1gVvS1fRawHNSrmqW' WHERE peer_id='12D3KooWPySxxWQjBgX9Jp6uAHQfVmdq8HG1gVvS1fRawHNSrmqW';
+UPDATE pin_location SET peer_id='12D3KooWFe387JFDpgNEVCP5ARut7gRkX7YuJCXMStpkq714ziK6', ipfs_peer_id='12D3KooWR19qPPiZH4khepNjS3CLXiB7AbrbAD4ZcDjN1UjGUNE1' WHERE peer_id='12D3KooWR19qPPiZH4khepNjS3CLXiB7AbrbAD4ZcDjN1UjGUNE1';
+UPDATE pin_location SET peer_id='12D3KooWHdBjmicdXu5X57mQ65oBpfy4p3ca5p31kfJT9FSUFu3P', ipfs_peer_id='12D3KooWKytRAd2ujxhGzaLHKJuje8sVrHXvjGNvHXovpar5KaKQ' WHERE peer_id='12D3KooWKytRAd2ujxhGzaLHKJuje8sVrHXvjGNvHXovpar5KaKQ';
+UPDATE pin_location SET peer_id='12D3KooWJeRQfPbiv5U2RqQ9yK3qijbNxKarKEGLMkGrfXJuZ2Bo', ipfs_peer_id='12D3KooWEDMw7oRqQkdCJbyeqS5mUmWGwTp8JJ2tjCzTkHboF6wK' WHERE peer_id='12D3KooWEDMw7oRqQkdCJbyeqS5mUmWGwTp8JJ2tjCzTkHboF6wK';
+UPDATE pin_location SET peer_id='12D3KooWLWFUri36dmTkki6o9PwfQNwGb2gsHuKD5FdcwzCXYnwc', ipfs_peer_id='12D3KooWNuoVEfVLJvU3jWY2zLYjGUaathsecwT19jhByjnbQvkj' WHERE peer_id='12D3KooWNuoVEfVLJvU3jWY2zLYjGUaathsecwT19jhByjnbQvkj';
+UPDATE pin_location SET peer_id='12D3KooWMbibcXHwkSjgV7VZ8TMfDKi6pZvmi97P83ZwHm9LEsvV', ipfs_peer_id='12D3KooWSnniGsyAF663gvHdqhyfJMCjWJv54cGSzcPiEMAfanvU' WHERE peer_id='12D3KooWSnniGsyAF663gvHdqhyfJMCjWJv54cGSzcPiEMAfanvU';
+UPDATE pin_location SET peer_id='12D3KooWGFuccA83SpGGHb92PtM4LAQenxmCYkbB2G2BSEPa2Reo', ipfs_peer_id='12D3KooWRi18oHN1j8McxS9RMnuibcTwxu6VCTYHyLNH2R14qhTy' WHERE peer_id='12D3KooWRi18oHN1j8McxS9RMnuibcTwxu6VCTYHyLNH2R14qhTy';
+UPDATE pin_location SET peer_id='12D3KooWLf5E9SqSuA8BNmFPkokEayfKpHVyg8zT8qEm4Ruz6gk3', ipfs_peer_id='12D3KooWQYBPcvxFnnWzPGEx6JuBnrbF1FZq4jTahczuG2teEk1m' WHERE peer_id='12D3KooWQYBPcvxFnnWzPGEx6JuBnrbF1FZq4jTahczuG2teEk1m';
+UPDATE pin_location SET peer_id='12D3KooW9yCAQ2edw5N75b7t9qCGYb7uFVzkfAgp4KoyTEJKXenF', ipfs_peer_id='12D3KooWJEfH2MB4RsUoaJPogDPRWbFTi8iehsxsqrQpiJwFNDrP' WHERE peer_id='12D3KooWJEfH2MB4RsUoaJPogDPRWbFTi8iehsxsqrQpiJwFNDrP';

--- a/packages/db/postgres/migrations/003-add-ipfs-peer-ids.sql
+++ b/packages/db/postgres/migrations/003-add-ipfs-peer-ids.sql
@@ -11,3 +11,35 @@ UPDATE pin_location SET peer_id='12D3KooWMbibcXHwkSjgV7VZ8TMfDKi6pZvmi97P83ZwHm9
 UPDATE pin_location SET peer_id='12D3KooWGFuccA83SpGGHb92PtM4LAQenxmCYkbB2G2BSEPa2Reo', ipfs_peer_id='12D3KooWRi18oHN1j8McxS9RMnuibcTwxu6VCTYHyLNH2R14qhTy' WHERE peer_id='12D3KooWRi18oHN1j8McxS9RMnuibcTwxu6VCTYHyLNH2R14qhTy';
 UPDATE pin_location SET peer_id='12D3KooWLf5E9SqSuA8BNmFPkokEayfKpHVyg8zT8qEm4Ruz6gk3', ipfs_peer_id='12D3KooWQYBPcvxFnnWzPGEx6JuBnrbF1FZq4jTahczuG2teEk1m' WHERE peer_id='12D3KooWQYBPcvxFnnWzPGEx6JuBnrbF1FZq4jTahczuG2teEk1m';
 UPDATE pin_location SET peer_id='12D3KooW9yCAQ2edw5N75b7t9qCGYb7uFVzkfAgp4KoyTEJKXenF', ipfs_peer_id='12D3KooWJEfH2MB4RsUoaJPogDPRWbFTi8iehsxsqrQpiJwFNDrP' WHERE peer_id='12D3KooWJEfH2MB4RsUoaJPogDPRWbFTi8iehsxsqrQpiJwFNDrP';
+
+
+-- am6
+UPDATE pin_location SET peer_id='12D3KooWF6uxxqZf4sXpQEbNE4BfbVJWAKWrFSKamxmWm4E9vyzd', ipfs_peer_id='12D3KooWPySxxWQjBgX9Jp6uAHQfVmdq8HG1gVvS1fRawHNSrmqW' WHERE peer_id='12D3KooWPySxxWQjBgX9Jp6uAHQfVmdq8HG1gVvS1fRawHNSrmqW';
+-- sv15
+UPDATE pin_location SET peer_id='12D3KooWFe387JFDpgNEVCP5ARut7gRkX7YuJCXMStpkq714ziK6', ipfs_peer_id='12D3KooWR19qPPiZH4khepNjS3CLXiB7AbrbAD4ZcDjN1UjGUNE1' WHERE peer_id='12D3KooWR19qPPiZH4khepNjS3CLXiB7AbrbAD4ZcDjN1UjGUNE1';
+-- dc13-2
+UPDATE pin_location SET peer_id='12D3KooWHdBjmicdXu5X57mQ65oBpfy4p3ca5p31kfJT9FSUFu3P', ipfs_peer_id='12D3KooWKytRAd2ujxhGzaLHKJuje8sVrHXvjGNvHXovpar5KaKQ' WHERE peer_id='12D3KooWKytRAd2ujxhGzaLHKJuje8sVrHXvjGNvHXovpar5KaKQ';
+-- sv15-2
+UPDATE pin_location SET peer_id='12D3KooWJeRQfPbiv5U2RqQ9yK3qijbNxKarKEGLMkGrfXJuZ2Bo', ipfs_peer_id='12D3KooWEDMw7oRqQkdCJbyeqS5mUmWGwTp8JJ2tjCzTkHboF6wK' WHERE peer_id='12D3KooWEDMw7oRqQkdCJbyeqS5mUmWGwTp8JJ2tjCzTkHboF6wK';
+-- am6-2
+UPDATE pin_location SET peer_id='12D3KooWLWFUri36dmTkki6o9PwfQNwGb2gsHuKD5FdcwzCXYnwc', ipfs_peer_id='12D3KooWNuoVEfVLJvU3jWY2zLYjGUaathsecwT19jhByjnbQvkj' WHERE peer_id='12D3KooWNuoVEfVLJvU3jWY2zLYjGUaathsecwT19jhByjnbQvkj';
+-- dc13
+UPDATE pin_location SET peer_id='12D3KooWMbibcXHwkSjgV7VZ8TMfDKi6pZvmi97P83ZwHm9LEsvV', ipfs_peer_id='12D3KooWSnniGsyAF663gvHdqhyfJMCjWJv54cGSzcPiEMAfanvU' WHERE peer_id='12D3KooWSnniGsyAF663gvHdqhyfJMCjWJv54cGSzcPiEMAfanvU';
+-- sv15-3
+UPDATE pin_location SET peer_id='12D3KooWGFuccA83SpGGHb92PtM4LAQenxmCYkbB2G2BSEPa2Reo', ipfs_peer_id='12D3KooWRi18oHN1j8McxS9RMnuibcTwxu6VCTYHyLNH2R14qhTy' WHERE peer_id='12D3KooWRi18oHN1j8McxS9RMnuibcTwxu6VCTYHyLNH2R14qhTy';
+-- am6-3
+UPDATE pin_location SET peer_id='12D3KooWLf5E9SqSuA8BNmFPkokEayfKpHVyg8zT8qEm4Ruz6gk3', ipfs_peer_id='12D3KooWQYBPcvxFnnWzPGEx6JuBnrbF1FZq4jTahczuG2teEk1m' WHERE peer_id='12D3KooWQYBPcvxFnnWzPGEx6JuBnrbF1FZq4jTahczuG2teEk1m';
+-- dc13-3
+UPDATE pin_location SET peer_id='12D3KooW9yCAQ2edw5N75b7t9qCGYb7uFVzkfAgp4KoyTEJKXenF', ipfs_peer_id='12D3KooWJEfH2MB4RsUoaJPogDPRWbFTi8iehsxsqrQpiJwFNDrP' WHERE peer_id='12D3KooWJEfH2MB4RsUoaJPogDPRWbFTi8iehsxsqrQpiJwFNDrP';
+-- sv15-4
+UPDATE pin_location SET peer_id='12D3KooWN1voqaVzyvPHGLV9s4WnSR699bzvmKB9K73wiYnZ8bYc', ipfs_peer_id='12D3KooWKhPb9tSnCqBswVfC5EPE7iSTXhbF4Ywwz2MKg5UCagbr' WHERE peer_id='12D3KooWKhPb9tSnCqBswVfC5EPE7iSTXhbF4Ywwz2MKg5UCagbr';
+-- sv15-5
+UPDATE pin_location SET peer_id='12D3KooWFBRdRnrokAwhqpYHRz5VBkGkcVLN5ygy1GZLZ1US4cma', ipfs_peer_id='12D3KooWAdxvJCV5KXZ6zveTJmnYGrSzAKuLUKZYkZssLk7UKv4i' WHERE peer_id='12D3KooWAdxvJCV5KXZ6zveTJmnYGrSzAKuLUKZYkZssLk7UKv4i';
+-- am6-4
+UPDATE pin_location SET peer_id='12D3KooWGEtscYaBrGPmCBupTcGzXJyDnKfB7vfUeHBzGkMSD2YJ', ipfs_peer_id='12D3KooWDdzN3snjaMJEH9zuq3tjKUFpYHeSGNkiAreF6dQSbCiL' WHERE peer_id='12D3KooWDdzN3snjaMJEH9zuq3tjKUFpYHeSGNkiAreF6dQSbCiL';
+-- am6-5
+UPDATE pin_location SET peer_id='12D3KooWARoNFfnVTS6gBHNUQ4bgSLbXHb3aFfzdaiVffmu1sv89', ipfs_peer_id='12D3KooWEzCun34s9qpYEnKkG6epx2Ts9oVGRGnzCvM2s2edioLA' WHERE peer_id='12D3KooWEzCun34s9qpYEnKkG6epx2Ts9oVGRGnzCvM2s2edioLA';
+-- dc13-4
+UPDATE pin_location SET peer_id='12D3KooWGuxTyiADDRbmMmcP7A2EZA34BSdy91u7oBPhEJfUGPnU', ipfs_peer_id='12D3KooWHpE5KiQTkqbn8KbU88ZxwJxYJFaqP4mp9Z9bhNPhym9V' WHERE peer_id='12D3KooWHpE5KiQTkqbn8KbU88ZxwJxYJFaqP4mp9Z9bhNPhym9V';
+-- dc13-5
+UPDATE pin_location SET peer_id='12D3KooWQhAHsCcfWT2WFbtGC8s2QBt37exdpSEihHoj5obifYpy', ipfs_peer_id='12D3KooWBHvsSSKHeragACma3HUodK5FcPUpXccLu2vHooNsDf9k' WHERE peer_id='12D3KooWBHvsSSKHeragACma3HUodK5FcPUpXccLu2vHooNsDf9k';

--- a/packages/db/postgres/pg-rest-api-types.d.ts
+++ b/packages/db/postgres/pg-rest-api-types.d.ts
@@ -451,6 +451,102 @@ export interface paths {
       };
     };
   };
+  "/metric": {
+    get: {
+      parameters: {
+        query: {
+          name?: parameters["rowFilter.metric.name"];
+          value?: parameters["rowFilter.metric.value"];
+          inserted_at?: parameters["rowFilter.metric.inserted_at"];
+          updated_at?: parameters["rowFilter.metric.updated_at"];
+          /** Filtering Columns */
+          select?: parameters["select"];
+          /** Ordering */
+          order?: parameters["order"];
+          /** Limiting and Pagination */
+          offset?: parameters["offset"];
+          /** Limiting and Pagination */
+          limit?: parameters["limit"];
+        };
+        header: {
+          /** Limiting and Pagination */
+          Range?: parameters["range"];
+          /** Limiting and Pagination */
+          "Range-Unit"?: parameters["rangeUnit"];
+          /** Preference */
+          Prefer?: parameters["preferCount"];
+        };
+      };
+      responses: {
+        /** OK */
+        200: {
+          schema: definitions["metric"][];
+        };
+        /** Partial Content */
+        206: unknown;
+      };
+    };
+    post: {
+      parameters: {
+        body: {
+          /** metric */
+          metric?: definitions["metric"];
+        };
+        query: {
+          /** Filtering Columns */
+          select?: parameters["select"];
+        };
+        header: {
+          /** Preference */
+          Prefer?: parameters["preferReturn"];
+        };
+      };
+      responses: {
+        /** Created */
+        201: unknown;
+      };
+    };
+    delete: {
+      parameters: {
+        query: {
+          name?: parameters["rowFilter.metric.name"];
+          value?: parameters["rowFilter.metric.value"];
+          inserted_at?: parameters["rowFilter.metric.inserted_at"];
+          updated_at?: parameters["rowFilter.metric.updated_at"];
+        };
+        header: {
+          /** Preference */
+          Prefer?: parameters["preferReturn"];
+        };
+      };
+      responses: {
+        /** No Content */
+        204: never;
+      };
+    };
+    patch: {
+      parameters: {
+        query: {
+          name?: parameters["rowFilter.metric.name"];
+          value?: parameters["rowFilter.metric.value"];
+          inserted_at?: parameters["rowFilter.metric.inserted_at"];
+          updated_at?: parameters["rowFilter.metric.updated_at"];
+        };
+        body: {
+          /** metric */
+          metric?: definitions["metric"];
+        };
+        header: {
+          /** Preference */
+          Prefer?: parameters["preferReturn"];
+        };
+      };
+      responses: {
+        /** No Content */
+        204: never;
+      };
+    };
+  };
   "/name": {
     get: {
       parameters: {
@@ -665,6 +761,7 @@ export interface paths {
           id?: parameters["rowFilter.pin_location.id"];
           peer_id?: parameters["rowFilter.pin_location.peer_id"];
           peer_name?: parameters["rowFilter.pin_location.peer_name"];
+          ipfs_peer_id?: parameters["rowFilter.pin_location.ipfs_peer_id"];
           region?: parameters["rowFilter.pin_location.region"];
           /** Filtering Columns */
           select?: parameters["select"];
@@ -719,6 +816,7 @@ export interface paths {
           id?: parameters["rowFilter.pin_location.id"];
           peer_id?: parameters["rowFilter.pin_location.peer_id"];
           peer_name?: parameters["rowFilter.pin_location.peer_name"];
+          ipfs_peer_id?: parameters["rowFilter.pin_location.ipfs_peer_id"];
           region?: parameters["rowFilter.pin_location.region"];
         };
         header: {
@@ -737,6 +835,7 @@ export interface paths {
           id?: parameters["rowFilter.pin_location.id"];
           peer_id?: parameters["rowFilter.pin_location.peer_id"];
           peer_name?: parameters["rowFilter.pin_location.peer_name"];
+          ipfs_peer_id?: parameters["rowFilter.pin_location.ipfs_peer_id"];
           region?: parameters["rowFilter.pin_location.region"];
         };
         body: {
@@ -1390,11 +1489,14 @@ export interface paths {
       };
     };
   };
-  "/rpc/pin_dag_size_total": {
+  "/rpc/user_auth_keys_list": {
     post: {
       parameters: {
         body: {
-          args: { [key: string]: unknown };
+          args: {
+            /** Format: bigint */
+            query_user_id: number;
+          };
         };
         header: {
           /** Preference */
@@ -1407,11 +1509,14 @@ export interface paths {
       };
     };
   };
-  "/rpc/uuid_ns_url": {
+  "/rpc/create_psa_pin_request": {
     post: {
       parameters: {
         body: {
-          args: { [key: string]: unknown };
+          args: {
+            /** Format: json */
+            data: string;
+          };
         };
         header: {
           /** Preference */
@@ -1424,11 +1529,14 @@ export interface paths {
       };
     };
   };
-  "/rpc/pgrst_watch": {
+  "/rpc/user_used_storage": {
     post: {
       parameters: {
         body: {
-          args: { [key: string]: unknown };
+          args: {
+            /** Format: bigint */
+            query_user_id: number;
+          };
         };
         header: {
           /** Preference */
@@ -1441,7 +1549,67 @@ export interface paths {
       };
     };
   };
-  "/rpc/uuid_nil": {
+  "/rpc/json_arr_to_json_element_array": {
+    post: {
+      parameters: {
+        body: {
+          args: {
+            /** Format: json */
+            _json: string;
+          };
+        };
+        header: {
+          /** Preference */
+          Prefer?: parameters["preferParams"];
+        };
+      };
+      responses: {
+        /** OK */
+        200: unknown;
+      };
+    };
+  };
+  "/rpc/create_key": {
+    post: {
+      parameters: {
+        body: {
+          args: {
+            /** Format: json */
+            data: string;
+          };
+        };
+        header: {
+          /** Preference */
+          Prefer?: parameters["preferParams"];
+        };
+      };
+      responses: {
+        /** OK */
+        200: unknown;
+      };
+    };
+  };
+  "/rpc/json_arr_to_text_arr": {
+    post: {
+      parameters: {
+        body: {
+          args: {
+            /** Format: json */
+            _json: string;
+          };
+        };
+        header: {
+          /** Preference */
+          Prefer?: parameters["preferParams"];
+        };
+      };
+      responses: {
+        /** OK */
+        200: unknown;
+      };
+    };
+  };
+  "/rpc/uuid_generate_v1mc": {
     post: {
       parameters: {
         body: {
@@ -1475,11 +1643,148 @@ export interface paths {
       };
     };
   };
+  "/rpc/uuid_generate_v4": {
+    post: {
+      parameters: {
+        body: {
+          args: { [key: string]: unknown };
+        };
+        header: {
+          /** Preference */
+          Prefer?: parameters["preferParams"];
+        };
+      };
+      responses: {
+        /** OK */
+        200: unknown;
+      };
+    };
+  };
+  "/rpc/create_upload": {
+    post: {
+      parameters: {
+        body: {
+          args: {
+            /** Format: json */
+            data: string;
+          };
+        };
+        header: {
+          /** Preference */
+          Prefer?: parameters["preferParams"];
+        };
+      };
+      responses: {
+        /** OK */
+        200: unknown;
+      };
+    };
+  };
+  "/rpc/upsert_pin": {
+    post: {
+      parameters: {
+        body: {
+          args: {
+            /** Format: json */
+            data: string;
+          };
+        };
+        header: {
+          /** Preference */
+          Prefer?: parameters["preferParams"];
+        };
+      };
+      responses: {
+        /** OK */
+        200: unknown;
+      };
+    };
+  };
+  "/rpc/find_deals_by_content_cids": {
+    post: {
+      parameters: {
+        body: {
+          args: {
+            /** Format: text[] */
+            cids: string;
+          };
+        };
+        header: {
+          /** Preference */
+          Prefer?: parameters["preferParams"];
+        };
+      };
+      responses: {
+        /** OK */
+        200: unknown;
+      };
+    };
+  };
+  "/rpc/publish_name_record": {
+    post: {
+      parameters: {
+        body: {
+          args: {
+            /** Format: json */
+            data: string;
+          };
+        };
+        header: {
+          /** Preference */
+          Prefer?: parameters["preferParams"];
+        };
+      };
+      responses: {
+        /** OK */
+        200: unknown;
+      };
+    };
+  };
+  "/rpc/uuid_ns_url": {
+    post: {
+      parameters: {
+        body: {
+          args: { [key: string]: unknown };
+        };
+        header: {
+          /** Preference */
+          Prefer?: parameters["preferParams"];
+        };
+      };
+      responses: {
+        /** OK */
+        200: unknown;
+      };
+    };
+  };
+  "/rpc/uuid_generate_v5": {
+    post: {
+      parameters: {
+        body: {
+          args: {
+            /** Format: text */
+            name: string;
+            /** Format: uuid */
+            namespace: string;
+          };
+        };
+        header: {
+          /** Preference */
+          Prefer?: parameters["preferParams"];
+        };
+      };
+      responses: {
+        /** OK */
+        200: unknown;
+      };
+    };
+  };
   "/rpc/create_content": {
     post: {
       parameters: {
         body: {
           args: {
+            /** Format: json */
             data: string;
           };
         };
@@ -1511,90 +1816,11 @@ export interface paths {
       };
     };
   };
-  "/rpc/user_auth_keys_list": {
+  "/rpc/pgrst_watch": {
     post: {
       parameters: {
         body: {
-          args: {
-            query_user_id: number;
-          };
-        };
-        header: {
-          /** Preference */
-          Prefer?: parameters["preferParams"];
-        };
-      };
-      responses: {
-        /** OK */
-        200: unknown;
-      };
-    };
-  };
-  "/rpc/pin_from_status_total": {
-    post: {
-      parameters: {
-        body: {
-          args: {
-            query_status: string;
-          };
-        };
-        header: {
-          /** Preference */
-          Prefer?: parameters["preferParams"];
-        };
-      };
-      responses: {
-        /** OK */
-        200: unknown;
-      };
-    };
-  };
-  "/rpc/find_deals_by_content_cids": {
-    post: {
-      parameters: {
-        body: {
-          args: {
-            cids: string;
-          };
-        };
-        header: {
-          /** Preference */
-          Prefer?: parameters["preferParams"];
-        };
-      };
-      responses: {
-        /** OK */
-        200: unknown;
-      };
-    };
-  };
-  "/rpc/uuid_generate_v5": {
-    post: {
-      parameters: {
-        body: {
-          args: {
-            namespace: string;
-            name: string;
-          };
-        };
-        header: {
-          /** Preference */
-          Prefer?: parameters["preferParams"];
-        };
-      };
-      responses: {
-        /** OK */
-        200: unknown;
-      };
-    };
-  };
-  "/rpc/upsert_pin": {
-    post: {
-      parameters: {
-        body: {
-          args: {
-            data: string;
-          };
+          args: { [key: string]: unknown };
         };
         header: {
           /** Preference */
@@ -1624,101 +1850,7 @@ export interface paths {
       };
     };
   };
-  "/rpc/json_arr_to_text_arr": {
-    post: {
-      parameters: {
-        body: {
-          args: {
-            _json: string;
-          };
-        };
-        header: {
-          /** Preference */
-          Prefer?: parameters["preferParams"];
-        };
-      };
-      responses: {
-        /** OK */
-        200: unknown;
-      };
-    };
-  };
-  "/rpc/publish_name_record": {
-    post: {
-      parameters: {
-        body: {
-          args: {
-            data: string;
-          };
-        };
-        header: {
-          /** Preference */
-          Prefer?: parameters["preferParams"];
-        };
-      };
-      responses: {
-        /** OK */
-        200: unknown;
-      };
-    };
-  };
-  "/rpc/uuid_generate_v3": {
-    post: {
-      parameters: {
-        body: {
-          args: {
-            namespace: string;
-            name: string;
-          };
-        };
-        header: {
-          /** Preference */
-          Prefer?: parameters["preferParams"];
-        };
-      };
-      responses: {
-        /** OK */
-        200: unknown;
-      };
-    };
-  };
-  "/rpc/content_dag_size_total": {
-    post: {
-      parameters: {
-        body: {
-          args: { [key: string]: unknown };
-        };
-        header: {
-          /** Preference */
-          Prefer?: parameters["preferParams"];
-        };
-      };
-      responses: {
-        /** OK */
-        200: unknown;
-      };
-    };
-  };
-  "/rpc/create_key": {
-    post: {
-      parameters: {
-        body: {
-          args: {
-            data: string;
-          };
-        };
-        header: {
-          /** Preference */
-          Prefer?: parameters["preferParams"];
-        };
-      };
-      responses: {
-        /** OK */
-        200: unknown;
-      };
-    };
-  };
-  "/rpc/uuid_generate_v4": {
+  "/rpc/uuid_nil": {
     post: {
       parameters: {
         body: {
@@ -1752,86 +1884,15 @@ export interface paths {
       };
     };
   };
-  "/rpc/json_arr_to_json_element_array": {
+  "/rpc/uuid_generate_v3": {
     post: {
       parameters: {
         body: {
           args: {
-            _json: string;
-          };
-        };
-        header: {
-          /** Preference */
-          Prefer?: parameters["preferParams"];
-        };
-      };
-      responses: {
-        /** OK */
-        200: unknown;
-      };
-    };
-  };
-  "/rpc/create_psa_pin_request": {
-    post: {
-      parameters: {
-        body: {
-          args: {
-            data: string;
-          };
-        };
-        header: {
-          /** Preference */
-          Prefer?: parameters["preferParams"];
-        };
-      };
-      responses: {
-        /** OK */
-        200: unknown;
-      };
-    };
-  };
-  "/rpc/user_used_storage": {
-    post: {
-      parameters: {
-        body: {
-          args: {
-            query_user_id: number;
-          };
-        };
-        header: {
-          /** Preference */
-          Prefer?: parameters["preferParams"];
-        };
-      };
-      responses: {
-        /** OK */
-        200: unknown;
-      };
-    };
-  };
-  "/rpc/uuid_generate_v1mc": {
-    post: {
-      parameters: {
-        body: {
-          args: { [key: string]: unknown };
-        };
-        header: {
-          /** Preference */
-          Prefer?: parameters["preferParams"];
-        };
-      };
-      responses: {
-        /** OK */
-        200: unknown;
-      };
-    };
-  };
-  "/rpc/create_upload": {
-    post: {
-      parameters: {
-        body: {
-          args: {
-            data: string;
+            /** Format: text */
+            name: string;
+            /** Format: uuid */
+            namespace: string;
           };
         };
         header: {
@@ -1849,91 +1910,173 @@ export interface paths {
 
 export interface definitions {
   admin_search: {
+    /** Format: text */
     user_id?: string;
+    /** Format: text */
     email?: string;
+    /** Format: text */
     token?: string;
+    /** Format: text */
     token_id?: string;
+    /** Format: timestamp with time zone */
     deleted_at?: string;
+    /** Format: timestamp with time zone */
     reason_inserted_at?: string;
+    /** Format: text */
     reason?: string;
+    /** Format: public.auth_key_blocked_status_type */
     status?: "Blocked" | "Unblocked";
   };
   auth_key: {
     /**
-     * Note:
+     * Format: bigint
+     * @description Note:
      * This is a Primary Key.<pk/>
      */
     id: number;
+    /** Format: text */
     name: string;
+    /** Format: text */
     secret: string;
     /**
-     * Note:
+     * Format: bigint
+     * @description Note:
      * This is a Foreign Key to `user.id`.<fk table='user' column='id'/>
      */
     user_id: number;
+    /**
+     * Format: timestamp with time zone
+     * @default timezone('utc'::text, now())
+     */
     inserted_at: string;
+    /**
+     * Format: timestamp with time zone
+     * @default timezone('utc'::text, now())
+     */
     updated_at: string;
+    /** Format: timestamp with time zone */
     deleted_at?: string;
   };
   auth_key_history: {
     /**
-     * Note:
+     * Format: bigint
+     * @description Note:
      * This is a Primary Key.<pk/>
      */
     id: number;
+    /** Format: public.auth_key_blocked_status_type */
     status: "Blocked" | "Unblocked";
+    /** Format: text */
     reason: string;
     /**
-     * Note:
+     * Format: bigint
+     * @description Note:
      * This is a Foreign Key to `auth_key.id`.<fk table='auth_key' column='id'/>
      */
     auth_key_id: number;
+    /**
+     * Format: timestamp with time zone
+     * @default timezone('utc'::text, now())
+     */
     inserted_at: string;
+    /** Format: timestamp with time zone */
     deleted_at?: string;
   };
   backup: {
     /**
-     * Note:
+     * Format: bigint
+     * @description Note:
      * This is a Primary Key.<pk/>
      */
     id: number;
     /**
-     * Note:
+     * Format: bigint
+     * @description Note:
      * This is a Foreign Key to `upload.id`.<fk table='upload' column='id'/>
      */
     upload_id: number;
+    /** Format: text */
     url: string;
+    /**
+     * Format: timestamp with time zone
+     * @default timezone('utc'::text, now())
+     */
     inserted_at: string;
   };
   content: {
     /**
-     * Note:
+     * Format: text
+     * @description Note:
      * This is a Primary Key.<pk/>
      */
     cid: string;
+    /** Format: bigint */
     dag_size?: number;
+    /**
+     * Format: timestamp with time zone
+     * @default timezone('utc'::text, now())
+     */
     inserted_at: string;
+    /**
+     * Format: timestamp with time zone
+     * @default timezone('utc'::text, now())
+     */
+    updated_at: string;
+  };
+  metric: {
+    /**
+     * Format: text
+     * @description Note:
+     * This is a Primary Key.<pk/>
+     */
+    name: string;
+    /** Format: bigint */
+    value: number;
+    /**
+     * Format: timestamp with time zone
+     * @default timezone('utc'::text, now())
+     */
+    inserted_at: string;
+    /**
+     * Format: timestamp with time zone
+     * @default timezone('utc'::text, now())
+     */
     updated_at: string;
   };
   name: {
     /**
-     * Note:
+     * Format: text
+     * @description Note:
      * This is a Primary Key.<pk/>
      */
     key: string;
+    /** Format: text */
     record: string;
+    /** Format: boolean */
     has_v2_sig: boolean;
+    /** Format: bigint */
     seqno: number;
+    /** Format: bigint */
     validity: number;
+    /**
+     * Format: timestamp with time zone
+     * @default timezone('utc'::text, now())
+     */
     inserted_at: string;
+    /**
+     * Format: timestamp with time zone
+     * @default timezone('utc'::text, now())
+     */
     updated_at: string;
   };
   pin: {
     /**
-     * Note:
+     * Format: bigint
+     * @description Note:
      * This is a Primary Key.<pk/>
      */
     id: number;
+    /** Format: public.pin_status_type */
     status:
       | "Undefined"
       | "ClusterError"
@@ -1948,280 +2091,476 @@ export interface definitions {
       | "UnpinQueued"
       | "Sharded";
     /**
-     * Note:
+     * Format: text
+     * @description Note:
      * This is a Foreign Key to `content.cid`.<fk table='content' column='cid'/>
      */
     content_cid: string;
     /**
-     * Note:
+     * Format: bigint
+     * @description Note:
      * This is a Foreign Key to `pin_location.id`.<fk table='pin_location' column='id'/>
      */
     pin_location_id: number;
+    /**
+     * Format: timestamp with time zone
+     * @default timezone('utc'::text, now())
+     */
     inserted_at: string;
+    /**
+     * Format: timestamp with time zone
+     * @default timezone('utc'::text, now())
+     */
     updated_at: string;
   };
   pin_location: {
     /**
-     * Note:
+     * Format: bigint
+     * @description Note:
      * This is a Primary Key.<pk/>
      */
     id: number;
+    /** Format: text */
     peer_id: string;
+    /** Format: text */
     peer_name?: string;
+    /** Format: text */
+    ipfs_peer_id?: string;
+    /** Format: text */
     region?: string;
   };
   pin_request: {
     /**
-     * Note:
+     * Format: bigint
+     * @description Note:
      * This is a Primary Key.<pk/>
      */
     id: number;
     /**
-     * Note:
+     * Format: text
+     * @description Note:
      * This is a Foreign Key to `content.cid`.<fk table='content' column='cid'/>
      */
     content_cid: string;
+    /** Format: integer */
     attempts?: number;
+    /**
+     * Format: timestamp with time zone
+     * @default timezone('utc'::text, now())
+     */
     inserted_at: string;
+    /**
+     * Format: timestamp with time zone
+     * @default timezone('utc'::text, now())
+     */
     updated_at: string;
   };
   pin_sync_request: {
     /**
-     * Note:
+     * Format: bigint
+     * @description Note:
      * This is a Primary Key.<pk/>
      */
     id: number;
     /**
-     * Note:
+     * Format: bigint
+     * @description Note:
      * This is a Foreign Key to `pin.id`.<fk table='pin' column='id'/>
      */
     pin_id: number;
+    /**
+     * Format: timestamp with time zone
+     * @default timezone('utc'::text, now())
+     */
     inserted_at: string;
   };
   psa_pin_request: {
     /**
-     * Note:
+     * Format: text
+     * @description Note:
      * This is a Primary Key.<pk/>
+     * @default public.uuid_generate_v4()
      */
     id: string;
     /**
-     * Note:
+     * Format: bigint
+     * @description Note:
      * This is a Foreign Key to `auth_key.id`.<fk table='auth_key' column='id'/>
      */
     auth_key_id: number;
     /**
-     * Note:
+     * Format: text
+     * @description Note:
      * This is a Foreign Key to `content.cid`.<fk table='content' column='cid'/>
      */
     content_cid: string;
+    /** Format: text */
     source_cid: string;
+    /** Format: text */
     name?: string;
+    /** Format: jsonb */
     origins?: string;
+    /** Format: jsonb */
     meta?: string;
+    /** Format: timestamp with time zone */
     deleted_at?: string;
+    /**
+     * Format: timestamp with time zone
+     * @default timezone('utc'::text, now())
+     */
     inserted_at: string;
+    /**
+     * Format: timestamp with time zone
+     * @default timezone('utc'::text, now())
+     */
     updated_at: string;
   };
   upload: {
     /**
-     * Note:
+     * Format: bigint
+     * @description Note:
      * This is a Primary Key.<pk/>
      */
     id: number;
     /**
-     * Note:
+     * Format: bigint
+     * @description Note:
      * This is a Foreign Key to `user.id`.<fk table='user' column='id'/>
      */
     user_id: number;
     /**
-     * Note:
+     * Format: bigint
+     * @description Note:
      * This is a Foreign Key to `auth_key.id`.<fk table='auth_key' column='id'/>
      */
     auth_key_id?: number;
     /**
-     * Note:
+     * Format: text
+     * @description Note:
      * This is a Foreign Key to `content.cid`.<fk table='content' column='cid'/>
      */
     content_cid: string;
+    /** Format: text */
     source_cid: string;
+    /** Format: public.upload_type */
     type: "Car" | "Upload" | "Blob" | "Multipart";
+    /** Format: text */
     name?: string;
+    /**
+     * Format: timestamp with time zone
+     * @default timezone('utc'::text, now())
+     */
     inserted_at: string;
+    /**
+     * Format: timestamp with time zone
+     * @default timezone('utc'::text, now())
+     */
     updated_at: string;
+    /** Format: timestamp with time zone */
     deleted_at?: string;
   };
   user: {
     /**
-     * Note:
+     * Format: bigint
+     * @description Note:
      * This is a Primary Key.<pk/>
      */
     id: number;
+    /** Format: text */
     name: string;
+    /** Format: text */
     picture?: string;
+    /** Format: text */
     email: string;
+    /** Format: text */
     issuer: string;
+    /** Format: text */
     github?: string;
+    /** Format: text */
     public_address: string;
+    /**
+     * Format: timestamp with time zone
+     * @default timezone('utc'::text, now())
+     */
     inserted_at: string;
+    /**
+     * Format: timestamp with time zone
+     * @default timezone('utc'::text, now())
+     */
     updated_at: string;
   };
   user_tag: {
     /**
-     * Note:
+     * Format: bigint
+     * @description Note:
      * This is a Primary Key.<pk/>
      */
     id: number;
     /**
-     * Note:
+     * Format: bigint
+     * @description Note:
      * This is a Foreign Key to `user.id`.<fk table='user' column='id'/>
      */
     user_id: number;
+    /** Format: public.user_tag_type */
     tag: "HasAccountRestriction" | "HasPsaAccess" | "StorageLimitBytes";
+    /** Format: text */
     value: string;
+    /** Format: text */
     reason: string;
+    /**
+     * Format: timestamp with time zone
+     * @default timezone('utc'::text, now())
+     */
     inserted_at: string;
+    /** Format: timestamp with time zone */
     deleted_at?: string;
   };
 }
 
 export interface parameters {
-  /** Preference */
+  /** @description Preference */
   preferParams: "params=single-object";
-  /** Preference */
+  /** @description Preference */
   preferReturn: "return=representation" | "return=minimal" | "return=none";
-  /** Preference */
+  /** @description Preference */
   preferCount: "count=none";
-  /** Filtering Columns */
+  /** @description Filtering Columns */
   select: string;
-  /** On Conflict */
+  /** @description On Conflict */
   on_conflict: string;
-  /** Ordering */
+  /** @description Ordering */
   order: string;
-  /** Limiting and Pagination */
+  /** @description Limiting and Pagination */
   range: string;
-  /** Limiting and Pagination */
+  /**
+   * @description Limiting and Pagination
+   * @default items
+   */
   rangeUnit: string;
-  /** Limiting and Pagination */
+  /** @description Limiting and Pagination */
   offset: string;
-  /** Limiting and Pagination */
+  /** @description Limiting and Pagination */
   limit: string;
-  /** admin_search */
+  /** @description admin_search */
   "body.admin_search": definitions["admin_search"];
+  /** Format: text */
   "rowFilter.admin_search.user_id": string;
+  /** Format: text */
   "rowFilter.admin_search.email": string;
+  /** Format: text */
   "rowFilter.admin_search.token": string;
+  /** Format: text */
   "rowFilter.admin_search.token_id": string;
+  /** Format: timestamp with time zone */
   "rowFilter.admin_search.deleted_at": string;
+  /** Format: timestamp with time zone */
   "rowFilter.admin_search.reason_inserted_at": string;
+  /** Format: text */
   "rowFilter.admin_search.reason": string;
+  /** Format: public.auth_key_blocked_status_type */
   "rowFilter.admin_search.status": string;
-  /** auth_key */
+  /** @description auth_key */
   "body.auth_key": definitions["auth_key"];
+  /** Format: bigint */
   "rowFilter.auth_key.id": string;
+  /** Format: text */
   "rowFilter.auth_key.name": string;
+  /** Format: text */
   "rowFilter.auth_key.secret": string;
+  /** Format: bigint */
   "rowFilter.auth_key.user_id": string;
+  /** Format: timestamp with time zone */
   "rowFilter.auth_key.inserted_at": string;
+  /** Format: timestamp with time zone */
   "rowFilter.auth_key.updated_at": string;
+  /** Format: timestamp with time zone */
   "rowFilter.auth_key.deleted_at": string;
-  /** auth_key_history */
+  /** @description auth_key_history */
   "body.auth_key_history": definitions["auth_key_history"];
+  /** Format: bigint */
   "rowFilter.auth_key_history.id": string;
+  /** Format: public.auth_key_blocked_status_type */
   "rowFilter.auth_key_history.status": string;
+  /** Format: text */
   "rowFilter.auth_key_history.reason": string;
+  /** Format: bigint */
   "rowFilter.auth_key_history.auth_key_id": string;
+  /** Format: timestamp with time zone */
   "rowFilter.auth_key_history.inserted_at": string;
+  /** Format: timestamp with time zone */
   "rowFilter.auth_key_history.deleted_at": string;
-  /** backup */
+  /** @description backup */
   "body.backup": definitions["backup"];
+  /** Format: bigint */
   "rowFilter.backup.id": string;
+  /** Format: bigint */
   "rowFilter.backup.upload_id": string;
+  /** Format: text */
   "rowFilter.backup.url": string;
+  /** Format: timestamp with time zone */
   "rowFilter.backup.inserted_at": string;
-  /** content */
+  /** @description content */
   "body.content": definitions["content"];
+  /** Format: text */
   "rowFilter.content.cid": string;
+  /** Format: bigint */
   "rowFilter.content.dag_size": string;
+  /** Format: timestamp with time zone */
   "rowFilter.content.inserted_at": string;
+  /** Format: timestamp with time zone */
   "rowFilter.content.updated_at": string;
-  /** name */
+  /** @description metric */
+  "body.metric": definitions["metric"];
+  /** Format: text */
+  "rowFilter.metric.name": string;
+  /** Format: bigint */
+  "rowFilter.metric.value": string;
+  /** Format: timestamp with time zone */
+  "rowFilter.metric.inserted_at": string;
+  /** Format: timestamp with time zone */
+  "rowFilter.metric.updated_at": string;
+  /** @description name */
   "body.name": definitions["name"];
+  /** Format: text */
   "rowFilter.name.key": string;
+  /** Format: text */
   "rowFilter.name.record": string;
+  /** Format: boolean */
   "rowFilter.name.has_v2_sig": string;
+  /** Format: bigint */
   "rowFilter.name.seqno": string;
+  /** Format: bigint */
   "rowFilter.name.validity": string;
+  /** Format: timestamp with time zone */
   "rowFilter.name.inserted_at": string;
+  /** Format: timestamp with time zone */
   "rowFilter.name.updated_at": string;
-  /** pin */
+  /** @description pin */
   "body.pin": definitions["pin"];
+  /** Format: bigint */
   "rowFilter.pin.id": string;
+  /** Format: public.pin_status_type */
   "rowFilter.pin.status": string;
+  /** Format: text */
   "rowFilter.pin.content_cid": string;
+  /** Format: bigint */
   "rowFilter.pin.pin_location_id": string;
+  /** Format: timestamp with time zone */
   "rowFilter.pin.inserted_at": string;
+  /** Format: timestamp with time zone */
   "rowFilter.pin.updated_at": string;
-  /** pin_location */
+  /** @description pin_location */
   "body.pin_location": definitions["pin_location"];
+  /** Format: bigint */
   "rowFilter.pin_location.id": string;
+  /** Format: text */
   "rowFilter.pin_location.peer_id": string;
+  /** Format: text */
   "rowFilter.pin_location.peer_name": string;
+  /** Format: text */
+  "rowFilter.pin_location.ipfs_peer_id": string;
+  /** Format: text */
   "rowFilter.pin_location.region": string;
-  /** pin_request */
+  /** @description pin_request */
   "body.pin_request": definitions["pin_request"];
+  /** Format: bigint */
   "rowFilter.pin_request.id": string;
+  /** Format: text */
   "rowFilter.pin_request.content_cid": string;
+  /** Format: integer */
   "rowFilter.pin_request.attempts": string;
+  /** Format: timestamp with time zone */
   "rowFilter.pin_request.inserted_at": string;
+  /** Format: timestamp with time zone */
   "rowFilter.pin_request.updated_at": string;
-  /** pin_sync_request */
+  /** @description pin_sync_request */
   "body.pin_sync_request": definitions["pin_sync_request"];
+  /** Format: bigint */
   "rowFilter.pin_sync_request.id": string;
+  /** Format: bigint */
   "rowFilter.pin_sync_request.pin_id": string;
+  /** Format: timestamp with time zone */
   "rowFilter.pin_sync_request.inserted_at": string;
-  /** psa_pin_request */
+  /** @description psa_pin_request */
   "body.psa_pin_request": definitions["psa_pin_request"];
+  /** Format: text */
   "rowFilter.psa_pin_request.id": string;
+  /** Format: bigint */
   "rowFilter.psa_pin_request.auth_key_id": string;
+  /** Format: text */
   "rowFilter.psa_pin_request.content_cid": string;
+  /** Format: text */
   "rowFilter.psa_pin_request.source_cid": string;
+  /** Format: text */
   "rowFilter.psa_pin_request.name": string;
+  /** Format: jsonb */
   "rowFilter.psa_pin_request.origins": string;
+  /** Format: jsonb */
   "rowFilter.psa_pin_request.meta": string;
+  /** Format: timestamp with time zone */
   "rowFilter.psa_pin_request.deleted_at": string;
+  /** Format: timestamp with time zone */
   "rowFilter.psa_pin_request.inserted_at": string;
+  /** Format: timestamp with time zone */
   "rowFilter.psa_pin_request.updated_at": string;
-  /** upload */
+  /** @description upload */
   "body.upload": definitions["upload"];
+  /** Format: bigint */
   "rowFilter.upload.id": string;
+  /** Format: bigint */
   "rowFilter.upload.user_id": string;
+  /** Format: bigint */
   "rowFilter.upload.auth_key_id": string;
+  /** Format: text */
   "rowFilter.upload.content_cid": string;
+  /** Format: text */
   "rowFilter.upload.source_cid": string;
+  /** Format: public.upload_type */
   "rowFilter.upload.type": string;
+  /** Format: text */
   "rowFilter.upload.name": string;
+  /** Format: timestamp with time zone */
   "rowFilter.upload.inserted_at": string;
+  /** Format: timestamp with time zone */
   "rowFilter.upload.updated_at": string;
+  /** Format: timestamp with time zone */
   "rowFilter.upload.deleted_at": string;
-  /** user */
+  /** @description user */
   "body.user": definitions["user"];
+  /** Format: bigint */
   "rowFilter.user.id": string;
+  /** Format: text */
   "rowFilter.user.name": string;
+  /** Format: text */
   "rowFilter.user.picture": string;
+  /** Format: text */
   "rowFilter.user.email": string;
+  /** Format: text */
   "rowFilter.user.issuer": string;
+  /** Format: text */
   "rowFilter.user.github": string;
+  /** Format: text */
   "rowFilter.user.public_address": string;
+  /** Format: timestamp with time zone */
   "rowFilter.user.inserted_at": string;
+  /** Format: timestamp with time zone */
   "rowFilter.user.updated_at": string;
-  /** user_tag */
+  /** @description user_tag */
   "body.user_tag": definitions["user_tag"];
+  /** Format: bigint */
   "rowFilter.user_tag.id": string;
+  /** Format: bigint */
   "rowFilter.user_tag.user_id": string;
+  /** Format: public.user_tag_type */
   "rowFilter.user_tag.tag": string;
+  /** Format: text */
   "rowFilter.user_tag.value": string;
+  /** Format: text */
   "rowFilter.user_tag.reason": string;
+  /** Format: timestamp with time zone */
   "rowFilter.user_tag.inserted_at": string;
+  /** Format: timestamp with time zone */
   "rowFilter.user_tag.deleted_at": string;
 }
 

--- a/packages/db/postgres/reset.sql
+++ b/packages/db/postgres/reset.sql
@@ -1,5 +1,7 @@
-DROP TYPE IF EXISTS upload_type cascade;
-DROP TYPE IF EXISTS pin_status_type cascade;
+DROP TYPE IF EXISTS upload_type CASCADE;
+DROP TYPE IF EXISTS pin_status_type CASCADE;
+DROP TYPE IF EXISTS auth_key_blocked_status_type CASCADE;
+DROP TYPE IF EXISTS user_tag_type CASCADE;
 DROP TABLE IF EXISTS upload CASCADE;
 DROP TABLE IF EXISTS pin CASCADE;
 DROP TABLE IF EXISTS pin_location;

--- a/packages/db/postgres/tables.sql
+++ b/packages/db/postgres/tables.sql
@@ -152,10 +152,12 @@ END$$;
 CREATE TABLE IF NOT EXISTS pin_location
 (
   id              BIGSERIAL PRIMARY KEY,
-  -- Libp2p peer ID of the node pinning this pin.
+  -- Libp2p peer ID of the Cluster node pinning this pin.
   peer_id         TEXT                                                          NOT NULL UNIQUE,
-  -- Name of the peer pinning this pin.
+  -- Name of the Cluster peer pinning this pin.
   peer_name       TEXT,
+  -- Libp2p peer ID of the IPFS node pinning this pin.
+  ipfs_peer_id    TEXT,
   -- Geographic region this node resides in.
   region          TEXT
 );

--- a/packages/db/test/backup.spec.js
+++ b/packages/db/test/backup.spec.js
@@ -22,6 +22,7 @@ describe('backup', () => {
     location: {
       peerId: 'peer_id',
       peerName: 'peer_name',
+      ipfsPeerId: 'ipfs_peer_id',
       region: 'region'
     }
   }

--- a/packages/db/test/pin-request.spec.js
+++ b/packages/db/test/pin-request.spec.js
@@ -23,6 +23,7 @@ describe('pin-request', () => {
       location: {
         peerId: '12D3KooWFe387JFDpgNEVCP5ARut7gRkX7YuJCXMStpkq714ziK6',
         peerName: 'web3-storage-sv15',
+        ipfsPeerId: '12D3KooWR19qPPiZH4khepNjS3CLXiB7AbrbAD4ZcDjN1UjGUNE2',
         region: 'region'
       }
     },
@@ -31,6 +32,7 @@ describe('pin-request', () => {
       location: {
         peerId: '12D3KooWFe387JFDpgNEVCP5ARut7gRkX7YuJCXMStpkq714ziK7',
         peerName: 'web3-storage-sv16',
+        ipfsPeerId: '12D3KooWR19qPPiZH4khepNjS3CLXiB7AbrbAD4ZcDjN1UjGUNE3',
         region: 'region'
       }
     }

--- a/packages/db/test/pin-sync-request.spec.js
+++ b/packages/db/test/pin-sync-request.spec.js
@@ -63,6 +63,7 @@ describe('pin-sync-request', () => {
           id: 1,
           peerId: '12D3KooWFe387JFDpgNEVCP5ARut7gRkX7YuJCXMStpkq714ziK6',
           peerName: 'web3-storage-sv15',
+          ipfsPeerId: '12D3KooWR19qPPiZH4khepNjS3CLXiB7AbrbAD4ZcDjN1UjGUNE2',
           region: 'region'
         }
       },
@@ -72,6 +73,7 @@ describe('pin-sync-request', () => {
           id: 2,
           peerId: '12D3KooWFe387JFDpgNEVCP5ARut7gRkX7YuJCXMStpkq714ziK7',
           peerName: 'web3-storage-sv16',
+          ipfsPeerId: '12D3KooWR19qPPiZH4khepNjS3CLXiB7AbrbAD4ZcDjN1UjGUNE3',
           region: 'region'
         }
       },
@@ -81,6 +83,7 @@ describe('pin-sync-request', () => {
           id: 3,
           peerId: '12D3KooWFe387JFDpgNEVCP5ARut7gRkX7YuJCXMStpkq714ziK8',
           peerName: 'web3-storage-sv17',
+          ipfsPeerId: '12D3KooWR19qPPiZH4khepNjS3CLXiB7AbrbAD4ZcDjN1UjGUNE4',
           region: 'region'
         }
       }

--- a/packages/db/test/pin.spec.js
+++ b/packages/db/test/pin.spec.js
@@ -22,6 +22,7 @@ describe('pin', () => {
     location: {
       peerId: 'peer_id',
       peerName: 'peer_name',
+      ipfsPeerId: 'ipfs_peer_id',
       region: 'region'
     }
   }
@@ -69,7 +70,7 @@ describe('pin', () => {
       sourceCid: cid,
       authKey: authKeys[0]._id,
       type,
-      dagSize: dagSize,
+      dagSize,
       name,
       pins: [initialPinData],
       backupUrls: [initialBackupUrl]
@@ -91,7 +92,7 @@ describe('pin', () => {
     assert(pins[0].created, 'pin has inserted timestamp')
     assert(pins[0].updated, 'pin has inserted timestamp')
     assert.strictEqual(pins[0].status, initialPinData.status, 'pin has correct state')
-    assert.strictEqual(pins[0].peerId, initialPinData.location.peerId, 'pin has correct location peer id')
+    assert.strictEqual(pins[0].peerId, initialPinData.location.ipfsPeerId, 'pin has correct location peer id')
     assert.strictEqual(pins[0].peerName, initialPinData.location.peerName, 'pin has correct location peer name')
     assert.strictEqual(pins[0].region, initialPinData.location.region, 'pin has correct location peer region')
   })

--- a/packages/db/test/pinning.spec.js
+++ b/packages/db/test/pinning.spec.js
@@ -69,6 +69,7 @@ describe('Pin Request', () => {
       location: {
         peerId: '12D3KooWFe387JFDpgNEVCP5ARut7gRkX7YuJCXMStpkq714ziK6',
         peerName: 'web3-storage-sv15',
+        ipfsPeerId: '12D3KooWR19qPPiZH4khepNjS3CLXiB7AbrbAD4ZcDjN1UjGUNE2',
         region: 'region'
       }
     },
@@ -77,6 +78,7 @@ describe('Pin Request', () => {
       location: {
         peerId: '12D3KooWFe387JFDpgNEVCP5ARut7gRkX7YuJCXMStpkq714ziK7',
         peerName: 'web3-storage-sv16',
+        ipfsPeerId: '12D3KooWR19qPPiZH4khepNjS3CLXiB7AbrbAD4ZcDjN1UjGUNE3',
         region: 'region'
       }
     }

--- a/packages/db/test/status.spec.js
+++ b/packages/db/test/status.spec.js
@@ -22,6 +22,7 @@ describe('status', () => {
     location: {
       peerId: 'peer_id',
       peerName: 'peer_name',
+      ipfsPeerId: 'ipfs_peer_id',
       region: 'region'
     }
   }

--- a/packages/db/test/upload.spec.js
+++ b/packages/db/test/upload.spec.js
@@ -54,6 +54,7 @@ describe('upload', () => {
     location: {
       peerId: 'peer_id',
       peerName: 'peer_name',
+      ipfsPeerId: 'ipfs_peer_id',
       region: 'region'
     }
   }
@@ -90,7 +91,7 @@ describe('upload', () => {
     assert.strictEqual(upload.dagSize, dagSize, 'upload has correct dag size')
     assert.strictEqual(upload.pins.length, 1, 'upload has one pin')
     assert.strictEqual(upload.pins[0].status, initialPinData.status, 'pin has added status')
-    assert.strictEqual(upload.pins[0].peerId, initialPinData.location.peerId, 'pin has added peerId')
+    assert.strictEqual(upload.pins[0].peerId, initialPinData.location.ipfsPeerId, 'pin has added peerId')
     assert.strictEqual(upload.pins[0].peerName, initialPinData.location.peerName, 'pin has added peer name')
     assert.strictEqual(upload.pins[0].region, initialPinData.location.region, 'pin has added region')
     assert.strictEqual(upload.deals.length, 0, 'upload has no deals')

--- a/packages/db/test/utils.js
+++ b/packages/db/test/utils.js
@@ -43,6 +43,7 @@ export const defaultPinData = [{
   location: {
     peerId: '12D3KooWFe387JFDpgNEVCP5ARut7gRkX7YuJCXMStpkq714ziK6',
     peerName: 'web3-storage-sv15',
+    ipfsPeerId: '12D3KooWR19qPPiZH4khepNjS3CLXiB7AbrbAD4ZcDjN1UjGUNE1',
     region: 'region'
   }
 }]

--- a/packages/db/utils.js
+++ b/packages/db/utils.js
@@ -67,7 +67,7 @@ export function normalizePins (pins, {
       status: pin.status,
       created: pin.created,
       updated: pin.updated,
-      peerId: pin.location.peerId,
+      peerId: pin.location.ipfsPeerId,
       peerName: pin.location.peerName,
       region: pin.location.region
     }))


### PR DESCRIPTION
Reverts https://github.com/web3-storage/web3.storage/pull/966 and instead stores the IPFS peer ID in the `pin_location` table.