### PR TITLE
fix: add missing statuses

### DIFF
--- a/packages/api/src/utils/psa.js
+++ b/packages/api/src/utils/psa.js
@@ -41,7 +41,7 @@ export const getEffectivePinStatus = (pins) => {
 
 const psaStatusesToDBStatusesMap = {
   pinned: ['Pinned'],
-  queued: ['PinQueued'],
+  queued: ['PinQueued', 'Unpinned', 'Remote'],
   pinning: ['Pinning'],
   failed: [
     'UnexpectedlyUnpinned',

--- a/packages/api/src/utils/psa.js
+++ b/packages/api/src/utils/psa.js
@@ -28,7 +28,6 @@ export const getEffectivePinStatus = (pins) => {
   // The cluster will return "Remote" if it has been queued for pinning by another node.
   // A cluster status of "Unpinned", "Remote" or "PinQueued" is equivalent to a "queued" PSA status.
   if (pinStatuses.includes('PinQueued') ||
-      pinStatuses.includes('Remote') ||
       pinStatuses.includes('Unpinned')) {
     return 'queued'
   }
@@ -41,7 +40,7 @@ export const getEffectivePinStatus = (pins) => {
 
 const psaStatusesToDBStatusesMap = {
   pinned: ['Pinned'],
-  queued: ['PinQueued', 'Unpinned', 'Remote'],
+  queued: ['PinQueued', 'Unpinned'],
   pinning: ['Pinning'],
   failed: [
     'UnexpectedlyUnpinned',

--- a/packages/api/test/fixtures/init-data.sql
+++ b/packages/api/test/fixtures/init-data.sql
@@ -52,7 +52,8 @@ VALUES (3, 'bafybeifnfkzjeohjf2dch2iqqpef3bfjylwxlcjws2msvdfyze5bvdprfm', 'bafyb
        (3, 'bafybeiaiipiibr7aletbbrzmpklw4l5go6sodl22xs6qtcqo3lqogfogy4', 'bafybeiaiipiibr7aletbbrzmpklw4l5go6sodl22xs6qtcqo3lqogfogy4', 'Car', '2021-07-14T19:27:14.934572Z', '2021-07-14T19:27:14.934572Z');
 
 INSERT INTO pin_location (peer_id, peer_name, ipfs_peer_id, region)
-VALUES ('12D3KooEL1Jc', 'who?', '12D3KooWR1Js', 'where?');
+VALUES ('12D3KooEL1Jc', 'who?', '12D3KooWR1Js', 'where?'),
+       ('12D3KooEL1Jd', 'whoTwo?', '12D3KooWR1Jd', 'whereTwo?');
 
 INSERT INTO pin (status, content_cid, pin_location_id, inserted_at, updated_at)
 VALUES ('Pinned', 'bafybeifnfkzjeohjf2dch2iqqpef3bfjylwxlcjws2msvdfyze5bvdprfm', 1, '2021-07-14T19:27:14.934572+00:00', '2021-07-14T19:27:14.934572+00:00'),
@@ -94,6 +95,7 @@ VALUES  ('bafybeid46f7zggioxjm5p2ze2l6s6wbqvoo4gzbdzfjtdosthmfyxdign4'),
         ('bafybeidrzt6t4k25qjeasydgi3fyh6ejos5x4d6tk2pdzxkb66bkomezy4'),
         ('bafybeifsrhq2qtkcgjt4gzi7rkafrv2gaai24ptt6rohe2ebqzydkz47sm'),
         ('bafybeiaqu6ijhfhwzjipwesbqf4myz6uczyigahib5joqbo5jw2xmjczfa'),
+        ('bafybeifsrhq2qtkcgjt4gzi7rkafrv2gaai24ptt6rohe2ebqzydkz47s5'),
         ('bafybeidqts3rbwkprggjojbvcxy4jzpgzgcvs4a73y3gx2jjxphjeerbcy');
 
 INSERT INTO pin (status, content_cid, pin_location_id, inserted_at, updated_at)
@@ -103,6 +105,8 @@ VALUES
        ('PinError', 'bafybeia45bscvzxngto555xsel4gwoclb5fxd7zpxige7rl3maoleznswu', 1, '2021-07-14T19:27:14.934572+00:00', '2021-07-14T19:27:14.934572+00:00'),
        ('Pinning', 'bafybeidw7pc6nvm7u4rfhpctac4qgtpmwxapw4duugvsl3ppivvzibdlgy', 1, '2021-07-14T19:27:14.934572+00:00', '2021-07-14T19:27:14.934572+00:00'),
        ('Pinning', 'bafybeidrzt6t4k25qjeasydgi3fyh6ejos5x4d6tk2pdzxkb66bkomezy4', 1, '2021-07-14T19:27:14.934572+00:00', '2021-07-14T19:27:14.934572+00:00'),
+       ('Unpinned', 'bafybeifsrhq2qtkcgjt4gzi7rkafrv2gaai24ptt6rohe2ebqzydkz47s5', 1, '2021-07-14T19:27:14.934572+00:00', '2021-07-14T19:27:14.934572+00:00'),
+       ('Unpinned', 'bafybeifsrhq2qtkcgjt4gzi7rkafrv2gaai24ptt6rohe2ebqzydkz47s5', 2, '2021-07-14T19:27:14.934572+00:00', '2021-07-14T19:27:14.934572+00:00'),
        ('Pinning', 'bafybeifsrhq2qtkcgjt4gzi7rkafrv2gaai24ptt6rohe2ebqzydkz47sm', 1, '2021-07-14T19:27:14.934572+00:00', '2021-07-14T19:27:14.934572+00:00');
 
 INSERT INTO psa_pin_request (id, auth_key_id, content_cid, source_cid, name, origins, meta, inserted_at, updated_at)
@@ -112,5 +116,6 @@ VALUES ('ab62cf3c-c98d-494b-a756-b3a3fb6ddcab', 4, 'bafybeid46f7zggioxjm5p2ze2l6
        ('63992f6e-5bbf-4d01-8a69-9e0561c38b04', 4, 'bafybeidw7pc6nvm7u4rfhpctac4qgtpmwxapw4duugvsl3ppivvzibdlgy', 'bafybeidw7pc6nvm7u4rfhpctac4qgtpmwxapw4duugvsl3ppivvzibdlgy', 'Image.jpeg', null, '{"app_id": "99986338-1113-4706-8302-4420da6158bb", "region": "europe", "vendor_policy": "1"}', '2021-07-14T19:27:14.934572Z', '2021-07-14T19:27:14.934572Z'),
        ('3fa630f2-f22c-486f-ad1c-b36d4d740e31', 4, 'bafybeidrzt6t4k25qjeasydgi3fyh6ejos5x4d6tk2pdzxkb66bkomezy4', 'bafybeidrzt6t4k25qjeasydgi3fyh6ejos5x4d6tk2pdzxkb66bkomezy4', 'Image.png', null, '{"app_id": "99986338-1113-4706-8302-4420da6158bb"}', '2021-07-14T19:27:14.934572Z', '2021-07-14T19:27:14.934572Z'),
        ('5c7e7885-7f68-462d-bdfb-3f0abfb367b5', 4, 'bafybeifsrhq2qtkcgjt4gzi7rkafrv2gaai24ptt6rohe2ebqzydkz47sm', 'bafybeifsrhq2qtkcgjt4gzi7rkafrv2gaai24ptt6rohe2ebqzydkz47sm', 'Image.jpg', null, null, '2021-07-20T19:27:14.934572Z', '2021-07-14T19:27:14.934572Z'),
+       ('5c7e7885-7f68-462d-bdfb-3f0abfb367b6', 4, 'bafybeifsrhq2qtkcgjt4gzi7rkafrv2gaai24ptt6rohe2ebqzydkz47s5', 'bafybeifsrhq2qtkcgjt4gzi7rkafrv2gaai24ptt6rohe2ebqzydkz47sm', 'Image.jpg', null, null, '2021-07-20T19:27:14.934572Z', '2021-07-14T19:27:14.934572Z'),
        ('3a19e48d-d6db-4f36-b686-fb8bc37c9d48', 2, 'bafybeiaqu6ijhfhwzjipwesbqf4myz6uczyigahib5joqbo5jw2xmjczfa', 'bafybeiaqu6ijhfhwzjipwesbqf4myz6uczyigahib5joqbo5jw2xmjczfa', 'Image.jpg', null, null, '2021-07-20T19:27:14.934572Z', '2021-07-14T19:27:14.934572Z'),
        ('9be23b92-918e-44b8-98f4-6043c346fb4e', 2, 'bafybeidqts3rbwkprggjojbvcxy4jzpgzgcvs4a73y3gx2jjxphjeerbcy', 'bafybeidqts3rbwkprggjojbvcxy4jzpgzgcvs4a73y3gx2jjxphjeerbcy', 'Image.jpg', null, null, '2021-07-14T19:27:14.934572Z', '2021-07-14T19:27:14.934572Z');

--- a/packages/api/test/pin.spec.js
+++ b/packages/api/test/pin.spec.js
@@ -339,7 +339,7 @@ describe('Pinning APIs endpoints', () => {
       assert(res, 'Server responded')
       assert(res.ok, 'Server response is ok')
       const data = await res.json()
-      assert.strictEqual(data.count, 3)
+      assert.strictEqual(data.count, 4)
     })
 
     it('filters pins by status', async () => {
@@ -381,7 +381,27 @@ describe('Pinning APIs endpoints', () => {
       assert(res, 'Server responded')
       assert(res.ok, 'Server response is ok')
       const data = await res.json()
-      assert.strictEqual(data.count, 4)
+      assert.strictEqual(data.count, 5)
+    })
+
+    it('filters pins by queued', async () => {
+      const opts = new URLSearchParams({
+        status: 'queued'
+      })
+      const url = new URL(`${baseUrl}?${opts}`).toString()
+      const res = await fetch(
+        url, {
+          method: 'GET',
+          headers: {
+            Authorization: `Bearer ${token}`,
+            'Content-Type': 'application/json'
+          }
+        })
+
+      assert(res, 'Server responded')
+      assert(res.ok, 'Server response is ok')
+      const data = await res.json()
+      assert.strictEqual(data.count, 1)
     })
 
     it('filters pins created before a date', async () => {
@@ -424,8 +444,8 @@ describe('Pinning APIs endpoints', () => {
       assert(res, 'Server responded')
       assert(res.ok, 'Server response is ok')
       const data = await res.json()
-      assert.strictEqual(data.results.length, 1)
-      assert.strictEqual(data.count, 1)
+      assert.strictEqual(data.results.length, 2)
+      assert.strictEqual(data.count, 2)
     })
 
     it('limits the number of pins returned for this user and includes the total', async () => {
@@ -446,7 +466,7 @@ describe('Pinning APIs endpoints', () => {
       assert(res, 'Server responded')
       assert(res.ok, 'Server response is ok')
       const data = await res.json()
-      assert.strictEqual(data.count, 6)
+      assert.strictEqual(data.count, 7)
       assert.strictEqual(data.results.length, 3)
     })
 

--- a/packages/api/test/pin.spec.js
+++ b/packages/api/test/pin.spec.js
@@ -875,16 +875,6 @@ describe('Pinning APIs endpoints', () => {
       assert.strictEqual(getEffectivePinStatus(pins), 'queued')
     })
 
-    it('should return "queued" if at least 1 pin has remote status', () => {
-      const pins = [
-        createPinWithStatus('UnpinQueued'),
-        createPinWithStatus('PinError'),
-        createPinWithStatus('PinQueued')
-      ]
-
-      assert.strictEqual(getEffectivePinStatus(pins), 'queued')
-    })
-
     it('should return "queued" if at least 1 pin has Unpinned status', () => {
       const pins = [
         createPinWithStatus('PinError'),


### PR DESCRIPTION
Resolves #1102

While I'm pretty confident the fix in this PR should solve the bug reported in #1102, reviewing this made me suspect the logic for filtering PSA pin requests is buggy.

Currently, [here](https://github.com/web3-storage/web3.storage/blob/main/packages/api/src/utils/psa.js#L14)'s the logic we use to convert from Cluster to Psa status does not match the way we filter by those statuses.

We're currently using `query.in('content.pins.status', opts.statuses)` to filter psa requests, but given we different nodes might report different statuses, the same requests might be filtered in different statuses not exclusively.


Here's a description of the bug:
if for a specific CID, 1 node reports `Pinned` and one `Pinning`, the same request would show up in 
`/?status=pinned` and `/?status=pinning`




Unfortunately fixing that bug requires us to write some not trivial remote procedure, and require more time. 
For this reason, I think we should tackle it as a separate ticket?
Would you agree? If yes, I'll create a separate ticket
