### PR TITLE
fix: Set fetch date before changing isFetching state

### DIFF
--- a/packages/website/components/contexts/uploadsContext.js
+++ b/packages/website/components/contexts/uploadsContext.js
@@ -152,8 +152,8 @@ export const UploadsProvider = ({ children }) => {
       setIsFetchingUploads(true);
       const updatedUploads = await getUploads(args);
       setUploads(updatedUploads);
-      setIsFetchingUploads(false);
       setFetchDate(Date.now());
+      setIsFetchingUploads(false);
 
       return updatedUploads;
     },


### PR DESCRIPTION
Changing the order of execution of the `fetchDate` state change and `isFetchingUploads` state change in the uploads context fixed the problem of requesting the uploads list twice.