### PR TITLE
fix: typo in Logging constructor

### DIFF
--- a/packages/api/src/env.js
+++ b/packages/api/src/env.js
@@ -106,7 +106,7 @@ export function envAll (req, env, ctx) {
   // Note that we pass `ctx` as the `event` param here, because it's kind of both:
   // https://developers.cloudflare.com/workers/runtime-apis/fetch-event/#syntax-module-worker
   env.log = new Logging(req, ctx, {
-    token: env.log = env.LOGTAIL_TOKEN,
+    token: env.LOGTAIL_TOKEN,
     debug: env.DEBUG === 'true',
     sentry: env.sentry,
     version: env.VERSION,


### PR DESCRIPTION
I assume this is a typo?

@adamalton can you also look into this logger running during testing in CI?

https://github.com/web3-storage/web3.storage/runs/6553500624?check_suite_focus=true