### PR TITLE
feat: add github workflow cron job for storage limit email alerts

### DIFF
--- a/.github/workflows/cron-storage-limits.yaml
+++ b/.github/workflows/cron-storage-limits.yaml
@@ -37,9 +37,5 @@ jobs:
           STAGING_PG_REST_JWT: ${{ secrets.STAGING_PG_REST_JWT }}
           PROD_PG_REST_URL: ${{ secrets.PROD_PG_REST_URL }}
           STAGING_PG_REST_URL: ${{ secrets.STAGING_PG_REST_URL }}
-          CLUSTER_API_URL: ${{ secrets.CLUSTER_API_URL }}
-          CLUSTER_BASIC_AUTH_TOKEN: ${{ secrets.CLUSTER_BASIC_AUTH_TOKEN }}
-          CLUSTER_IPFS_PROXY_API_URL: ${{ secrets.CLUSTER_IPFS_PROXY_API_URL }}
-          CLUSTER_IPFS_PROXY_BASIC_AUTH_TOKEN: ${{ secrets.CLUSTER_IPFS_PROXY_BASIC_AUTH_TOKEN }}
           MAILCHIMP_API_KEY: ${{ secrets.MAILCHIMP_API_KEY }}
         run: npm run start:storage -w packages/cron

--- a/.github/workflows/cron-storage-limits.yaml
+++ b/.github/workflows/cron-storage-limits.yaml
@@ -1,0 +1,45 @@
+name: Storage Limit Email Notifications
+
+on:
+  schedule:
+    - cron: '0 5 * * *'
+  # Including 'workflow_dispatch' here allows the job to be triggered manually,
+  # as well as on the schedule.
+  workflow_dispatch:
+
+jobs:
+  send-notifications:
+    name: Send notifications
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        # TODO: Update this to include production once it's been successfully
+        # tested on staging
+        # env: ['staging', 'production']
+        env: ['staging']
+    timeout-minutes: 100
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Setup node
+        uses: actions/setup-node@v1
+        with:
+          node-version: 16
+
+      - name: Install dependencies
+        uses: bahmutov/npm-install@v1
+
+      - name: Run job
+        env:
+          DEBUG: '*'
+          ENV: ${{ matrix.env }}
+          PROD_PG_REST_JWT: ${{ secrets.PROD_PG_REST_JWT }}
+          STAGING_PG_REST_JWT: ${{ secrets.STAGING_PG_REST_JWT }}
+          PROD_PG_REST_URL: ${{ secrets.PROD_PG_REST_URL }}
+          STAGING_PG_REST_URL: ${{ secrets.STAGING_PG_REST_URL }}
+          CLUSTER_API_URL: ${{ secrets.CLUSTER_API_URL }}
+          CLUSTER_BASIC_AUTH_TOKEN: ${{ secrets.CLUSTER_BASIC_AUTH_TOKEN }}
+          CLUSTER_IPFS_PROXY_API_URL: ${{ secrets.CLUSTER_IPFS_PROXY_API_URL }}
+          CLUSTER_IPFS_PROXY_BASIC_AUTH_TOKEN: ${{ secrets.CLUSTER_IPFS_PROXY_BASIC_AUTH_TOKEN }}
+          MAILCHIMP_API_KEY: ${{ secrets.MAILCHIMP_API_KEY }}
+        run: npm run start:storage -w packages/cron

--- a/.github/workflows/cron-storage-limits.yaml
+++ b/.github/workflows/cron-storage-limits.yaml
@@ -22,7 +22,7 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Setup node
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v2
         with:
           node-version: 16
 


### PR DESCRIPTION
Fixes #1193.

This adds the GitHub workflow configuration for running the cron job to send email notifications about users approaching or over their storage limits.

Notes:

* It's currently only configured for staging, because we want to test it there before adding it to production.
* I've configured it so that it can be run manually like [this](https://docs.github.com/en/github-ae@latest/actions/managing-workflow-runs/manually-running-a-workflow) (as well as running on its schedule).
* It requires the MailChimp API key to be added to the `MAILCHIMP_API_KEY` secret. I don't think I've got access to the right stuff in GitHub to be able to do this.
