### PR TITLE
fix: create stream when needed

### DIFF
--- a/packages/client/src/lib.js
+++ b/packages/client/src/lib.js
@@ -109,10 +109,7 @@ class Web3Storage {
     const blockstore = new Blockstore()
     try {
       const { out, root } = await pack({
-        input: Array.from(files).map((f) => ({
-          path: f.name,
-          content: f.stream()
-        })),
+        input: Array.from(files).map(toImportCandidate),
         blockstore,
         wrapWithDirectory,
         maxChunkSize: MAX_BLOCK_SIZE,
@@ -484,6 +481,25 @@ function toWeb3Response (res) {
     }
   })
   return response
+}
+
+/**
+ * Convert the passed file to an "import candidate" - an object suitable for
+ * passing to the ipfs-unixfs-importer. Note: content is an accessor so that
+ * the stream is only created when needed.
+ *
+ * @param {Filelike} file
+ */
+function toImportCandidate (file) {
+  /** @type {ReadableStream} */
+  let stream
+  return {
+    path: file.name,
+    get content () {
+      stream = stream || file.stream()
+      return stream
+    }
+  }
 }
 
 /**


### PR DESCRIPTION
Replaces the import candidate `content` property with a getter function that allows the stream to be created (and file descriptor opened) only when it is accessed.

The issue is that when there are many thousands of files in a directory, we'll attempt to open that many file descriptors eagerly, which can cause `EMFILE` errors on some systems.

refs https://github.com/nftstorage/nft.storage/issues/1672
refs https://github.com/nftstorage/nft.storage/pull/1693