### PR TITLE
fix: npm package name

### DIFF
--- a/packages/website/content/pages/index.json
+++ b/packages/website/content/pages/index.json
@@ -440,7 +440,7 @@
               {
                 "type": "B",
                 "label": "JS Client Library",
-                "feature": "<span class='highlight'>npm install</span> Web3.Storage",
+                "feature": "<span class='highlight'>npm install</span> web3.storage",
                 "description": "Import the lightweight Web3.Storage library into your project, and enjoy a simple and familiar way to store and retrieve.",
                 "icon_before": {
                   "url": "https://www.npmjs.com/package/web3.storage",


### PR DESCRIPTION
```console
$ npm install Web3.Storage
npm ERR! code E404
npm ERR! 404 Not Found - GET https://registry.npmjs.org/Web3.Storage - Not found
npm ERR! 404 
npm ERR! 404  'Web3.Storage@*' is not in this registry.
npm ERR! 404 This package name is not valid, because 
npm ERR! 404  1. name can no longer contain capital letters
npm ERR! 404 
npm ERR! 404 Note that you can also install from a
npm ERR! 404 tarball, folder, http url, or git url.

npm ERR! A complete log of this run can be found in:
npm ERR!     /Users/alan/.npm/_logs/2022-03-18T12_00_04_881Z-debug-0.log
```