### PR TITLE
fix: Remove mistakenly generated link in file manager header

### DIFF
--- a/packages/website/components/account/filesManager/fileRowItem.js
+++ b/packages/website/components/account/filesManager/fileRowItem.js
@@ -73,6 +73,7 @@ const FileRowItem = props => {
   const statusMessages = fileRowLabels.status.tooltip;
   /** @type {import('react').RefObject<HTMLTextAreaElement>} */
   const editingNameRef = useRef(null);
+  const truncatedCID = useMemo(() => truncateString(cid, 5, '...', 'double'), [cid]);
   const statusTooltip = useMemo(
     () =>
       ({
@@ -125,14 +126,18 @@ const FileRowItem = props => {
           <Tooltip content={fileRowLabels.cid.tooltip} />
           {fileRowLabels.cid.label}
         </span>
-        <a
-          className="cid-truncate underline medium-up-only"
-          href={`https://dweb.link/ipfs/${cid}`}
-          target="_blank"
-          rel="noreferrer"
-        >
-          {useMemo(() => truncateString(cid, 5, '...', 'double'), [cid])}
-        </a>
+        {isHeader ? (
+          <span className="cid-full medium-up-only">{cid}</span>
+        ) : (
+          <a
+            className="cid-truncate underline medium-up-only"
+            href={`https://dweb.link/ipfs/${cid}`}
+            target="_blank"
+            rel="noreferrer"
+          >
+            {truncatedCID}
+          </a>
+        )}
         <span className="cid-full medium-down-only">{cid}</span>
         {isHeader ? (
           <Tooltip content={fileRowLabels.cid.tooltip} />


### PR DESCRIPTION
The mistakenly generated link on the CID header item in the app UI file manager has been removed and replaced with regular text:

![Screen Shot 2022-05-17 at 3 49 38 PM](https://user-images.githubusercontent.com/53056774/168897904-fa47209a-4161-429a-a4a1-72d1d16d06c2.png)


