### PR TITLE
fix: Bump MAX_BLOCK_SIZE to 2MiB limit imposed by bitswap

### DIFF
--- a/packages/api/src/constants.js
+++ b/packages/api/src/constants.js
@@ -2,7 +2,7 @@ export const JWT_ISSUER = 'web3-storage'
 export const METRICS_CACHE_MAX_AGE = 10 * 60 // in seconds (10 minutes)
 export const DAG_SIZE_CALC_LIMIT = 1024 * 1024 * 9
 // Maximum permitted block size in bytes.
-export const MAX_BLOCK_SIZE = 1 << 20 // 1MiB
+export const MAX_BLOCK_SIZE = 1 << 21 // 2MiB
 export const UPLOAD_TYPES = ['Car', 'Blob', 'Multipart', 'Upload']
 export const PIN_STATUSES = ['PinQueued', 'Pinning', 'Pinned', 'PinError']
 export const USER_TAGS = {


### PR DESCRIPTION
go-ipfs's chunker produces blocks containing 1MiB of data, however the protobuf wrapping each block results in ~0.001MiB of overhead. This means that when uploading CAR files containing blocks that go-ipfs produces, sometimes there are well-formed blocks that exceed the current limit. I am proposing bumping the max block size accepted by web3.storage to the limit imposed by ipfs bitswap, which seems like it's more in line with the reasoning behind imposing a block size limit.

The 2MiB value selected is proposed by @Jorropo in the ipfs Discord, who claims that it's a part of the bitswap spec. This value is also mentioned in ipfs/go-ipfs#3104