### PR TITLE
fix: Message banner obscuring nav

### DIFF
--- a/packages/website/components/messagebanner/messagebanner.js
+++ b/packages/website/components/messagebanner/messagebanner.js
@@ -53,7 +53,7 @@ export default function MessageBanner() {
   }
 
   useEffect(() => {
-    if (typeof window !== 'undefined' && bannerContent === marketingPrompt) {
+    if (typeof window !== 'undefined') {
       const oldMessage = localStorage.getItem('web3StorageBannerMessage');
       const oldDate = /** @type {string} */ (
         localStorage.getItem('web3StorageBannerClickDate') ? localStorage.getItem('web3StorageBannerClickDate') : '0'


### PR DESCRIPTION
This fix changes the conditional logic on the calculation of the message banner height. The height was prevented from being re-calculated after maintenance messages fetched from the status page api came in some time after component load. Now the container recalculates its height on receiving a new maintenance message.