### PR TITLE
chore: update API and Website Readmes

### DIFF
--- a/packages/api/README.md
+++ b/packages/api/README.md
@@ -29,10 +29,13 @@ Kill the process to stop miniflare, then run `npm run stop` to shutdown the clus
 npm run stop
 ```
 
-## Setting up a cloudflare worker
-While in most cases the [Getting Started](#getting-started) section is enough to develop locally, if you want to test and preview you worker on Cloudflare's infrastructure here's the instructions to setup your worker and environment.  
+You may need to make sure the underlying DB is populated with the required tables.
+Please follow the instructions in the [Populate Database](../../packages/db/README.md#2-populate-database) section in the db package README.
 
-If you want more in depth information please look at [Cloudflare Get Started guide](https://developers.cloudflare.com/workers/get-started/guide#1-sign-up-for-a-workers-account).  
+## Setting up a cloudflare worker
+While in most cases the [Getting Started](#getting-started) section is enough to develop locally, if you want to test and preview you worker on Cloudflare's infrastructure here's the instructions to setup your worker and environment.
+
+If you want more in depth information please look at [Cloudflare Get Started guide](https://developers.cloudflare.com/workers/get-started/guide#1-sign-up-for-a-workers-account).
 
 The following instructions assume that you did go through the Getting started section.
 
@@ -40,12 +43,12 @@ The following instructions assume that you did go through the Getting started se
 Before you can start publishing your Workers on your own domain or a free *.workers.dev subdomain, you must sign up for a Cloudflare Workers account
 ### 2. Install the Workers CLI
 Install `wrangler` cli on your local machine
-```bash 
+```bash
 npm install -g @cloudflare/wrangler
 ```
 ### 3. Configure the Workers CLI
 With installation complete, wrangler will need access to a Cloudflare OAuth token to manage Workers resources on your behalf.
-```bash 
+```bash
 wrangler login
 ```
 Open the browser, log into your account, and select Allow.

--- a/packages/website/README.md
+++ b/packages/website/README.md
@@ -30,7 +30,7 @@ NEXT_PUBLIC_API=http://127.0.0.1:8787
 NEXT_PUBLIC_MAGIC=<magic test mode publishable key>
 ```
 
-for local debugging API:
+To hit the local mock API:
 
 ```ini
 NEXT_PUBLIC_ENV=dev


### PR DESCRIPTION
Updating the readme to address a few issues I found when setting up the project. 

- When running the API using the readme in `packages/api/README.md` I missed the DB  _"Load schema"_ step resulting in some confusion when trying to log in. Thought I'd add this context in the API readme.
- I got a little confused when running the website, I didn't realise running my env vars for "for local debugging API" meant I'd be using the mock API and not my local API, so updated some text here.

Hope that's okay!

Thanks