### PR TITLE
chore: add chores to CHANGELOG

### DIFF
--- a/.github/workflows/api.yml
+++ b/.github/workflows/api.yml
@@ -70,6 +70,7 @@ jobs:
           release-type: node
           monorepo-tags: true
           package-name: api
+          changelog-types: '[{"type":"feat","section":"Features","hidden":false},{"type":"fix","section":"Bug Fixes","hidden":false},{"type":"chore","section":"Other Changes","hidden":false}]'
       - uses: actions/checkout@v2
         if: ${{ steps.tag-release.outputs.releases_created }}
       - uses: actions/setup-node@v2

--- a/.github/workflows/client.yml
+++ b/.github/workflows/client.yml
@@ -42,6 +42,7 @@ jobs:
           release-type: node
           monorepo-tags: true
           package-name: web3.storage
+          changelog-types: '[{"type":"feat","section":"Features","hidden":false},{"type":"fix","section":"Bug Fixes","hidden":false},{"type":"chore","section":"Other Changes","hidden":false}]'
       - uses: actions/checkout@v2
         if: ${{ steps.tag-release.outputs.releases_created }}
       - uses: actions/setup-node@v2

--- a/.github/workflows/w3.yml
+++ b/.github/workflows/w3.yml
@@ -60,6 +60,7 @@ jobs:
           release-type: node
           monorepo-tags: true
           package-name: w3
+          changelog-types: '[{"type":"feat","section":"Features","hidden":false},{"type":"fix","section":"Bug Fixes","hidden":false},{"type":"chore","section":"Other Changes","hidden":false}]'
       - uses: actions/checkout@v2
         if: ${{ steps.tag-release.outputs.releases_created }}
       - uses: actions/setup-node@v2

--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -127,6 +127,7 @@ jobs:
           release-type: node
           monorepo-tags: true
           package-name: website
+          changelog-types: '[{"type":"feat","section":"Features","hidden":false},{"type":"fix","section":"Bug Fixes","hidden":false},{"type":"chore","section":"Other Changes","hidden":false}]'
       - uses: actions/checkout@v2
         if: ${{ steps.tag-release.outputs.releases_created }}
       - uses: actions/setup-node@v2


### PR DESCRIPTION
Configure release-please to write `chore` commits to the CHANGELOG as an "Other Changes" section.

This allows us to quickly verify all the code changes going into a release before deploying

See: https://github.com/google-github-actions/release-please-action#overriding-the-changelog-sections


License: (Apache-2.0 AND MIT)
Signed-off-by: Oli Evans <oli@tableflip.io>