### PR TITLE
style: Rescale app ui

### DIFF
--- a/packages/website/components/account/ctaCard/CTACard.scss
+++ b/packages/website/components/account/ctaCard/CTACard.scss
@@ -1,4 +1,4 @@
-$cta-card-padding-top: 4rem;
+$cta-card-padding-top: 5rem;
 
 .cta-card {
   position: relative;
@@ -6,11 +6,11 @@ $cta-card-padding-top: 4rem;
   flex-direction: column;
   justify-content: space-between;
   padding-top: $cta-card-padding-top;
-  padding-bottom: 1.5rem;
+  padding-bottom: 1.875rem;
   align-items: baseline;
 
   @include medium {
-    padding: 2.95rem 2rem;
+    padding: 3.6875rem 2.5rem;
   }
 
   > * {
@@ -18,8 +18,8 @@ $cta-card-padding-top: 4rem;
   }
 
   span {
-    padding-top: 0.5rem;
-    padding-bottom: 1.25rem;
+    padding-top: 0.625rem;
+    padding-bottom: 1.5625rem;
     @include label_4;
   }
 }
@@ -28,7 +28,7 @@ $cta-card-padding-top: 4rem;
   display: flex;
   justify-content: space-between;
   width: 100%;
-  gap: 0.75rem;
+  gap: 0.9375rem;
   @include medium {
     flex-wrap: wrap;
   }
@@ -38,7 +38,7 @@ $cta-card-padding-top: 4rem;
     }
   }
   button {
-    padding: 0 1rem;
+    padding: 0 1.25rem;
     align-items: center;
   }
 }

--- a/packages/website/components/account/filesManager/fileRowItem.scss
+++ b/packages/website/components/account/filesManager/fileRowItem.scss
@@ -1,13 +1,13 @@
 @use 'sass:math';
 
-$base-row-width: 60.125rem;
-$file-select: calculateWidthPercentage(3.375rem, $base-row-width);
-$file-date: calculateWidthPercentage(6.8125rem, $base-row-width);
-$file-name: calculateWidthPercentage(14rem, $base-row-width);
-$file-cid: calculateWidthPercentage(13.6875rem, $base-row-width);
+$base-row-width: 75.125rem;
+$file-select: calculateWidthPercentage(4.25rem, $base-row-width);
+$file-date: calculateWidthPercentage(8.5rem, $base-row-width);
+$file-name: calculateWidthPercentage(17.5rem, $base-row-width);
+$file-cid: calculateWidthPercentage(17.125rem, $base-row-width);
 $file-availability: calculateWidthPercentage(0rem, $base-row-width);
-$file-pin-status: calculateWidthPercentage(7.5625rem, $base-row-width);
-$file-storage-providers: calculateWidthPercentage(8.875rem, $base-row-width);
+$file-pin-status: calculateWidthPercentage(9.5rem, $base-row-width);
+$file-storage-providers: calculateWidthPercentage(11.125rem, $base-row-width);
 $file-size: auto;
 
 .files-manager-row {
@@ -19,24 +19,24 @@ $file-size: auto;
   position: relative;
   grid-template-columns: $file-select $file-date $file-name $file-cid $file-pin-status $file-storage-providers $file-size;
   align-items: flex-start;
-  padding-left: 1.125rem;
-  min-height: 6.25rem;
-  border-bottom: 0.0625rem solid rgba(white, 0.05);
-  margin-top: 1.3rem;
-  padding-bottom: 1rem;
+  padding-left: 1.4375rem;
+  min-height: 7.8125rem;
+  border-bottom: 0.078125rem solid rgba(white, 0.05);
+  margin-top: 1.625rem;
+  padding-bottom: 1.25rem;
 
   @include medium {
     grid-template-columns: auto;
     border-bottom: 0;
     padding: 0;
-    margin-top: 1.25rem;
+    margin-top: 1.5625rem;
     @include border_Background_Waterloo_White;
   }
 
   &-header {
-    padding-bottom: 1.25rem;
+    padding-bottom: 1.5625rem;
     min-height: initial;
-    border-bottom: 0.125rem solid rgba(white, 0.15);
+    border-bottom: 0.15625rem solid rgba(white, 0.15);
   }
 
   // Targeting all columns
@@ -47,36 +47,36 @@ $file-size: auto;
     word-break: break-word;
     @include fontWeight_Regular;
     @include medium {
-      padding: 0.85rem 1rem 0.85rem 1.975rem;
+      padding: 1.25rem 1.5625rem 1.25rem 3.125rem;
       justify-content: flex-start;
-      border-bottom: 0.0625rem solid rgba(white, 0.05);
+      border-bottom: 0.078125rem solid rgba(white, 0.05);
       &.file-date {
-        padding-top: 1.375rem;
+        padding-top: 1.75rem;
       }
       &:last-child {
-        padding-bottom: 1.375rem;
+        padding-bottom: 1.75rem;
       }
 
       .file-row-label {
         @include fontWeight_Semibold;
-        width: 6rem;
+        width: 7.5rem;
         flex-shrink: 0;
         &.delete {
           width: auto;
-          padding-right: 1rem;
+          padding-right: 1.25rem;
           color: $pictonBlue;
         }
         .Tooltip {
           position: absolute;
-          left: 0.5rem;
+          left: 0.625rem;
           padding-left: 0;
         }
       }
       .Tooltip {
-        padding-left: 0.5rem;
+        padding-left: 0.625rem;
         svg {
-          width: 1rem;
-          height: 1rem;
+          width: 1.25rem;
+          height: 1.25rem;
         }
       }
     }
@@ -85,19 +85,19 @@ $file-size: auto;
     display: flex;
     align-items: center;
     justify-content: center;
-    column-gap: 0.25rem;
+    column-gap: 0.3125rem;
     span,
     .Tooltip {
       flex-grow: 1;
       flex-shrink: 1;
     }
     .Tooltip {
-      margin-right: 1rem;
+      margin-right: 1.25rem;
     }
   }
   a {
     padding-bottom: 0;
-    border-bottom: 0.03125rem solid rgba(255, 255, 255, 0.25);
+    border-bottom: 0.0390625rem solid rgba(255, 255, 255, 0.25);
     line-height: 1.6;
     transition: all $transitionDuration linear;
     &:hover {
@@ -114,23 +114,23 @@ $file-size: auto;
     }
     &-select {
       @include border_Background_Waterloo_White;
-      width: 0.75rem;
-      height: 0.75rem;
-      border-radius: 0.125rem;
+      width: 0.9375rem;
+      height: 0.9375rem;
+      border-radius: 0.15625rem;
       cursor: pointer;
       position: relative;
-      margin-bottom: 0.125rem;
+      margin-bottom: 0.15625rem;
       input {
         cursor: pointer;
         opacity: 0;
       }
       svg.check {
         color: $cyan;
-        top: -0.55rem;
-        left: -0.25rem;
+        top: -0.6875rem;
+        left: -0.3125rem;
         position: absolute;
         pointer-events: none;
-        width: 1.5rem;
+        width: 1.875rem;
         .tick {
           stroke-dashoffset: -100;
           stroke-dasharray: 1000;
@@ -145,19 +145,19 @@ $file-size: auto;
       }
     }
     &-date {
-      padding-right: 2.1875rem;
+      padding-right: 2.75rem;
       @include medium {
-        padding-right: 1rem;
+        padding-right: 1.25rem;
       }
     }
     &-name {
-      padding-right: 2.1875rem;
+      padding-right: 2.75rem;
       @include medium {
-        padding-right: 1rem;
+        padding-right: 1.25rem;
       }
       svg.pencil-icon {
         flex-shrink: 0;
-        margin-left: 0.5rem;
+        margin-left: 0.625rem;
         @include hoverSvg;
         @include medium {
           display: none;
@@ -169,9 +169,9 @@ $file-size: auto;
           display: flex;
           position: relative;
           width: 100%;
-          height: calc(100% + 0.5rem);
-          margin-top: -0.65rem;
-          margin-left: -0.68rem;
+          height: calc(100% + 0.625rem);
+          margin-top: -0.8125rem;
+          margin-left: -0.875rem;
         }
         svg.pencil-icon {
           color: $pictonBlue;
@@ -182,23 +182,23 @@ $file-size: auto;
         resize: none;
         @include border_Background_Waterloo_White;
         @include hoverInput;
-        padding: 0.625rem 0 0.625rem 0.625rem;
-        height: calc(100% + 0.5rem);
+        padding: 0.8125rem 0 0.8125rem 0.8125rem;
+        height: calc(100% + 0.625rem);
         width: 100%;
       }
     }
     &-cid {
-      padding-right: 3rem;
+      padding-right: 3.75rem;
       justify-content: flex-start;
       .cid-truncate,
       .cid-full {
         @include monospace_Text;
         word-break: break-all;
-        margin-right: 0.5rem;
+        margin-right: 0.625rem;
       }
       @include medium {
         justify-content: flex-start;
-        padding-right: 1rem;
+        padding-right: 1.25rem;
       }
       svg {
         @include hoverSvg;
@@ -208,25 +208,25 @@ $file-size: auto;
       }
     }
     &-availability {
-      padding-right: 2.3rem;
+      padding-right: 2.875rem;
       @include medium {
-        padding-right: 1rem;
+        padding-right: 1.25rem;
       }
     }
     &-pin-status {
       justify-content: flex-start;
-      gap: 0.5rem;
+      gap: 0.625rem;
       @include medium {
         gap: 0;
       }
     }
     &-storage-providers {
-      padding-right: 2.3rem;
+      padding-right: 2.875rem;
       flex-wrap: wrap;
 
       &-content {
         button {
-          margin-top: toRem(5);
+          margin-top: 0.40625rem;
           transition: color $transitionDuration;
           &:hover {
             color: $cyan;
@@ -234,7 +234,7 @@ $file-size: auto;
           }
           &:before {
             content: '❯ ';
-            margin-right: toRem(10);
+            margin-right: 0.78125rem;
             display: inline-block;
             transform: rotate(270deg);
             transition: transform $transitionDuration;
@@ -242,13 +242,13 @@ $file-size: auto;
         }
         .content {
           overflow: hidden;
-          max-height: 1000px;
+          max-height: 1250px;
           @include monospace_Text;
           transition: max-height $transitionDuration ease-in;
         }
         &.show-all {
           .content {
-            max-height: toRem(80);
+            max-height: 6.25rem;
             transition: max-height $transitionDuration ease-out;
             @include medium {
               max-height: auto;
@@ -264,11 +264,11 @@ $file-size: auto;
       }
 
       @include medium {
-        padding-right: 1rem;
+        padding-right: 1.25rem;
         flex-wrap: nowrap;
         > span {
           &:not(:last-child) {
-            margin-right: 0.3125rem;
+            margin-right: 0.375rem;
             @include medium {
               margin-right: 0;
             }
@@ -290,7 +290,7 @@ $file-size: auto;
     }
     .file {
       &-storage-providers {
-        padding-right: 2.5rem;
+        padding-right: 3.125rem;
         flex-direction: row;
         flex-wrap: nowrap;
       }

--- a/packages/website/components/account/filesManager/filesManager.scss
+++ b/packages/website/components/account/filesManager/filesManager.scss
@@ -3,7 +3,7 @@
   flex-direction: column;
   position: relative;
   justify-content: flex-start;
-  padding: 1.5rem 0;
+  padding: 1.875rem 0;
 
   @include medium {
     background: none;
@@ -26,7 +26,7 @@
   align-items: center;
   justify-content: space-between;
   justify-items: center;
-  padding: 0 2.125rem 1.5rem;
+  padding: 0 2.6875rem 1.875rem;
   flex-wrap: wrap;
 
   @include medium {
@@ -36,9 +36,9 @@
 
   // Title
   > :first-child {
-    margin-right: 8rem;
+    margin-right: 10rem;
     @include medium {
-      padding-left: 1rem;
+      padding-left: 1.25rem;
       margin-right: initial;
     }
   }
@@ -47,24 +47,24 @@
     @include medium {
       flex-basis: 100%;
       order: 4;
-      margin-top: 0.5rem;
-      margin-bottom: 0.375rem;
+      margin-top: 0.625rem;
+      margin-bottom: 0.5rem;
     }
   }
 
   .refresh {
     @include label_5;
     position: relative;
-    top: 0.1rem;
+    top: 0.125rem;
     cursor: pointer;
-    margin-right: 2.5rem;
+    margin-right: 3.125rem;
     @include medium {
       margin-right: 0;
     }
     svg {
       transition: transform $transitionDuration;
       color: $cyan;
-      margin-right: 0.625rem;
+      margin-right: 0.8125rem;
     }
     span {
       display: inline-block;
@@ -84,30 +84,30 @@
 
   .Sortable {
     @include medium {
-      padding-right: 1rem;
+      padding-right: 1.25rem;
     }
   }
 }
 
 .files-manager-table-header-divider {
-  border-bottom: 0.0625rem solid rgba($white, 0.05);
+  border-bottom: 0.078125rem solid rgba($white, 0.05);
   position: absolute;
   width: 100%;
   left: 0;
-  top: 8.125rem;
+  top: 10.1875rem;
 }
 
 .files-manager-table-content {
   display: flex;
   flex-direction: column;
-  min-height: toRem(300);
+  min-height: 23.4375rem;
 }
 
 .files-manager-upload-cta {
   @include fontWeight_Regular;
   @include fontSize_Medium;
-  padding-left: 2.5rem;
-  padding-top: 0.85rem;
+  padding-left: 3.125rem;
+  padding-top: 1.0625rem;
   .button {
     button {
       @include fontSize_Medium;
@@ -119,19 +119,19 @@
 .files-loading-spinner {
   width: 100%;
   padding: 0;
-  padding-top: 2em;
+  padding-top: 2.5rem;
 }
 
 .files-manager-footer {
   display: flex;
   justify-content: space-between;
   justify-items: center;
-  padding: 1.5rem 2rem 0;
+  padding: 1.875rem 2.5rem 0;
   padding-bottom: 0rem;
   flex-wrap: wrap;
 
   @include medium {
-    padding: 1rem;
+    padding: 1.25rem;
     padding-bottom: 0rem;
     .Pagination .pageList {
       justify-content: center;
@@ -139,7 +139,7 @@
   }
 
   .files-manager-result-dropdown .dropdownContent {
-    right: -0.75rem;
+    right: -0.9375rem;
   }
 
   .delete {
@@ -166,35 +166,35 @@
     position: relative;
   }
   .modalContainer {
-    min-width: toRem(550);
+    min-width: 43rem;
     @include medium {
       min-width: auto;
     }
     @include borderRadius_Large;
     .modalInner {
-      padding: toRem(49) 2rem toRem(29) 4rem;
+      padding: 3.875rem 2.5rem 2.25rem 5rem;
     }
   }
   .modalClose {
     color: $ebony;
-    font-size: 2rem;
+    font-size: 2.5rem;
   }
   &-content {
     position: relative;
     h5 {
-      font-size: toRem(24);
+      font-size: 1.875rem;
     }
     p {
-      font-size: toRem(16);
+      font-size: 1.25rem;
       @include leading_Small;
     }
   }
   &-buttons {
-    margin-top: toRem(27);
+    margin-top: 2.125rem;
     display: flex;
     justify-content: flex-end;
     .button {
-      margin-left: 0.5rem;
+      margin-left: 0.625rem;
     }
   }
 }
@@ -221,14 +221,14 @@
     align-items: center;
     justify-content: center;
     display: flex;
-    width: toRem(286);
-    height: toRem(286);
-    border-radius: 10px;
+    width: 22.375rem;
+    height: 22.375rem;
+    border-radius: 12.5px;
     background: rgba(#757a9b, 0.25);
     mix-blend-mode: normal;
-    border: toRem(4) solid rgba($white, 0.25);
-    box-shadow: 0px 12.6176px 25.2353px rgba(0, 0, 0, 0.160784);
-    border-radius: toRem(8.5);
+    border: 0.3125rem solid rgba($white, 0.25);
+    box-shadow: 0px 15.772px 31.544125px rgba(0, 0, 0, 0.160784);
+    border-radius: 0.6875rem;
     svg {
       opacity: 0.49;
     }

--- a/packages/website/components/account/storageManager/storageManager.scss
+++ b/packages/website/components/account/storageManager/storageManager.scss
@@ -4,17 +4,17 @@
   > * {
     width: 100%;
   }
-  padding: 1.875rem 0 0.9375rem 2.375rem;
+  padding: 2.375rem 0 1.1875rem 3rem;
   @include medium {
-    padding: 2.25rem 1.375rem 2.25rem 1rem;
+    padding: 2.8125rem 1.71875rem 2.8125rem 1.25rem;
   }
 }
 
 .storage-manager-info,
 .storage-manager-space {
   display: flex;
-  padding-left: 0.5625rem;
-  padding-right: 3.15rem;
+  padding-left: 0.6875rem;
+  padding-right: 3.9375rem;
   align-items: center;
 }
 
@@ -23,7 +23,7 @@
   justify-content: space-between;
   margin-bottom: 0.325rem;
   @include medium {
-    margin-bottom: 0.4rem;
+    margin-bottom: 0.4375rem;
   }
   .button {
     height: auto;
@@ -41,12 +41,12 @@
   a {
     @include hoverTextLinkColor;
   }
-  margin-top: 1.25rem;
+  margin-top: 1.5625rem;
   @include medium {
     @include leading_Small;
     button a {
       &::after {
-        margin-left: 0.5rem;
+        margin-left: 0.625rem;
         content: '❯';
       }
     }
@@ -72,18 +72,18 @@
   position: relative;
   color: $white;
   width: 100%;
-  gap: 0.95rem;
-  padding-right: 2.25rem;
+  gap: 1.1875rem;
+  padding-right: 2.8125rem;
 
   @include medium {
-    gap: 0.625rem;
+    gap: 0.78125rem;
   }
 
   .button {
     padding: 0;
     height: auto;
     svg {
-      margin-right: 0.35rem;
+      margin-right: 0.4375rem;
       @include hoverSvg;
     }
     button {
@@ -113,24 +113,24 @@
   display: flex;
   align-items: center;
   position: relative;
-  height: 1.375rem;
+  height: 1.75rem;
   background: rgba($vulcan, 0.15);
-  border: 0.0625rem solid rgba($waterloo, 0.15);
+  border: 0.078125rem solid rgba($waterloo, 0.15);
   flex: 1;
   &:only-child {
     flex: 1;
-    max-width: 35.5rem;
+    max-width: 44.375rem;
   }
   span {
     @include fontSize_Atom;
     position: absolute;
-    right: 0.75rem;
-    text-shadow: 0 0 0.125rem rgba(0, 0, 0, 0.94);
+    right: 0.9375rem;
+    text-shadow: 0 0 0.15625rem rgba(0, 0, 0, 0.94);
   }
 }
 
 .storage-manager-used {
-  margin-bottom: 0.5rem;
+  margin-bottom: 0.625rem;
   .storage-label {
     @include fontWeight_Semibold;
   }
@@ -155,7 +155,7 @@
   background-size: 410%;
   background-position: 50% 0;
   @include borderRadius_UltraLarge;
-  height: 1.5rem;
+  height: 1.875rem;
   top: 0;
   left: 0;
   transition: 250ms ease-out;

--- a/packages/website/components/tokens/tokenCreator/tokenCreator.scss
+++ b/packages/website/components/tokens/tokenCreator/tokenCreator.scss
@@ -10,7 +10,7 @@
   @include fontSize_Mini;
   @include medium {
     position: absolute;
-    top: 8rem;
+    top: 10rem;
     width: 100%;
     .button {
       width: 100%;
@@ -55,9 +55,9 @@
   transition: all $transitionDurationLong ease-in-out;
   text-decoration: none;
   outline: none;
-  min-width: 22.625rem;
-  height: 2.375rem;
-  padding: 0 2.5rem 0 1rem;
+  min-width: 28.25rem;
+  height: 3rem;
+  padding: 0 3.125rem 0 1.25rem;
   color: $cyan;
 
   @include border_Background_Waterloo_White;
@@ -86,15 +86,15 @@
 
 .token-creator-submit {
   position: absolute;
-  right: 1rem;
+  right: 1.25rem;
   @include fontSize_MediumLarge;
   @include hoverScale;
   .token-creator-check {
-    padding: 0.375rem 0;
-    width: 1.5rem;
-    transform: translate(3px, 1px);
+    padding: 0.5rem 0;
+    width: 1.875rem;
+    transform: translate(3.75px, 1.25px);
     path {
-      stroke-width: 0.75rem;
+      stroke-width: 0.9375rem;
     }
   }
 }

--- a/packages/website/components/tokens/tokensManager/tokenRowItem.scss
+++ b/packages/website/components/tokens/tokensManager/tokenRowItem.scss
@@ -1,35 +1,35 @@
-$base-row-width: 52.8125rem;
-$date-name: calculateWidthPercentage(15.5rem, $base-row-width);
-$date-id: calculateWidthPercentage(34rem, $base-row-width);
-$date-copy: calculateWidthPercentage(3rem, $base-row-width);
+$base-row-width: 64rem;
+$date-name: calculateWidthPercentage(18.5rem, $base-row-width);
+$date-id: calculateWidthPercentage(41.125rem, $base-row-width);
+$date-copy: calculateWidthPercentage(3.625rem, $base-row-width);
 $date-delete: auto;
 
 .tokens-manager-row {
   @include fontSize_Tiny;
   display: grid;
   position: relative;
-  padding: 0.3125rem 1.4rem 0.3125rem 0;
+  padding: 0.375rem 1.75rem 0.375rem 0;
   grid-template-columns: $date-name $date-id $date-copy $date-delete;
-  border-bottom: 0.0625rem solid rgba($white, 0.05);
+  border-bottom: 0.078125rem solid rgba($white, 0.05);
 
   @include medium {
     @include border_Background_Waterloo_White;
     grid-template-columns: auto;
     border-bottom: 0;
     padding: 0;
-    margin-bottom: 1rem;
+    margin-bottom: 1.25rem;
   }
 
   > span {
     @include medium {
       @include leading_Tiny;
-      padding: 0.85rem 3.975rem 0.85rem 1.375rem;
+      padding: 1.0625rem 5rem 1.0625rem 1.71875rem;
       justify-content: flex-start;
-      border-bottom: 0.0625rem solid rgba(white, 0.05);
+      border-bottom: 0.078125rem solid rgba(white, 0.05);
       .file-row-label {
         @include fontWeight_Semibold;
-        padding-bottom: 0.25rem;
-        width: 4.5rem;
+        padding-bottom: 0.3125rem;
+        width: 5.625rem;
         flex-shrink: 0;
         display: inline-block;
       }
@@ -38,7 +38,7 @@ $date-delete: auto;
 
   &.tokens-manager-row-header {
     padding-bottom: 0;
-    padding-left: 1.125rem;
+    padding-left: 1.40625rem;
     @include fontWeight_Semibold;
     @include medium {
       display: none;
@@ -54,7 +54,7 @@ $date-delete: auto;
   }
   @include medium {
     position: absolute;
-    right: 1rem;
+    right: 1.25rem;
   }
   svg {
     @include hoverSvg;
@@ -64,12 +64,12 @@ $date-delete: auto;
 .token-copy {
   display: flex;
   @include medium {
-    bottom: 1rem;
+    bottom: 1.25rem;
   }
 }
 
 .token-delete {
   @include medium {
-    top: 1rem;
+    top: 1.25rem;
   }
 }

--- a/packages/website/components/tokens/tokensManager/tokensManager.scss
+++ b/packages/website/components/tokens/tokensManager/tokensManager.scss
@@ -4,7 +4,7 @@
   position: relative;
   align-items: baseline;
   justify-content: flex-start;
-  padding: 1.5rem 0 1.5rem 1.5rem;
+  padding: 1.875rem 0 1.875rem 1.875rem;
   width: 100%;
 
   @include medium {
@@ -15,14 +15,14 @@
 
   > * {
     width: 100%;
-    padding-left: 1.125rem;
+    padding-left: 1.40625rem;
 
     @include medium {
       padding-left: 0;
     }
     &:not(.delete-modal),
     &:not(.tokens-manager-footer) {
-      max-width: 52.8125rem;
+      max-width: 64rem;
       @include medium {
         max-width: none;
       }
@@ -30,37 +30,37 @@
   }
 
   > h4 {
-    margin-bottom: 1rem;
+    margin-bottom: 1.25rem;
   }
 }
 
 .tokens-manager-header {
   display: flex;
-  padding-bottom: 0.75rem;
+  padding-bottom: 0.9375rem;
   align-items: center;
-  padding-right: 1.5rem;
+  padding-right: 1.875rem;
   flex-wrap: wrap;
 
   @include medium {
-    padding-bottom: 1.625rem;
+    padding-bottom: 2rem;
     padding-right: 0;
     justify-content: space-between;
   }
 
   // Title
   > :first-child {
-    margin-right: 7.85rem;
+    margin-right: 9.8125rem;
     @include medium {
-      margin-left: 1rem;
+      margin-left: 1.25rem;
       margin-right: 0;
     }
   }
 
   .Filterable {
-    margin-right: 3.75rem;
+    margin-right: 4.6875rem;
     @include medium {
       flex-basis: 100%;
-      margin-top: 4rem;
+      margin-top: 5rem;
       order: 3;
       margin-right: 0;
     }
@@ -68,13 +68,13 @@
 
   .Sortable {
     @include medium {
-      margin-right: 1rem;
+      margin-right: 1.25rem;
     }
   }
 }
 
 .tokens-manager-table-content {
-  min-height: 21.25rem;
+  min-height: 26.5625rem;
 
   @include medium {
     min-height: auto;
@@ -82,8 +82,8 @@
 
   .tokens-manager-upload-cta {
     position: relative;
-    top: 1.25rem;
-    left: 0.25rem;
+    top: 1.5625rem;
+    left: 0.3125rem;
   }
 
   .token-id {
@@ -92,20 +92,20 @@
 
   .token-name {
     line-height: 1.5;
-    padding: 0.5rem 1rem 0.5rem 0;
+    padding: 0.625rem 1.25rem 0.625rem 0;
     word-break: break-word;
     @include medium {
-      padding: 0.85rem 3.975rem 0.85rem 1.375rem;
+      padding: 1.0625rem 5rem 1.0625rem 1.75rem;
     }
   }
 
   @include medium {
     .token-name {
-      padding-top: 1.375rem;
+      padding-top: 1.75rem;
     }
     .token-id-container {
       display: flex;
-      padding-bottom: 1.375rem;
+      padding-bottom: 1.75rem;
       .token-id {
         word-break: break-all;
         @include leading_Tiny;
@@ -122,25 +122,25 @@
 }
 
 .tokens-manager-result-dropdown .dropdownContent {
-  right: -0.75rem;
+  right: -0.9375rem;
 }
 
 .tokens-manager-loading-spinner {
   width: 100%;
   padding: 0;
-  padding-top: 2em;
+  padding-top: 2.5rem;
 }
 
 .tokens-manager-footer {
   display: flex;
   justify-content: space-between;
-  padding-right: 4.125rem;
+  padding-right: 5.125rem;
   flex-wrap: wrap;
   &:before {
     content: '';
   }
   @include medium {
-    padding-right: 1rem;
+    padding-right: 1.25rem;
     .Pagination {
       flex-basis: 100%;
       order: 2;

--- a/packages/website/pages/account/index.js
+++ b/packages/website/pages/account/index.js
@@ -67,7 +67,7 @@ const Account = () => {
 
   return (
     <>
-      <div className="page-container account-container grid">
+      <div className="page-container account-container">
         <h3>{dashboard.heading}</h3>
         <div className="account-content">
           <StorageManager content={AppData.page_content.storage_manager} className="account-storage-manager" />

--- a/packages/website/pages/account/index.scss
+++ b/packages/website/pages/account/index.scss
@@ -1,14 +1,19 @@
 .account-container {
-  max-width: 61.125rem;
+  max-width: 64rem;
   margin: auto;
   display: table;
-  padding-bottom: 10rem;
+  padding-bottom: 12.5rem;
   position: relative;
 
+  @include medium {
+    padding: 0 4.1665%;
+    width: 100%;
+  }
+
   h3 {
-    padding: 0 1.75rem 0.75rem;
+    padding: 0 2.1875rem 0.9375rem;
     @include medium {
-      padding: 2rem 0;
+      padding: 2.5rem 0;
     }
   }
 }
@@ -22,7 +27,7 @@
     'files-manager    files-manager   files-manager';
 
   grid-template-columns: 1fr 1fr 1fr;
-  grid-gap: 0.6875rem 0.9375rem;
+  grid-gap: 0.875rem 1.1875rem;
 
   @include medium {
     grid-template-columns: 1fr;
@@ -32,7 +37,7 @@
       'tokens-cta'
       'docs-cta'
       'files-manager';
-    grid-gap: 1rem 0;
+    grid-gap: 1.25rem 0;
   }
 
   .account {
@@ -48,7 +53,7 @@
       justify-content: center;
 
       h4 {
-        padding-bottom: 0.5rem;
+        padding-bottom: 0.625rem;
       }
     }
     &-tokens-cta {
@@ -59,7 +64,7 @@
     }
     &-files-manager {
       grid-area: files-manager;
-      min-height: 17.125rem;
+      min-height: 21.375rem;
     }
   }
 }
@@ -86,8 +91,16 @@
       transform: translate(-15%, -35%) scaleY(0.75) rotate(-40deg);
     }
     @include tiny {
-      width: 40rem;
+      width: 50rem;
       transform: translate(-20%, -20%) scaleY(1.4) rotate(-40deg);
+    }
+  }
+}
+
+.account-tokens-cta {
+  .cta-buttons-container {
+    @include medium {
+      width: unset;
     }
   }
 }

--- a/packages/website/pages/login/index.scss
+++ b/packages/website/pages/login/index.scss
@@ -1,20 +1,20 @@
 .login-container {
   .section {
     svg {
-      margin-right: 0.6875rem;
+      margin-right: 0.875rem;
     }
     &-email {
       flex-direction: column;
-      gap: 1.25rem;
+      gap: 1.5625rem;
     }
     &-github {
       @include hoverInput;
     }
     .button {
-      width: 8.5625rem;
-      height: 2.1875rem;
+      width: 10.75rem;
+      height: 2.75rem;
       button {
-        min-height: 1.5rem;
+        min-height: 1.875rem;
       }
     }
   }
@@ -23,16 +23,16 @@
 .login-content {
   position: relative;
   margin: auto;
-  max-width: 19.75rem;
+  max-width: 24.6875rem;
   display: flex;
   flex-direction: column;
   text-align: center;
-  gap: 0.25rem;
+  gap: 0.3125rem;
 }
 
 .login-email {
   @include border_Background_Waterloo_White;
-  padding: 1rem 2rem;
+  padding: 1.25rem 2.5rem;
   width: 100%;
   border-radius: 0;
   @include hoverInput;

--- a/packages/website/pages/tokens/index.js
+++ b/packages/website/pages/tokens/index.js
@@ -19,7 +19,7 @@ const Tokens = () => {
   }, [fetchDate, getTokens, isFetchingTokens]);
 
   return (
-    <div className="page-container tokens-container grid">
+    <div className="page-container tokens-container">
       <div className="tokens-header">
         <h3>{content.heading}</h3>
         <TokenCreator content={TokensData.page_content.token_creator} />

--- a/packages/website/pages/tokens/index.scss
+++ b/packages/website/pages/tokens/index.scss
@@ -1,8 +1,14 @@
 .tokens-container {
-  max-width: 60rem;
+  max-width: 64rem;
   margin: auto;
+
+  @include medium {
+    padding: 0 4.1665%;
+    width: 100%;
+  }
+
   h3 {
-    padding: 0 1.75rem 0.75rem;
+    padding: 0 2.1875rem 0.9375rem;
   }
   .isDisabled {
     pointer-events: none;
@@ -27,9 +33,9 @@
 .tokens-footer {
   @include fontSize_Tiny;
   @include fontWeight_Regular;
-  margin-top: 0.75rem;
+  margin-top: 0.9375rem;
   @include medium {
-    margin-top: 2.36rem;
+    margin-top: 3rem;
     justify-content: center;
     text-align: center;
   }
@@ -38,7 +44,11 @@
 .dashboard-link {
   @include fontSize_Mini;
   @include fontWeight_Semibold;
+  @include large {
+    margin-left: 3rem;
+  }
   @include medium {
+    margin-left: unset;
     order: 2;
     flex-basis: 100%;
   }
@@ -46,7 +56,7 @@
     display: none;
   }
   button {
-    padding-left: 1rem;
+    padding-left: 1.25rem;
     @include medium {
       padding-left: 0;
       align-items: center;
@@ -69,6 +79,6 @@
     @include hoverArrowRight;
   }
   @include medium {
-    margin-bottom: 1.59375rem;
+    margin-bottom: 2rem;
   }
 }


### PR DESCRIPTION
This is a new PR based on the changes requested in [this PR](https://github.com/web3-storage/web3.storage/pull/1291). It was easier to scale all rem values in the app UI based off of current values in `main` rather than the increased values in `style-scale-up-app-ui`.

Now all rem values in the app UI have been increased by a factor of 1.25 and the container width has been increased from 61.25rem to 64rem. All app pages have been tested at all breakpoints without issues. No changes were made to the file uploader modal. When scaling the modal up by 1.25 the contents tended to overflow the page introducing a scroll bar and it seemed to just look better with the original sizing. But if we want to scale this as well it can easily be done.