### PR TITLE
feat: respond with unique error message when blocked API key is used

### DIFF
--- a/packages/api/src/auth.js
+++ b/packages/api/src/auth.js
@@ -4,6 +4,7 @@ import {
   MagicTokenRequiredError,
   NoTokenError,
   PinningUnauthorizedError,
+  TokenBlockedError,
   TokenNotFoundError,
   UnrecognisedTokenError,
   UserNotFoundError
@@ -171,6 +172,17 @@ async function tryWeb3ApiToken (token, env) {
     // we have a web3 api token, but it's no longer valid
     throw new TokenNotFoundError()
   }
+
+  if (apiToken.isDeleted) {
+    const isBlocked = await checkIsTokenBlocked(apiToken, env)
+
+    if (isBlocked) {
+      throw new TokenBlockedError()
+    } else {
+      throw new TokenNotFoundError()
+    }
+  }
+
   return apiToken
 }
 
@@ -180,6 +192,10 @@ function findUserByIssuer (issuer, env) {
 
 function getUserTags (userId, env) {
   return env.db.getUserTags(userId)
+}
+
+function checkIsTokenBlocked (token, env) {
+  return env.db.checkIsTokenBlocked(token)
 }
 
 function verifyAuthToken (token, decoded, env) {

--- a/packages/api/src/errors.js
+++ b/packages/api/src/errors.js
@@ -58,6 +58,15 @@ export class TokenNotFoundError extends HTTPError {
 }
 TokenNotFoundError.CODE = 'ERROR_TOKEN_NOT_FOUND'
 
+export class TokenBlockedError extends HTTPError {
+  constructor (msg = 'API token is blocked') {
+    super(msg, 403)
+    this.name = 'TokenBlocked'
+    this.code = TokenBlockedError.CODE
+  }
+}
+TokenBlockedError.CODE = 'ERROR_TOKEN_BLOCKED'
+
 export class UnrecognisedTokenError extends HTTPError {
   constructor (msg = 'Could not parse provided API token') {
     super(msg, 401)

--- a/packages/api/src/errors.js
+++ b/packages/api/src/errors.js
@@ -59,7 +59,7 @@ export class TokenNotFoundError extends HTTPError {
 TokenNotFoundError.CODE = 'ERROR_TOKEN_NOT_FOUND'
 
 export class TokenBlockedError extends HTTPError {
-  constructor (msg = 'API token is blocked') {
+  constructor (msg = 'API token is blocked, please contact support@web3.storage') {
     super(msg, 403)
     this.name = 'TokenBlocked'
     this.code = TokenBlockedError.CODE

--- a/packages/db/index.js
+++ b/packages/db/index.js
@@ -751,13 +751,13 @@ export class DBClient {
         keys:auth_key_user_id_fkey(
           _id:id::text,
           name,
-          secret
+          secret,
+          deleted_at
         )
       `)
       .match({
         issuer
       })
-      .filter('keys.deleted_at', 'is', null)
       .eq('keys.secret', secret)
 
     if (error) {
@@ -776,11 +776,27 @@ export class DBClient {
     return {
       _id: keyData.keys[0]._id,
       name: keyData.keys[0].name,
+      isDeleted: Boolean(keyData.keys[0].deleted_at),
       user: {
         _id: keyData._id,
         issuer: keyData.issuer
       }
     }
+  }
+
+  async checkIsTokenBlocked (token) {
+    const { data, error } = await this._client
+      .from('auth_key_history')
+      .select('status')
+      .filter('deleted_at', 'is', null)
+      .eq('auth_key_id', token._id)
+      .single()
+
+    if (error) {
+      throw new DBError(error)
+    }
+
+    return data?.status === 'Blocked'
   }
 
   /**


### PR DESCRIPTION
When an API key is blocked in admin.storage, it sets deleted_at to the current time, and then sets the last auth_key_history item to have status 'Blocked.'  This PR just updates the code to look at the status so it can send a unique error to the client when an API key is deleted via a block.  Refers to #1382 in nft.storage.