### PR TITLE
chore: bring back dnslink publishing for website

### DIFF
--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -112,7 +112,7 @@ jobs:
 
       # Add the site to web3.storage, output the cid as `steps.ipfs.outputs.cid`
       - name: Add to web3.storage
-        if: ${{ steps.tag-release.outputs.release_created && matrix.package == 'website' }}
+        if: ${{ steps.tag-release.outputs.release_created }}
         uses: web3-storage/add-to-web3@v2
         id: ipfs
         with:
@@ -122,7 +122,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Deploy https://web3.storage
-        if: ${{ steps.tag-release.outputs.release_created && matrix.package == 'website' }}
+        if: ${{ steps.tag-release.outputs.release_created }}
         run: npx dnslink-cloudflare --record _dnslink --domain web3.storage --link /ipfs/${{ steps.ipfs.outputs.cid }}
         env:
           CF_API_TOKEN: ${{ secrets.CF_API_TOKEN }}


### PR DESCRIPTION
The dnslink for the website should be updated when we do a prod release of the website. This PR should bring that back.

License: (Apache-2.0 AND MIT)
Signed-off-by: Oli Evans <oli@tableflip.io>