### PR TITLE
fix: return 400 on malformed form data

### DIFF
--- a/packages/api/src/upload.js
+++ b/packages/api/src/upload.js
@@ -21,8 +21,7 @@ export async function uploadPost (request, env, ctx) {
   let input
   if (contentType.includes('multipart/form-data')) {
     const form = await toFormData(request).catch(
-      error => HTTPError.throw(error.message),
-      400
+      error => HTTPError.throw(error.message, 400)
     )
     const files = form.getAll('file')
     input = files.map((f) => ({


### PR DESCRIPTION
`HTTPError.throw(error.message, 400)` was not properly receiving status code, leading to non handling of https://sentry.io/organizations/protocol-labs-it/issues/3185331407/?project=5864302