### PR TITLE
fix: website deploy workflow release tag condition

### DIFF
--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -112,7 +112,7 @@ jobs:
 
       # Add the site to web3.storage, output the cid as `steps.ipfs.outputs.cid`
       - name: Add to web3.storage
-        if: ${{ steps.tag-release.outputs.release_created }}
+        if: ${{ steps.tag-release.outputs.releases_created }}
         uses: web3-storage/add-to-web3@v2
         id: ipfs
         with:
@@ -122,7 +122,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Deploy https://web3.storage
-        if: ${{ steps.tag-release.outputs.release_created }}
+        if: ${{ steps.tag-release.outputs.releases_created }}
         run: npx dnslink-cloudflare --record _dnslink --domain web3.storage --link /ipfs/${{ steps.ipfs.outputs.cid }}
         env:
           CF_API_TOKEN: ${{ secrets.CF_API_TOKEN }}


### PR DESCRIPTION
_dnslink is not being updated for web3.storage as https://github.com/web3-storage/web3.storage/runs/5987111338?check_suite_focus=true workflow tasks `Add to web3.storage` and `Deploy https://web3.storage` have not been running.

They were re-enabled on https://github.com/web3-storage/web3.storage/pull/1200 but it looks that there is a typo and the condition is falsy (previous workflow steps have `steps.tag-release.outputs.releases_created`