### PR TITLE
chore: drop the Mailchimp API client library

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3885,25 +3885,6 @@
       "integrity": "sha512-CvVUPTF9tSLNFA4JhcAFjheiqWyVp9r9ooy/AheK+0rWRZCxE5QCwc81d2FduDTqzEJZeUV9+9F9R0AplhnX7w==",
       "license": "MIT"
     },
-    "node_modules/@mailchimp/mailchimp_transactional": {
-      "version": "1.0.47",
-      "resolved": "https://registry.npmjs.org/@mailchimp/mailchimp_transactional/-/mailchimp_transactional-1.0.47.tgz",
-      "integrity": "sha512-dZ45jWALktR4+/mMnUprSodWdnVHprrXK0uxPo9mUShihBNHIOeHGYoxahsTyhqPPx6lVu7nNj96VLzomUL1YQ==",
-      "dependencies": {
-        "axios": "^0.21.1"
-      },
-      "engines": {
-        "node": ">=10.0.0"
-      }
-    },
-    "node_modules/@mailchimp/mailchimp_transactional/node_modules/axios": {
-      "version": "0.21.4",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
-      "integrity": "sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==",
-      "dependencies": {
-        "follow-redirects": "^1.14.0"
-      }
-    },
     "node_modules/@mdx-js/loader": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/@mdx-js/loader/-/loader-2.1.1.tgz",
@@ -27413,7 +27394,6 @@
       "version": "1.0.0",
       "license": "(Apache-2.0 OR MIT)",
       "dependencies": {
-        "@mailchimp/mailchimp_transactional": "^1.0.47",
         "@nftstorage/ipfs-cluster": "^5.0.1",
         "@web-std/fetch": "^2.0.1",
         "@web3-storage/db": "^4.0.0",
@@ -40096,24 +40076,6 @@
       "resolved": "https://registry.npmjs.org/@magic-sdk/types/-/types-1.6.0.tgz",
       "integrity": "sha512-CvVUPTF9tSLNFA4JhcAFjheiqWyVp9r9ooy/AheK+0rWRZCxE5QCwc81d2FduDTqzEJZeUV9+9F9R0AplhnX7w=="
     },
-    "@mailchimp/mailchimp_transactional": {
-      "version": "1.0.47",
-      "resolved": "https://registry.npmjs.org/@mailchimp/mailchimp_transactional/-/mailchimp_transactional-1.0.47.tgz",
-      "integrity": "sha512-dZ45jWALktR4+/mMnUprSodWdnVHprrXK0uxPo9mUShihBNHIOeHGYoxahsTyhqPPx6lVu7nNj96VLzomUL1YQ==",
-      "requires": {
-        "axios": "^0.21.1"
-      },
-      "dependencies": {
-        "axios": {
-          "version": "0.21.4",
-          "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
-          "integrity": "sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==",
-          "requires": {
-            "follow-redirects": "^1.14.0"
-          }
-        }
-      }
-    },
     "@mdx-js/loader": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/@mdx-js/loader/-/loader-2.1.1.tgz",
@@ -41901,7 +41863,6 @@
     "@web3-storage/cron": {
       "version": "file:packages/cron",
       "requires": {
-        "@mailchimp/mailchimp_transactional": "^1.0.47",
         "@nftstorage/ipfs-cluster": "^5.0.1",
         "@types/node": "^16.3.1",
         "@web-std/fetch": "^2.0.1",

--- a/packages/cron/package.json
+++ b/packages/cron/package.json
@@ -17,7 +17,6 @@
   "author": "Alan Shaw",
   "license": "(Apache-2.0 OR MIT)",
   "dependencies": {
-    "@mailchimp/mailchimp_transactional": "^1.0.47",
     "@nftstorage/ipfs-cluster": "^5.0.1",
     "@web-std/fetch": "^2.0.1",
     "@web3-storage/db": "^4.0.0",


### PR DESCRIPTION
Call the end point directly instead.

This is based on Hugo's suggestion in #1273.