### PR TITLE
fixes #1133: Allow admins to search for users with no tokens

### DIFF
--- a/packages/db/postgres/migrations/006-update-admin_search-view-to-return-users-with-no-tokens.sql
+++ b/packages/db/postgres/migrations/006-update-admin_search-view-to-return-users-with-no-tokens.sql
@@ -1,0 +1,15 @@
+DROP VIEW IF EXISTS admin_search;
+
+CREATE VIEW admin_search as
+select
+  u.id::text as user_id,
+  u.email as email,
+  ak.secret as token,
+  ak.id::text as token_id,
+  ak.deleted_at as deleted_at,
+  akh.inserted_at as reason_inserted_at,
+  akh.reason as reason,
+  akh.status as status
+from public.user u
+full outer join auth_key ak on ak.user_id = u.id
+full outer join (select * from auth_key_history where deleted_at is null) as akh on akh.auth_key_id = ak.id;

--- a/packages/db/postgres/tables.sql
+++ b/packages/db/postgres/tables.sql
@@ -310,6 +310,5 @@ select
   akh.reason as reason,
   akh.status as status
 from public.user u
-right join auth_key ak on ak.user_id = u.id
-full outer join (select * from auth_key_history where deleted_at is null) as akh on akh.auth_key_id = ak.id
-where ak.deleted_at is NULL or ak.deleted_at is not NULL and akh.status is not NULL;
+full outer join auth_key ak on ak.user_id = u.id
+full outer join (select * from auth_key_history where deleted_at is null) as akh on akh.auth_key_id = ak.id;


### PR DESCRIPTION
The previous join was based on the assumption that admins only wanted to see users with tokens. That is no longer valid. This new join returns users from the user table whether or not they have tokens. This is the same PR that was merged into nft.storage a few weeks ago: https://github.com/nftstorage/nft.storage/pull/1668