### PR TITLE
chore: do not convert bigint to number

### DIFF
--- a/packages/cron/src/jobs/storage.js
+++ b/packages/cron/src/jobs/storage.js
@@ -65,7 +65,7 @@ export async function checkStorageUsed ({ db, emailService }) {
       if (email.emailType === EMAIL_TYPE.User100PercentStorage) {
         const adminUser = await db.getUserByEmail('admin@web3.storage')
         const toAdmin = {
-          _id: Number(adminUser._id),
+          _id: adminUser._id,
           email: adminUser.email,
           name: adminUser.name
         }
@@ -82,7 +82,7 @@ export async function checkStorageUsed ({ db, emailService }) {
 
       for (const user of users) {
         const to = {
-          _id: Number(user.id),
+          _id: user.id,
           email: user.email,
           name: user.name
         }

--- a/packages/cron/src/lib/email/service.js
+++ b/packages/cron/src/lib/email/service.js
@@ -39,7 +39,7 @@ export class EmailService {
    * Send an email to a user.
    * Optionally checks email sending history for this user and email type to avoid
    * re-sending if user has been recently notified.
-   * @param {{_id: number, email: string, name: string}} user
+   * @param {{_id: string, email: string, name: string}} user
    * @param {string} emailType
    * @param {Object} [options]
    * @param {number} [options.secondsSinceLastSent]

--- a/packages/cron/test/email.spec.js
+++ b/packages/cron/test/email.spec.js
@@ -20,7 +20,7 @@ const env = {
   PG_REST_URL: 'http://localhost:3000',
   PG_REST_JWT: 'eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJzdXBhYmFzZSIsImlhdCI6MTYwMzk2ODgzNCwiZXhwIjoyNTUwNjUzNjM0LCJyb2xlIjoic2VydmljZV9yb2xlIn0.necIJaiP7X2T2QjGeV-FhpkizcNTX8HjDDBAxpgQTEI'
 }
-const aUser = { _id: 1, email: 'some.email@mail.com', name: 'aName' }
+const aUser = { _id: '1', email: 'some.email@mail.com', name: 'aName' }
 
 describe('Mail service', () => {
   let db

--- a/packages/db/db-client-types.ts
+++ b/packages/db/db-client-types.ts
@@ -359,12 +359,12 @@ export type Email = {
   type: definitions['email_history']['email_type']
 }
 export type EmailSentInput = {
-  userId: number,
+  userId: string,
   emailType: string,
   secondsSinceLastSent?: number
 }
 export type LogEmailSentInput = {
-  userId: number,
+  userId: string,
   emailType: string,
   messageId: string
 }

--- a/packages/db/test/email.spec.js
+++ b/packages/db/test/email.spec.js
@@ -20,21 +20,21 @@ describe('Email', () => {
 
     // check an email has not been sent
     let emailHasBeenSent = await dbClient.emailHasBeenSent({
-      userId: Number(user._id),
+      userId: user._id,
       emailType: EMAIL_TYPE[EMAIL_TYPE.User100PercentStorage]
     })
     assert.strictEqual(emailHasBeenSent, false, 'Has not been sent')
 
     // log an email
     await dbClient.logEmailSent({
-      userId: Number(user._id),
+      userId: user._id,
       emailType: EMAIL_TYPE[EMAIL_TYPE.User100PercentStorage],
       messageId: '1'
     })
 
     // check the email has already been sent today
     emailHasBeenSent = await dbClient.emailHasBeenSent({
-      userId: Number(user._id),
+      userId: user._id,
       emailType: EMAIL_TYPE[EMAIL_TYPE.User100PercentStorage],
       secondsSinceLastSent: 60 * 60 * 23
     })


### PR DESCRIPTION
We shouldn't be converting bigints to numbers to avoid integer overflow.