### PR TITLE
chore: add test for CORS OPTIONS handler

### DIFF
--- a/packages/api/src/utils/logs.js
+++ b/packages/api/src/utils/logs.js
@@ -42,6 +42,7 @@ export class Logging {
     this.logEventsBatch = []
     this.startTs = Date.now()
     this.currentTs = this.startTs
+    this._finished = false
 
     const cf = request.cf
     let rCf
@@ -145,6 +146,12 @@ export class Logging {
    * @param {Response} response
    */
   async end (response) {
+    if (this._finished) {
+      throw new Error(
+        `end() has already been called on this Logging instance.
+        You must make a new instance per request.`
+      )
+    }
     if (this.opts?.debug) {
       response.headers.set('Server-Timing', this._timersString())
     }
@@ -171,7 +178,7 @@ export class Logging {
       await this.postBatch()
     }
     this.ctx.waitUntil(run())
-
+    this._finished = true
     return response
   }
 
@@ -276,7 +283,7 @@ export class Logging {
     if (!timeObj) {
       return console.warn(`No such name ${name}`)
     }
-
+    this._times.delete(name)
     const end = Date.now()
     const duration = end - timeObj.start
     const value = duration

--- a/packages/api/src/utils/logs.js
+++ b/packages/api/src/utils/logs.js
@@ -152,6 +152,7 @@ export class Logging {
         You must make a new instance per request.`
       )
     }
+    this._finished = true
     if (this.opts?.debug) {
       response.headers.set('Server-Timing', this._timersString())
     }
@@ -178,7 +179,6 @@ export class Logging {
       await this.postBatch()
     }
     this.ctx.waitUntil(run())
-    this._finished = true
     return response
   }
 

--- a/packages/api/test/cors.spec.js
+++ b/packages/api/test/cors.spec.js
@@ -25,4 +25,19 @@ describe('CORS', () => {
     assert.strictEqual(res.status, 500, 'Expected 500 on /error')
     assert.strictEqual(res.headers.get('Access-Control-Allow-Origin'), '*')
   })
+
+  it('correctly responds to preflight request', async () => {
+    const res = await fetch(new URL('version', endpoint), {
+      method: 'OPTIONS',
+      headers: {
+        Origin: 'web3.storage',
+        'Access-Control-Request-Method': 'whatever',
+        'Access-Control-Request-Headers': 'whatever'
+      }
+    })
+    assert(res.ok)
+    assert.strictEqual(res.status, 204, 'Expected 204 status for OPTIONS request')
+    assert.strictEqual(res.headers.get('Access-Control-Allow-Origin'), 'web3.storage')
+    assert.strictEqual(res.headers.get('Access-Control-Allow-Methods'), 'GET,POST,DELETE,OPTIONS')
+  })
 })


### PR DESCRIPTION
This is a follow-up from #1329, adding a test for the functionality that I broke. But it warrants a bit more explanation…

* The `envAll` middleware attaches a `Logging` instance to `env.log`. This should be a new instance for each request.
* The `corsOptions` function is not a middleware in the eyes of the itty-router, because it returns a response, and so the router then skips all other middlwares and just returns that response. This means that, if `corsOptions` is registered before `envAll` then the `Logging` instance is never attached to `env.log` and so when our main `fetch` function tries to call `env.log.end(response)` it dies trying to access the non-existent `env.log` property.
* BUT!... that problem only occurs if the OPTIONS request is the first request made to the server. If a GET/POST/DELETE/ request has already successfully completed then the `env.log` will already be set, and that will be **reused for the next request** thus causing:
    1. the problem to be silently hidden; and 
    2. the old `Logging` instance to be reused, including all its metadata, which may include the User ID from the previous request 😱 . (This User ID is only used for logging purposes, so it's nothing disastrous, but it will cause us to log misleading information.)
* This little quirk means that the test I've added here doesn't catch the problem that was fixed in #1329 without the additional thing that I've added, which is…

I've made the `Logging.end` method blow up if you call it twice, thereby preventing it being reused on a second request. This seems to me like a reasonable solution, and it makes the test that I've added catch the problem that #1329 fixed.  But alternative solutions could be:

1. Store the `Logging` instance on `request.log` rather than `env.log`, because the request is guaranteed to be new for each request.
2. Move to a more "proper" middleware setup, where there's a clear distinction between middlewares and handler functions, and where each middleware is therefore guaranteed to be run.

I'm happy to implement idea 1, if we think that's better, or to stick with the solution I've done. Idea 2 is probably beyond the scope of this PR.