### PR TITLE
fix: add pinning service docs to sidebar

### DIFF
--- a/packages/docs/sidebars.js
+++ b/packages/docs/sidebars.js
@@ -13,6 +13,7 @@ module.exports = {
         'how-tos/work-with-car-files',
         'how-tos/generate-api-token',
         'how-tos/get-status',
+        'how-tos/pinning-services-api',
         'how-tos/troubleshooting'
       ]
     },


### PR DESCRIPTION
Adds a link to the pinning service docs to the sidebar and fixes the page layout.

see: https://web3.storage/docs/how-tos/pinning-services-api/

preview
<img width="1552" alt="Screenshot 2022-04-29 at 15 20 12" src="https://user-images.githubusercontent.com/58871/165963019-c56357f4-9834-487f-8c00-81c3da0df460.png">


License: (Apache-2.0 AND MIT)
Signed-off-by: Oli Evans <oli@tableflip.io>