### PR TITLE
fix: pin_location lock contention

### DIFF
--- a/packages/db/postgres/functions.sql
+++ b/packages/db/postgres/functions.sql
@@ -236,7 +236,7 @@ BEGIN
   -- Add to pin table if new
   insert into pin (content_cid, status, pin_location_id, updated_at)
     SELECT data ->> 'content_cid' AS content_cid,
-           (data -> pin ->> 'status')::pin_status_type AS status,
+           (data -> 'pin' ->> 'status')::pin_status_type AS status,
            id AS pin_location_id,
            (NOW())::timestamptz AS updated_at
       FROM pin_location

--- a/packages/db/postgres/functions.sql
+++ b/packages/db/postgres/functions.sql
@@ -216,7 +216,6 @@ CREATE OR REPLACE FUNCTION upsert_pin(data json) RETURNS TEXT
 AS
 $$
 DECLARE
-  pin_location_result_id BIGINT;
   pin_result_id BIGINT;
 BEGIN
   -- DATA => content_cid, pin(status, location(peer_id, peer_name, region))
@@ -246,7 +245,7 @@ BEGIN
             "updated_at" = NOW()
   returning id into pin_result_id;
 
-  return (pin_location_result_id)::TEXT;
+  return (pin_result_id)::TEXT;
 END
 $$;
 

--- a/packages/db/test/pin.spec.js
+++ b/packages/db/test/pin.spec.js
@@ -99,30 +99,24 @@ describe('pin', () => {
 
   it('can update previously created pin', async () => {
     const newStatus = 'Pinned'
-    const newName = 'peer_name_2'
 
     const pinsPreUpdated = await client.getPins(cid)
     assert.strictEqual(pinsPreUpdated[0].status, initialPinData.status, 'pin has correct state')
     assert.strictEqual(pinsPreUpdated[0].peerName, initialPinData.location.peerName, 'pin has correct location peer name')
     assert.notStrictEqual(pinsPreUpdated[0].status, newStatus, 'pin is pinning')
-    assert.notStrictEqual(pinsPreUpdated[0].peerName, newName, 'pin has first name')
 
     // Update pin status to Pinned
     const updatedPin = await client.upsertPin(cid, {
       status: newStatus,
-      location: {
-        ...initialPinData.location,
-        peerName: newName
-      }
+      location: initialPinData.location
     })
     assert(updatedPin, 'pin updated')
     assert.strictEqual(updatedPin, pinsPreUpdated[0]._id, 'id of previous pin')
 
     const pinsAfterUpdated = await client.getPins(cid)
     assert.strictEqual(pinsAfterUpdated[0].status, newStatus, 'pin is pinned')
-    assert.strictEqual(pinsAfterUpdated[0].peerName, newName, 'pin has second name')
+    assert.strictEqual(pinsAfterUpdated[0].peerName, initialPinData.location.peerName, 'pin has second name')
     assert.notStrictEqual(pinsAfterUpdated[0].status, initialPinData.status, 'pin has correct state')
-    assert.notStrictEqual(pinsAfterUpdated[0].peerName, initialPinData.location.peerName, 'pin has correct location peer name')
   })
 
   it('can insert a new pin for a cid', async () => {


### PR DESCRIPTION
For every upload we lock every `pin_location` record to update it with values that never change. This PR changes that behaviour to only insert into the table if the row does not exist.

It results in two `SELECT`s for the same row on the `pin_location` table but the idea is that this will be better than locking the records.

fixes https://github.com/web3-storage/web3.storage/issues/1099 🤞