### PR TITLE
fix: restore pinning services api docs page

### DIFF
--- a/packages/docs/docs/how-tos/pinning-services-api.md
+++ b/packages/docs/docs/how-tos/pinning-services-api.md
@@ -1,0 +1,74 @@
+---
+title: Pinning Services API
+sidebar_label: Pinning Services API
+description: Learn how to pin a file to IPFS using the Pinning Services API
+---
+
+[IPFS](https://ipfs.io/) is a distributed storage network. Data is cached on IPFS nodes, but may be deleted to make room for new content. A pinning service is a collection of IPFS nodes dedicated to saving data on the network so that it is not removed.
+
+Web3.Storage provides a pinning service that complies with the [IPFS Pinning Service API specification](https://ipfs.github.io/pinning-services-api-spec/).
+
+For a full list and documentation of all the available pinning service endpoints, visit the [IPFS Pinning Service API endpoint documentation](https://ipfs.github.io/pinning-services-api-spec/#tag/pins).
+
+## Requesting access
+
+To request access to the pinning service for your Web3.Storage account, you will need to create a [new issue](https://github.com/web3-storage/web3.storage/issues/new/choose) with a type of **Pinning Service Access Request** on the Web3.Storage GitHub repo. Once approved, you will be able to access the pinning service API endpoints using your [API token](/how-tos/generate-api-token).
+
+## Using the HTTP API
+
+The Web3.Storage pinning service endpoint for all requests is [https://api.web3.storage/pins](https://api.web3.storage/pins).
+
+### Add a pin
+
+```bash
+curl -X POST 'https://api.web3.storage/pins' \
+  --header 'Accept: */*' \
+  --header 'Authorization: Bearer <YOUR_AUTH_KEY_JWT>' \
+  --header 'Content-Type: application/json' \
+  -d '{
+  "cid": "<CID_TO_BE_PINNED>",
+  "name": "PreciousData.pdf"
+}'
+```
+
+### List successful pins
+
+```bash
+curl -X GET 'https://api.web3.storage/pins' \
+  --header 'Accept: */*' \
+  --header 'Authorization: Bearer <YOUR_AUTH_KEY_JWT>'
+```
+
+### Delete a pin
+
+```bash
+curl -X DELETE 'https://api-staging.web3.storage/pins/<REQUEST_ID>' \
+  --header 'Accept: */*' \
+  --header 'Authorization: Bearer <YOUR_AUTH_KEY_JWT>'
+```
+
+## Using the IPFS CLI
+
+The [IPFS CLI](https://docs.ipfs.io/reference/cli/) can be used to maintain pins by first adding the Web3.Storage pinning service.
+
+```bash
+ipfs pin remote service add web3.storage https://api.web3.storage/ <YOUR_AUTH_KEY_JWT>
+```
+
+### Add a pin
+
+```bash
+ipfs pin remote add --service=web3.storage --name=<PIN_NAME> <CID>
+```
+
+### List pins
+
+```bash
+ipfs pin remote ls --service=web3.storage
+```
+
+### Remove a pin
+
+```bash
+ipfs pin remote rm --service=web3.storage --cid=<CID>
+```


### PR DESCRIPTION
The latest version of the docs includes a page in the how-to's that was written more recently than the new docs design. This PR moves that page to `web3.storage/docs`.

Closes #1160 and #1154.