### PR TITLE
fix: db delete should match content cid

### DIFF
--- a/packages/db/index.js
+++ b/packages/db/index.js
@@ -369,7 +369,7 @@ export class DBClient {
         updated_at: now
       })
       .match({
-        source_cid: cid,
+        content_cid: cid,
         user_id: userId
       })
       .is('deleted_at', null)

--- a/packages/db/test/upload.spec.js
+++ b/packages/db/test/upload.spec.js
@@ -214,6 +214,26 @@ describe('upload', () => {
     assert.strictEqual(uploadId, uploadIdRestored)
   })
 
+  it('delete uploads by normalized cid', async () => {
+    const contentCid = 'bafybeigdyrzt5sfp7udm7hu76uh7y26nf3efuylqabf3oclgtqy55fbzdi'
+    const name = `Upload_${new Date().toISOString()}`
+
+    await client.createUpload({
+      user: user._id,
+      contentCid,
+      sourceCid: 'QmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR',
+      authKey: authKeys[0]._id,
+      type,
+      dagSize,
+      name,
+      pins: [initialPinData],
+      backupUrls: [`https://backup.cid/${new Date().toISOString()}`]
+    })
+
+    // Delete previously created upload
+    await client.deleteUpload(user._id, contentCid)
+  })
+
   it('creates a new upload for the same content when content uploaded by multiple users', async () => {
     // Create other user
     const name = 'test-other-name'


### PR DESCRIPTION
We were previously deleting uploads by source_cid, which does not match the CIDs we provide in all the API endpoints like list.

Closes #1202 