### PR TITLE
chore: increase api test setup timeout

### DIFF
--- a/packages/api/test/hooks.js
+++ b/packages/api/test/hooks.js
@@ -26,7 +26,7 @@ export const mochaHooks = () => {
 
   return {
     async beforeAll () {
-      this.timeout(60_000)
+      this.timeout(120_000)
 
       console.log('⚡️ Starting Miniflare')
       srv = await new Miniflare({


### PR DESCRIPTION
trying to stop the api tests from failing like https://github.com/web3-storage/web3.storage/runs/6217415452?check_suite_focus=true

License: (Apache-2.0 AND MIT)
Signed-off-by: Oli Evans <oli@tableflip.io>