### PR TITLE
fix: Fixing pagination and order scrolling

### DIFF
--- a/packages/website/components/account/filesManager/filesManager.tsx
+++ b/packages/website/components/account/filesManager/filesManager.tsx
@@ -77,6 +77,9 @@ const FilesManager = ({ className, content, onFileUpload }: FilesManagerProps) =
         { shallow: true }
       );
 
+      const scrollToElement = document.querySelector('.account-files-manager');
+      scrollToElement?.scrollIntoView(true);
+
       queryOrderRef.current = query.order;
     }
   }, [query.order, query, replace]);
@@ -276,6 +279,7 @@ const FilesManager = ({ className, content, onFileUpload }: FilesManagerProps) =
             visiblePages={1}
             queryParam="page"
             onChange={setPaginatedFiles}
+            scrollTarget={'.account-files-manager'}
           />
           <Dropdown
             className="files-manager-result-dropdown"

--- a/packages/website/components/tokens/tokensManager/tokensManager.js
+++ b/packages/website/components/tokens/tokensManager/tokensManager.js
@@ -54,6 +54,9 @@ const TokensManager = ({ content }) => {
         { shallow: true }
       );
 
+      const scrollToElement = document.querySelector('.tokens-manager-container');
+      scrollToElement?.scrollIntoView(true);
+
       queryOrderRef.current = query.order;
     }
   }, [query.order, query, replace]);
@@ -139,6 +142,7 @@ const TokensManager = ({ content }) => {
           visiblePages={2}
           queryParam="page"
           onChange={setPaginatedTokens}
+          scrollTarget={'.tokens-manager-container'}
         />
         <Dropdown
           className="tokens-manager-result-dropdown"

--- a/packages/website/modules/zero/components/accordion/accordionSection.js
+++ b/packages/website/modules/zero/components/accordion/accordionSection.js
@@ -62,7 +62,7 @@ function AccordionSection({
   }, [uid])
 
   useEffect(() => {
-    if (router.query.section === slug) {
+    if (!!slug && !!router.query.section && router.query.section === slug) {
       const element = document.getElementById(`accordion-section_${slug}`)
       if (element) {
         const y = element.getBoundingClientRect().top + window.scrollY - 16

--- a/packages/website/modules/zero/components/pagination/pagination.js
+++ b/packages/website/modules/zero/components/pagination/pagination.js
@@ -12,6 +12,7 @@ import useQueryParams from 'ZeroHooks/useQueryParams'
  * @prop {number} [defaultPage]
  * @prop {string} [queryParam]
  * @prop {function} [onChange]
+ * @prop {string} [scrollTarget]
  */
 
 /**
@@ -24,7 +25,8 @@ const Pagination = ({
   visiblePages,
   defaultPage,
   queryParam,
-  onChange
+  onChange,
+  scrollTarget,
 }) => {
   const [queryValue, setQueryValue] = useQueryParams(queryParam, defaultPage);
 
@@ -37,7 +39,10 @@ const Pagination = ({
 
   const setCurrentPage = useCallback((page) => {
     queryParam ? setQueryValue(page) : setActivePage(page)
-  }, [queryParam, setQueryValue, setActivePage])
+    const scrollToElement= document.querySelector(scrollTarget);
+    scrollToElement?.scrollIntoView(true);
+    
+  }, [queryParam, setQueryValue, setActivePage, scrollTarget])
 
   useEffect(() => {
     pageCount && setPageList(
@@ -51,9 +56,6 @@ const Pagination = ({
     const firstItem = (currentPage - 1) * parseInt(/** @type {string} */(itemsPerPage))
     onChange && onChange(items.slice(firstItem, firstItem + parseInt(/** @type {string} */(itemsPerPage))))
 
-    const scrollToElement= document.querySelector('.Pagination');
-    scrollToElement?.scrollIntoView({block: "end", inline: "nearest"});
-    
   }, [items, itemsPerPage, visiblePages, pageCount, setPageList, currentPage, setCurrentPage, onChange])
 
   return (


### PR DESCRIPTION
### Changes
- Refactoring pagination onChange for targeted scrolling on pagination
- Adding scrollTop fix for sort changes for both tokens and files
- Fixing bug with `accordionSection` that always caused window to scroll to top when both `slug` and `router.query.section` were undefined, triggering a false-positive