### PR TITLE
fix: testimonial cards link behavior

### DIFF
--- a/packages/website/components/card/card.js
+++ b/packages/website/components/card/card.js
@@ -67,10 +67,11 @@ export default function Card({ card, cardsGroup = [], index = 0, targetClass, on
 
   const navigateOnCardClick = useCallback(
     item => {
-      if (!card.cta && card.action === 'next-link') {
-        router.push(card.url)
+      if (!item.cta && item.action === 'next-link') {
+        router.push(item.url);
       }
-    }
+    },
+    [router]
   );
 
   const renderExploreCards = obj => {
@@ -160,14 +161,14 @@ export default function Card({ card, cardsGroup = [], index = 0, targetClass, on
     return <CardTier card={card} cardsGroup={cardsGroup} index={index} onCardLoad={onCardLoad} />;
   }
 
-  const CustomTag = card.action === 'link' ? 'a' : 'div'
+  const CustomTag = card.action === 'link' ? 'a' : 'div';
   return (
     <CustomTag
       href={card.action === 'link' ? card.url : undefined}
       target="_blank"
       className={clsx('card', `type__${card.type}`, card.action ? `has-${card.action}` : '')}
-      onClick={card.action === 'next-link' ? () => navigateOnCardClick(card) : undefined}>
-
+      onClick={card.action === 'next-link' ? () => navigateOnCardClick(card) : undefined}
+    >
       {card.label && <div className="label">{card.label}</div>}
 
       {<div className={clsx('feature-wrapper', targetClass)}>{getFeaturedElement(card)}</div>}
@@ -195,7 +196,6 @@ export default function Card({ card, cardsGroup = [], index = 0, targetClass, on
           {card.cta.text}
         </Button>
       )}
-
     </CustomTag>
   );
 }

--- a/packages/website/components/card/card.js
+++ b/packages/website/components/card/card.js
@@ -65,6 +65,14 @@ export default function Card({ card, cardsGroup = [], index = 0, targetClass, on
     [router]
   );
 
+  const navigateOnCardClick = useCallback(
+    item => {
+      if (!card.cta && card.action === 'next-link') {
+        router.push(card.url)
+      }
+    }
+  );
+
   const renderExploreCards = obj => {
     return (
       <>
@@ -152,8 +160,14 @@ export default function Card({ card, cardsGroup = [], index = 0, targetClass, on
     return <CardTier card={card} cardsGroup={cardsGroup} index={index} onCardLoad={onCardLoad} />;
   }
 
+  const CustomTag = card.action === 'link' ? 'a' : 'div'
   return (
-    <div className={clsx('card', `type__${card.type}`)}>
+    <CustomTag
+      href={card.action === 'link' ? card.url : undefined}
+      target="_blank"
+      className={clsx('card', `type__${card.type}`, card.action ? `has-${card.action}` : '')}
+      onClick={card.action === 'next-link' ? () => navigateOnCardClick(card) : undefined}>
+
       {card.label && <div className="label">{card.label}</div>}
 
       {<div className={clsx('feature-wrapper', targetClass)}>{getFeaturedElement(card)}</div>}
@@ -181,6 +195,7 @@ export default function Card({ card, cardsGroup = [], index = 0, targetClass, on
           {card.cta.text}
         </Button>
       )}
-    </div>
+
+    </CustomTag>
   );
 }

--- a/packages/website/components/card/card.scss
+++ b/packages/website/components/card/card.scss
@@ -133,7 +133,7 @@
   }
 }
 
-// /////////////////////////////////////////////// Card [Type C] -> Shadow Cards
+// //////////////////////////////// Card [Type C] -> Shadow Cards (Testimonials)
 // -----------------------------------------------------------------------------
 .card.type__C {
   background-color: $ebony;
@@ -163,9 +163,19 @@
     transition: 250ms ease;
   }
 
-  &:hover {
-    &:before {
-      opacity: 1;
+  // &:hover {
+  //   &:before {
+  //     opacity: 1;
+  //   }
+  // }
+
+  &.has-link,
+  &.has-next-link {
+    &:hover {
+      cursor: pointer;
+      &:before {
+        opacity: 1;
+      }
     }
   }
 
@@ -206,7 +216,7 @@
     @include fontSize_Mini;
     @include fontWeight_Regular;
     line-height: leading(22, 15);
-    a {
+    .description-link {
       border-bottom: 1px solid;
       transition: all $transitionDuration;
       &:hover {

--- a/packages/website/content/pages/index.json
+++ b/packages/website/content/pages/index.json
@@ -526,10 +526,12 @@
             "cards": [
               {
                 "type": "C",
+                "action": "link",
+                "url": "//www.strangemood.org",
                 "image": "/images/index/testimonial-jacob-p.jpg",
                 "title": "Jacob P.",
                 "subtitle": "New York, USA",
-                "description": "Web3.Storage enables <a href='//www.strangemood.org' target='blank'>Strangemood</a> to provide game devs with fast, free, and censorship resistant storage. Their simple SDK and responsive team makes decentralized storage on IPFS easier than even centralized alternatives."
+                "description": "Web3.Storage enables <span className='description-link'>Strangemood</span> to provide game devs with fast, free, and censorship resistant storage. Their simple SDK and responsive team makes decentralized storage on IPFS easier than even centralized alternatives."
               },
               {
                 "type": "C",
@@ -540,10 +542,12 @@
               },
               {
                 "type": "C",
+                "action": "link",
+                "url": "//galacticpunks.io",
                 "image": "/images/index/testimonial-frank-j.jpg",
                 "title": "Frank J.",
                 "subtitle": "Toronto, Canada",
-                "description": "Web3.Storage was so simple to hook into, and does what you need it to do. We run the <a href='//galacticpunks.io' target='blank'>Galactic Punks</a> community on Terra, and it is great for storing off-chain data. It's like simplified S3 for IPFS."
+                "description": "Web3.Storage was so simple to hook into, and does what you need it to do. We run the <span className='description-link'>Galactic Punks</span> community on Terra, and it is great for storing off-chain data. It's like simplified S3 for IPFS."
               }
             ]
           },

--- a/packages/website/content/pages/index.json
+++ b/packages/website/content/pages/index.json
@@ -564,10 +564,12 @@
             "slides": [
               {
                 "type": "C",
+                "action": "link",
+                "url": "//www.strangemood.org",
                 "image": "/images/index/testimonial-jacob-p.jpg",
                 "title": "Jacob P.",
                 "subtitle": "New York, USA",
-                "description": "Web3.Storage enables <a href='//www.strangemood.org' target='blank'>Strangemood</a> to provide game devs with fast, free, and censorship resistant storage. Their simple SDK and responsive team makes decentralized storage on IPFS easier than even centralized alternatives."
+                "description": "Web3.Storage enables <span className='description-link'>Strangemood</span> to provide game devs with fast, free, and censorship resistant storage. Their simple SDK and responsive team makes decentralized storage on IPFS easier than even centralized alternatives."
               },
               {
                 "type": "C",
@@ -578,10 +580,12 @@
               },
               {
                 "type": "C",
+                "action": "link",
+                "url": "//galacticpunks.io",
                 "image": "/images/index/testimonial-frank-j.jpg",
                 "title": "Frank J.",
                 "subtitle": "Toronto, Canada",
-                "description": "Web3.Storage was so simple to hook into, and does what you need it to do. We run the <a href='//galacticpunks.io' target='blank'>Galactic Punks</a> community on Terra, and it is great for storing off-chain data. It's like simplified S3 for IPFS."
+                "description": "Web3.Storage was so simple to hook into, and does what you need it to do. We run the <span className='description-link'>Galactic Punks</span> community on Terra, and it is great for storing off-chain data. It's like simplified S3 for IPFS."
               }
             ]
           }

--- a/packages/website/pages/index.scss
+++ b/packages/website/pages/index.scss
@@ -231,7 +231,7 @@
     content: '';
     position: absolute;
     width: 101%;
-    height: 20rem;
+    height: 16rem;
     top: 3px;
     left: 0;
     transform: translateY(-100%);
@@ -243,6 +243,17 @@
   @include ultraLarge {
     &:before {
       display: block;
+      height: 20rem;
+    }
+  }
+  @include xlarge {
+    &:before {
+      height: 16rem;
+    }
+  }
+  @include large {
+    &:before {
+      height: 12rem;
     }
   }
   @include small {
@@ -731,6 +742,9 @@
   padding-bottom: 12rem;
 
   @include ultraLarge {
+    padding-bottom: 19rem;
+  }
+  @include xlarge {
     padding-bottom: 15rem;
   }
   @include large {


### PR DESCRIPTION
A fix to update the index page testimonial cards with the correct behaviour outlined below:

If a card has a link in its description:

- Clicking anywhere on the card takes the user to that link (in a new tab)
- Hovering over the card shows the current glow effect
- The text that's linked should still be underscored (currently shown with a bottom border)

If the card does not have a link in its description:

- Hovering on the card does not produce the hover effect
- The card is not clickable