### PR TITLE
fix: safari checkmark is always checked

### DIFF
--- a/packages/website/components/account/filesManager/fileRowItem.scss
+++ b/packages/website/components/account/filesManager/fileRowItem.scss
@@ -314,3 +314,17 @@ $file-size: auto;
     @include gradient_Background_PinkBlue;
   }
 }
+
+// safari hack since it does not support negative stroke-dashoffset
+// transition is opacity instead of tick drawing behaviour
+@include Safari7Plus('.files-manager-row .file-select svg.check .tick') {
+  // unchecked
+  stroke-dashoffset: 1000;
+  opacity: 0;
+  transition: opacity $transitionDuration 0s ease-out;
+}
+@include Safari7Plus('.files-manager-row .file-select input:checked ~ svg.check .tick') {
+  // checked
+  opacity: 1;
+  transition: opacity $transitionDuration 0s ease-in;
+}


### PR DESCRIPTION
Fixing issue where checkmark in safari is always checked.

Safari does not support negative stroke-dashoffset so I've adjusted it to use positive value. However, this affects the transition animation. So in order to "fix" it, I've just made safari to animate opacity instead of "drawing tick".