### PR TITLE
fix: swap the order of `corsOptions` and `envAll` to avoid error

### DIFF
--- a/packages/api/src/index.js
+++ b/packages/api/src/index.js
@@ -21,8 +21,8 @@ import { nameGet, nameWatchGet, namePost } from './name.js'
 import { compose } from './utils/fn.js'
 
 const router = Router()
-router.options('*', corsOptions)
 router.all('*', envAll)
+router.options('*', corsOptions)
 
 router.get('*', withMode(READ_ONLY))
 router.head('*', withMode(READ_ONLY))


### PR DESCRIPTION
Otherwise, for OPTIONS requests, the `corsOptions` function returns a response, meaning that `envAll` is never called, and so when the router tries to call `env.log.end()` we get an error.

This is fixing something which I broke with #1270.

The problem is that in packages/api/src/index.js at the top we now do this:

```js
const router = Router()
router.options('*', corsOptions)
router.all('*', envAll)
```

and then further down we do this:

```js
await env.log.end(response)
return response
```

But the `corsOptions` function is not a middleware - it actually returns a response. So for an options request, the `envAll` never gets called, and so `env.log` is `undefined` and the `env.log.end()` causes an error.

The solution is simply to put the `envAll` call first. This fixes the problem and also means that we now log the response times of our OPTIONS requests to Logtail.