### PR TITLE
docs: fix client retrieval example web3 file property

### DIFF
--- a/packages/docs/code-snippets/how-to/index.js
+++ b/packages/docs/code-snippets/how-to/index.js
@@ -78,7 +78,7 @@ async function retrieveFiles (cid) {
   // unpack File objects from the response
   const files = await res.files()
   for (const file of files) {
-    console.log(`${file.cid} -- ${file.path} -- ${file.size}`)
+    console.log(`${file.cid} -- ${file.name} -- ${file.size}`)
   }
 }
 // #endregion retrieve-unpack-files


### PR DESCRIPTION
This PR changes docs on how to handle response from web3.storage client.get. It was using a property `path` from Web3File type which does [not](https://github.com/web3-storage/web3.storage/blob/web3.storage-v4.0.0/packages/client/src/lib/interface.ts#L158-L163) exist. 

We create the File with its path as name per https://github.com/web3-storage/web3.storage/blob/web3.storage-v4.0.0/packages/client/src/lib.js#L416-L441 and we should recommend users to rely on name property to have this type as close as possible to [Web File](https://developer.mozilla.org/en-US/docs/Web/API/File)

Closes https://github.com/web3-storage/docs/issues/226