### PR TITLE
chore: cron pin update for cluster@1.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5118,9 +5118,9 @@
       }
     },
     "node_modules/@nftstorage/ipfs-cluster": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@nftstorage/ipfs-cluster/-/ipfs-cluster-4.0.0.tgz",
-      "integrity": "sha512-PEt85HJdXpmQ8PULbC7iDdtf12KrM9tblR+o/2k+/0pvcpAdrplJeTQkUiEGRBiyeevjFXvyMs0f/eGpfxBBgA=="
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@nftstorage/ipfs-cluster/-/ipfs-cluster-5.0.1.tgz",
+      "integrity": "sha512-e5+ICMllFgMRWIojh00vk/nk6SshDKQK/LDslg2249lHuBLEeIEajxiI8eM+9+w6DO14+o12IRjhtVIRk5rRaw=="
     },
     "node_modules/@noble/ed25519": {
       "version": "1.4.0",
@@ -28401,11 +28401,6 @@
         "crypto-js": "^3.3.0"
       }
     },
-    "packages/api/node_modules/@nftstorage/ipfs-cluster": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/@nftstorage/ipfs-cluster/-/ipfs-cluster-5.0.1.tgz",
-      "integrity": "sha512-e5+ICMllFgMRWIojh00vk/nk6SshDKQK/LDslg2249lHuBLEeIEajxiI8eM+9+w6DO14+o12IRjhtVIRk5rRaw=="
-    },
     "packages/api/node_modules/@web-std/fetch": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/@web-std/fetch/-/fetch-3.0.2.tgz",
@@ -29144,7 +29139,7 @@
       "version": "0.0.0",
       "license": "(Apache-2.0 OR MIT)",
       "dependencies": {
-        "@nftstorage/ipfs-cluster": "^4.0.0",
+        "@nftstorage/ipfs-cluster": "^5.0.1",
         "@web-std/fetch": "^2.0.1",
         "@web3-storage/db": "^4.0.0",
         "debug": "^4.3.1",
@@ -42497,9 +42492,9 @@
       }
     },
     "@nftstorage/ipfs-cluster": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@nftstorage/ipfs-cluster/-/ipfs-cluster-4.0.0.tgz",
-      "integrity": "sha512-PEt85HJdXpmQ8PULbC7iDdtf12KrM9tblR+o/2k+/0pvcpAdrplJeTQkUiEGRBiyeevjFXvyMs0f/eGpfxBBgA=="
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@nftstorage/ipfs-cluster/-/ipfs-cluster-5.0.1.tgz",
+      "integrity": "sha512-e5+ICMllFgMRWIojh00vk/nk6SshDKQK/LDslg2249lHuBLEeIEajxiI8eM+9+w6DO14+o12IRjhtVIRk5rRaw=="
     },
     "@noble/ed25519": {
       "version": "1.4.0",
@@ -43519,7 +43514,7 @@
         "@ipld/dag-pb": "^2.0.2",
         "@magic-ext/oauth": "^0.8.0",
         "@magic-sdk/admin": "^1.3.0",
-        "@nftstorage/ipfs-cluster": "5.0.1",
+        "@nftstorage/ipfs-cluster": "^5.0.1",
         "@sentry/cli": "^1.72.1",
         "@types/mocha": "^9.0.0",
         "@web-std/fetch": "^3.0.2",
@@ -43570,11 +43565,6 @@
             "@magic-sdk/types": "^1.1.0",
             "crypto-js": "^3.3.0"
           }
-        },
-        "@nftstorage/ipfs-cluster": {
-          "version": "5.0.1",
-          "resolved": "https://registry.npmjs.org/@nftstorage/ipfs-cluster/-/ipfs-cluster-5.0.1.tgz",
-          "integrity": "sha512-e5+ICMllFgMRWIojh00vk/nk6SshDKQK/LDslg2249lHuBLEeIEajxiI8eM+9+w6DO14+o12IRjhtVIRk5rRaw=="
         },
         "@web-std/fetch": {
           "version": "3.0.2",
@@ -43966,7 +43956,7 @@
     "@web3-storage/cron": {
       "version": "file:packages/cron",
       "requires": {
-        "@nftstorage/ipfs-cluster": "^4.0.0",
+        "@nftstorage/ipfs-cluster": "5.0.1",
         "@types/node": "^16.3.1",
         "@web-std/fetch": "^2.0.1",
         "@web3-storage/db": "^4.0.0",

--- a/packages/cron/package.json
+++ b/packages/cron/package.json
@@ -16,7 +16,7 @@
   "author": "Alan Shaw",
   "license": "(Apache-2.0 OR MIT)",
   "dependencies": {
-    "@nftstorage/ipfs-cluster": "^4.0.0",
+    "@nftstorage/ipfs-cluster": "^5.0.1",
     "@web-std/fetch": "^2.0.1",
     "@web3-storage/db": "^4.0.0",
     "debug": "^4.3.1",


### PR DESCRIPTION
Adopt the new ipfs-cluster client to be ready for the ipfs cluster v1 roll out.

Should be merged to main **after** the production cluster is upgraded to v1

see: https://github.com/web3-storage/web3.storage/issues/1184
see: https://github.com/web3-storage/web3.storage/pull/1227

License: (Apache-2.0 AND MIT)
Signed-off-by: Oli Evans <oli@tableflip.io>