### PR TITLE
feat: js client accepts user provided fetch function

### DIFF
--- a/packages/client/src/lib.js
+++ b/packages/client/src/lib.js
@@ -89,7 +89,7 @@ class Web3Storage {
     token,
     endpoint = new URL('https://api.web3.storage'),
     rateLimiter,
-    fetch = _fetch,
+    fetch = _fetch
   }) {
     /**
      * Authorization token.
@@ -110,7 +110,7 @@ class Web3Storage {
      * Optional custom fetch function. Defaults to global fetch in browsers or @web-std/fetch on node.
      * @readonly
      */
-    this.fetch = fetch;
+    this.fetch = fetch
   }
 
   /**

--- a/packages/client/src/lib/interface.ts
+++ b/packages/client/src/lib/interface.ts
@@ -3,6 +3,9 @@ import type { CID } from 'multiformats'
 export type { CID, UnixFSEntry }
 import type { CarReader } from '@ipld/car/api'
 import type { BlockDecoder } from 'multiformats/codecs/interface'
+import {
+  fetch as _fetch,
+} from '../platform'
 
 /**
  * Define nominal type of U based on type of T. Similar to Opaque types in Flow
@@ -13,7 +16,7 @@ export interface Service {
   endpoint: URL
   token: string
   rateLimiter?: RateLimiter
-  customFetch?: typeof fetch
+  fetch?: typeof _fetch
 }
 
 export interface PublicService {

--- a/packages/client/src/lib/interface.ts
+++ b/packages/client/src/lib/interface.ts
@@ -13,7 +13,7 @@ export interface Service {
   endpoint: URL
   token: string
   rateLimiter?: RateLimiter
-  pre?: (requestInit: RequestInit) => RequestInit;
+  customFetch?: typeof fetch
 }
 
 export interface PublicService {

--- a/packages/client/src/lib/interface.ts
+++ b/packages/client/src/lib/interface.ts
@@ -13,6 +13,7 @@ export interface Service {
   endpoint: URL
   token: string
   rateLimiter?: RateLimiter
+  pre?: (requestInit: RequestInit) => RequestInit;
 }
 
 export interface PublicService {

--- a/packages/client/test/custom-fetch.spec.js
+++ b/packages/client/test/custom-fetch.spec.js
@@ -31,7 +31,7 @@ describe('test customFetch', () => {
     function customFetch (...opts) {
       result = true
 
-      fetch(...opts)
+      return fetch(...opts)
     }
 
     const client = new Web3Storage({ endpoint, token, fetch: customFetch })

--- a/packages/client/test/custom-fetch.spec.js
+++ b/packages/client/test/custom-fetch.spec.js
@@ -7,15 +7,14 @@ describe('test customFetch', () => {
   const { AUTH_TOKEN, API_PORT } = process.env
   const token = AUTH_TOKEN || 'good'
   const endpoint = new URL(API_PORT ? `http://localhost:${API_PORT}` : '')
-  
 
   it('without customFetch', async () => {
     // @ts-ignore
     const client = new Web3Storage({ endpoint, token })
     const files = prepareFiles()
     const cid = 'bafkreifzjut3te2nhyekklss27nh3k72ysco7y32koao5eei66wof36n5e'
-    const result = false;
-    
+    const result = false
+
     await client.put(files)
     await client.get(cid)
     await client.list()
@@ -27,18 +26,18 @@ describe('test customFetch', () => {
 
   it('with customFetch', async () => {
     // @ts-ignore
-    let result = false;
+    let result = false
 
-    function customFetch(...opts) {
-      result = true;
+    function customFetch (...opts) {
+      result = true
 
-      fetch(...opts);
+      fetch(...opts)
     }
 
     const client = new Web3Storage({ endpoint, token, fetch: customFetch })
     const files = prepareFiles()
     const cid = 'bafkreifzjut3te2nhyekklss27nh3k72ysco7y32koao5eei66wof36n5e'
-    
+
     result = false
     await client.put(files)
     assert.is(result, true)
@@ -60,6 +59,6 @@ function prepareFiles () {
     new File(
       [data],
       '/dir/data.txt'
-    ),
+    )
   ]
 }

--- a/packages/client/test/custom-fetch.spec.js
+++ b/packages/client/test/custom-fetch.spec.js
@@ -47,7 +47,8 @@ describe('test customFetch', () => {
     assert.is(result, true)
 
     result = false
-    await client.list()
+    for await (const item of client.list()) {
+    }
     assert.is(result, true)
   })
 })

--- a/packages/client/test/custom-fetch.spec.js
+++ b/packages/client/test/custom-fetch.spec.js
@@ -1,7 +1,7 @@
 /* eslint-env mocha */
 import * as assert from 'uvu/assert'
 import { Web3Storage } from 'web3.storage'
-import { File } from '../src/platform.js'
+import { File, fetch } from '../src/platform.js'
 
 describe('test customFetch', () => {
   const { AUTH_TOKEN, API_PORT } = process.env

--- a/packages/client/test/custom-fetch.spec.js
+++ b/packages/client/test/custom-fetch.spec.js
@@ -35,7 +35,7 @@ describe('test customFetch', () => {
       fetch(...opts);
     }
 
-    const client = new Web3Storage({ endpoint, token, customFetch })
+    const client = new Web3Storage({ endpoint, token, fetch: customFetch })
     const files = prepareFiles()
     const cid = 'bafkreifzjut3te2nhyekklss27nh3k72ysco7y32koao5eei66wof36n5e'
     

--- a/packages/client/test/custom-fetch.spec.js
+++ b/packages/client/test/custom-fetch.spec.js
@@ -1,0 +1,65 @@
+/* eslint-env mocha */
+import * as assert from 'uvu/assert'
+import { Web3Storage } from 'web3.storage'
+import { File } from '../src/platform.js'
+
+describe('test customFetch', () => {
+  const { AUTH_TOKEN, API_PORT } = process.env
+  const token = AUTH_TOKEN || 'good'
+  const endpoint = new URL(API_PORT ? `http://localhost:${API_PORT}` : '')
+  
+
+  it('without customFetch', async () => {
+    // @ts-ignore
+    const client = new Web3Storage({ endpoint, token })
+    const files = prepareFiles()
+    const cid = 'bafkreifzjut3te2nhyekklss27nh3k72ysco7y32koao5eei66wof36n5e'
+    const result = false;
+    
+    await client.put(files)
+    await client.get(cid)
+    await client.list()
+
+    assert.is(result, false)
+    assert.is(result, false)
+    assert.is(result, false)
+  })
+
+  it('with customFetch', async () => {
+    // @ts-ignore
+    let result = false;
+
+    function customFetch(...opts) {
+      result = true;
+
+      fetch(...opts);
+    }
+
+    const client = new Web3Storage({ endpoint, token, customFetch })
+    const files = prepareFiles()
+    const cid = 'bafkreifzjut3te2nhyekklss27nh3k72ysco7y32koao5eei66wof36n5e'
+    
+    result = false
+    await client.put(files)
+    assert.is(result, true)
+
+    result = false
+    await client.get(cid)
+    assert.is(result, true)
+
+    result = false
+    await client.list()
+    assert.is(result, true)
+  })
+})
+
+function prepareFiles () {
+  const data = 'Hello web3.storage!'
+
+  return [
+    new File(
+      [data],
+      '/dir/data.txt'
+    ),
+  ]
+}

--- a/packages/client/test/custom-fetch.spec.js
+++ b/packages/client/test/custom-fetch.spec.js
@@ -47,7 +47,9 @@ describe('test customFetch', () => {
     assert.is(result, true)
 
     result = false
+    const uploads = []
     for await (const item of client.list()) {
+      uploads.push(item)
     }
     assert.is(result, true)
   })


### PR DESCRIPTION
I need to process some headers, like the cookie. because I post the request to my service and do some validation and then I create a proxy request to forward the request to your server. so, I need to add the `credentials: "include"` option to the `requestInit` option.

therefore, I add the `pre` middleware to achieve that, it will pass the requestInit to the user, and the user modifies and returns it to the client before the request is sent.