### PR TITLE
fix: add missing status UnexpectedlyUnpinned

### DIFF
--- a/packages/api/src/utils/pin.js
+++ b/packages/api/src/utils/pin.js
@@ -11,7 +11,8 @@
  *  | 'Remote'
  *  | 'PinQueued'
  *  | 'UnpinQueued'
- *  | 'Sharded'} PinStatus
+ *  | 'Sharded'
+ *  | 'UnexpectedlyUnpinned' } PinStatus
  */
 
 /** @type {Record<TrackerStatus, PinStatus>} */
@@ -27,7 +28,8 @@ const PinStatusMap = {
   remote: 'Remote',
   pin_queued: 'PinQueued',
   unpin_queued: 'UnpinQueued',
-  sharded: 'Sharded'
+  sharded: 'Sharded',
+  unexpectedly_unpinned: 'UnexpectedlyUnpinned'
 }
 
 // Duration between status check polls in ms.

--- a/packages/api/src/utils/psa.js
+++ b/packages/api/src/utils/psa.js
@@ -44,6 +44,7 @@ const psaStatusesToDBStatusesMap = {
   queued: ['PinQueued'],
   pinning: ['Pinning'],
   failed: [
+    'UnexpectedlyUnpinned',
     'ClusterError',
     'PinError'
   ]

--- a/packages/db/README.md
+++ b/packages/db/README.md
@@ -45,10 +45,10 @@ Start a docker compose with a Postgres Database and Postgrest.
 npm start
 ```
 
-### 2. Populate Database
+### 2. Load schema
 
 ```bash
-node scripts/cli.js db-sql --cargo --testing
+npm run load-schema
 ```
 
 ### 3. Ready to go

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -7,6 +7,7 @@
   "type": "module",
   "scripts": {
     "start": "node scripts/cli.js db --start --project web3-storage",
+    "load-schema": "node scripts/cli.js db-sql --cargo --testing",
     "stop": "node scripts/cli.js db --stop --project web3-storage",
     "stop:clean": "node scripts/cli.js db --stop --clean --project web3-storage",
     "pg-rest-api-types": "./scripts/cli.js pg-rest-api-types",

--- a/packages/db/postgres/migrations/004-add-UnexpectedlyUnpinned-status.sql
+++ b/packages/db/postgres/migrations/004-add-UnexpectedlyUnpinned-status.sql
@@ -1,0 +1,1 @@
+ALTER TYPE pin_status_type ADD VALUE 'UnexpectedlyUnpinned';

--- a/packages/db/postgres/pg-rest-api-types.d.ts
+++ b/packages/db/postgres/pg-rest-api-types.d.ts
@@ -2089,7 +2089,8 @@ export interface definitions {
       | "Remote"
       | "PinQueued"
       | "UnpinQueued"
-      | "Sharded";
+      | "Sharded"
+      | "UnexpectedlyUnpinned";
     /**
      * Format: text
      * @description Note:

--- a/packages/db/postgres/tables.sql
+++ b/packages/db/postgres/tables.sql
@@ -127,7 +127,9 @@ BEGIN
       'UnpinQueued',
       -- The IPFS daemon is not pinning the item through this CID but it is tracked
       -- in a cluster dag
-      'Sharded'
+      'Sharded',
+      -- The item should be pinned, but it is not pinned and not queued/pinning.
+      'UnexpectedlyUnpinned'
     );
   END IF;
   IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname = 'upload_type') THEN

--- a/packages/db/scripts/cmds/pg-rest-api-types.js
+++ b/packages/db/scripts/cmds/pg-rest-api-types.js
@@ -5,11 +5,15 @@ import { dbSqlCmd } from './db-sql.js'
 
 export async function dbTypesCmd () {
   const project = `web3-storage-pg-rest-api-types-${Date.now()}`
+  console.log('Starting DB...')
   await dbCmd({ start: true, project })
   await delay(2000)
 
   try {
+    console.log('Loading schema...')
     await dbSqlCmd({ cargo: true, testing: true })
+    await delay(2000) // it takes a moment for postgrest to update
+    console.log('Generating types...')
     const url = `${process.env.PG_REST_URL}/?apikey=${process.env.PG_REST_JWT}`
     await execa(
       'openapi-typescript',


### PR DESCRIPTION
Pins cron is currently failing with:

```
Error: unknown tracker status: unexpectedly_unpinned
    at toPinStatusEnum (file:///home/runner/work/web3.storage/web3.storage/packages/api/src/utils/pin.js:52:11)
    at file:///home/runner/work/web3.storage/web3.storage/packages/cron/src/jobs/pins.js:67:20
    at Array.map (<anonymous>)
    at updatePinStatuses (file:///home/runner/work/web3.storage/web3.storage/packages/cron/src/jobs/pins.js:52:49)
    at processTicksAndRejections (node:internal/process/task_queues:96:5)
    at async main (file:///home/runner/work/web3.storage/web3.storage/packages/cron/src/bin/pins.js:16:3)
```

https://github.com/web3-storage/web3.storage/runs/5509298651?check_suite_focus=true

...this is because we do not model this new status in our API code or in our DB schema yet.

resolves https://github.com/web3-storage/web3.storage/issues/912