### PR TITLE
docs: remove file parameter in node example

### DIFF
--- a/packages/docs/docs/examples/getting-started.md
+++ b/packages/docs/docs/examples/getting-started.md
@@ -34,7 +34,7 @@ Here's a brief look at how to run the Node.js example:
 1. Run the `put-files.js` script, along with the associated variables:
 
     ```shell
-    node put-files.js --token="your-token" ~/file.txt
+    node put-files.js --token="your-token"
     ```
 
 1. That's it!


### PR DESCRIPTION
This example does not support a CLI parameter with file path and should only receive token.

Closes https://github.com/web3-storage/docs/issues/228