### PR TITLE
docs: show off our tools in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,95 @@
 <h1 align="center">⁂<br/>web3.storage</h1>
 <p align="center">The simple file storage service for IPFS &amp; Filecoin.</p>
 
-## Getting started
+## Usage
 
-This project uses node v16 and npm v7. It's a monorepo that use [npm workspaces](https://docs.npmjs.com/cli/v7/using-npm/workspaces) to handle resolving dependencies between the local `packages/*` folders.
+Store your files with web3.storage and retrieve them via their unique Content ID. Our tools make it simple to hash your content locally, so you can verify the service only ever stores the exact bytes you asked us to. Pick the method of using with web3.storage that works for you!
+
+### Website
+
+Create an account via https://web3.storage and upload right from the website using our uploader. Under the hood it use the web3.storage client we publish to npm to chunk and hash your files to calculate the root IPFS CID **in your browser** before sending them to https://api.web3.storage.
+
+Once uploaded you can fetch your data from any IPFS gateway via [https://dweb.link/ipfs/<root cid>](https://dweb.link/ipfs/bafkreigh2akiscaildcqabsyg3dfr6chu3fgpregiymsck7e7aqa4s52zy)
+
+Create an api token for your account and you can use any of the following alternatives to upload your data.
+
+### JS Client
+
+Use npm to install the [`web3.storage`](https://www.npmjs.com/package/web3.storage) module into your JS project, create an instance of the client with your api token, and use the `.put` method to upload your files in node.js or the browser.
+ 
+**node.js**
+```js
+import { Web3Storage, getFilesFromPath } from 'web3.storage'
+const storage = new Web3Storage({ token: process.env.WEB3_TOKEN })
+const files = await getFilesFromPath(process.env.PATH_TO_ADD)
+const cid = await storage.put(files)
+console.log(`IPFS CID: ${cid}`)
+console.log(`Gateway URL: https://dweb.link/ipfs/${cid}`)
+```
+
+See https://web3.storage/docs/#quickstart for a guide to using the js client for the first time.
+  
+
+### CLI
+
+Our command line tool `w3` is a simple wrapper around the JS Client to make adding files from your terminal as simple as `w3 put ~/Pictures/room-guardian.jpg`.
+
+Install [`@web3-storage/w3`](https://www.npmjs.com/package/@web3-storage/w3) globally and save your api token then add your files to web3! It calculates the root CID for your files locally before sending them to web3.storage.
+
+**shell**
+```console
+$ w3 token
+? Paste your API token for api.web3.storage › <your api token here>
+⁂ API token saved
+
+$ w3 put ~/Pictures/ayy-lamo.jpg
+⁂ Stored 1 file
+⁂ https://dweb.link/ipfs/bafybeid6gpbsqkpfrsx6b6ywrt24je4xqe4eo4y2wldisl6sk7byny5uky
+```
+
+Use it anywhere you can get a shell. Get creative! For example, we use this for perfomance testing the [upload speed in CI](https://github.com/web3-storage/web3.storage/blob/9fafc830b841da0dd6bd5319c77febaded232240/.github/workflows/cron-test.yml#L36)!
+
+run `w3 --help` or have a look at https://github.com/web3-storage/web3.storage/tree/main/packages/w3#readme to find out everything it can do.
+
+### GitHub Action 
+
+The Action [`add_to_web3`](https://github.com/marketplace/actions/add-to-web3) is simple wrapper around the `w3` CLI to let you add files to web3.storage from your GitHub Workflows. 
+
+**github-workflow.yaml**
+```yaml
+- run: npm run build # e.g output your static site to `./dist`
+
+- uses: web3-storage/add-to-web3@v2
+  id: web3
+  with:
+    web3_token: ${{ secrets.WEB3_STORAGE_TOKEN }}
+    path_to_add: 'dist'
+
+- run: echo ${{ steps.web3.outputs.cid }}
+# "bafkreicysg23kiwv34eg2d7qweipxwosdo2py4ldv42nbauguluen5v6am"
+- run: echo ${{ steps.web3.outputs.url }}
+# "https://dweb.link/ipfs/bafkreicysg23kiwv34eg2d7qweipxwosdo2py4ldv42nbauguluen5v6am"
+```
+
+Set your api token and the `path_to_add` and watch it fly! We use `add_to_web3` to add the [web3.storage website to web3.storage](https://github.com/web3-storage/web3.storage/blob/c0227a0b927fedd324287ad6ef95db857c205939/.github/workflows/website.yml#L158-L165) from CI ∞!
+
+
+### cURL
+
+Want to try it out? You can POST a file smaller than 100MB straight to the `/upload` endpoint with `cURL`.
+
+```console
+curl -X POST --data-binary @file.txt -H 'Authorization: Bearer YOUR_API_KEY' http://127.0.0.1:8787/upload  -s | jq
+{
+  "cid":"bafkreid65ervf7fmfnbhyr2uqiqipufowox4tgkrw4n5cxgeyls4mha3ma"
+}
+```
+
+**See https://web3.storage/docs/ for our complete documentation 📖🔍**
+
+## Building web3.storage
+
+Want to help us improve web3.storage? Great! This project uses node v16 and npm v7. It's a monorepo that use [npm workspaces](https://docs.npmjs.com/cli/v7/using-npm/workspaces) to handle resolving dependencies between the local `packages/*` folders.
 
 You need an account on https://magic.link, and Docker running locally.
 
@@ -48,6 +134,7 @@ Each workspace has its own suite of testing tools, which you can learn more abou
 Our docs website is currently hosted in a [separate repo](https://github.com/web3-storage/docs), but you can test it too!
 
 ## Learn more
+
 To learn more about the Web3.Storage service, upload a file through our friendly UI, or find detailed documentation for the JS client library, please head over to https://web3.storage
 
 


### PR DESCRIPTION
Introduce all our recommended tools for using web3.storage in a developer friendly quickstart in the README. I don't think enough folks know that the action or the cli exist, and I like a README to give me the highlights.

https://github.com/web3-storage/web3.storage/blob/58500d8cae6c133acd755719b8398a02cbf8952f/README.md

Deliberately keeping it terse to keep folks intrerested, and assuming some developer familiarity if they are reading the README rather than the docs.

Link out to the docs at every possible opportunity in case folks need more context.

License: (Apache-2.0 AND MIT)
Signed-off-by: Oli Evans <oli@tableflip.io>