### PR TITLE
fix: trigger api release with db change

### DIFF
--- a/packages/api/src/env.js
+++ b/packages/api/src/env.js
@@ -9,7 +9,7 @@ import pkg from '../package.json'
 
 /**
  * @typedef {object} Env
- * // Environment vars
+ * // Environment and global vars
  * @property {string} ENV
  * @property {string} BRANCH
  * @property {string} VERSION


### PR DESCRIPTION
https://github.com/web3-storage/web3.storage/pull/1272 did not trigger release PR for API because it is not in the path of packages/api per https://github.com/web3-storage/web3.storage/runs/6174595070?check_suite_focus=true