### PR TITLE
chore: send list of storage quota violators to support@web3.storage

### DIFF
--- a/packages/cron/src/jobs/storage.js
+++ b/packages/cron/src/jobs/storage.js
@@ -63,7 +63,7 @@ export async function checkStorageUsed ({ db, emailService }) {
 
     if (users.length) {
       if (email.emailType === EMAIL_TYPE.User100PercentStorage) {
-        const adminUser = await db.getUserByEmail('admin@web3.storage')
+        const adminUser = await db.getUserByEmail('support@web3.storage')
         const toAdmin = {
           _id: adminUser._id,
           email: adminUser.email,

--- a/packages/cron/test/storage.spec.js
+++ b/packages/cron/test/storage.spec.js
@@ -28,7 +28,7 @@ describe('cron - check user storage quotas', () => {
   beforeEach(async () => {
     emailService = new EmailService({ db: dbClient, provider: EMAIL_PROVIDERS.dummy })
     adminUser = await createUser(dbClient, {
-      email: 'admin@web3.storage',
+      email: 'support@web3.storage',
       name: 'Web3 Storage Admin'
     })
 
@@ -62,14 +62,14 @@ describe('cron - check user storage quotas', () => {
     assert.equal(emailService.provider.sendEmail.callCount, 4)
 
     // Admin email
-    emailService.provider.sendEmail.calledWith(EMAIL_TYPE.AdminStorageExceeded, 'admin@web3.storage')
+    emailService.provider.sendEmail.calledWith(EMAIL_TYPE.AdminStorageExceeded, 'support@web3.storage')
 
     // Users email
     emailService.provider.sendEmail.calledWith(EMAIL_TYPE.User75PercentStorage, 'test2@email.com')
     emailService.provider.sendEmail.calledWith(EMAIL_TYPE.User85PercentStorage, 'test3@email.com')
     emailService.provider.sendEmail.calledWith(EMAIL_TYPE.User100PercentStorage, 'test4@email.com')
 
-    const adminUser = await dbClient.getUserByEmail('admin@web3.storage')
+    const adminUser = await dbClient.getUserByEmail('support@web3.storage')
     assert.ok(adminUser, 'admin user found')
     const adminStorageExceeded = await dbClient.emailHasBeenSent({
       userId: Number(adminUser._id),

--- a/packages/db/postgres/migrations/010-add-admin-user.sql
+++ b/packages/db/postgres/migrations/010-add-admin-user.sql
@@ -5,7 +5,7 @@ INSERT INTO public.user (
   public_address
 )
 VALUES (
-  'admin@web3.storage',
+  'support@web3.storage',
   'Web3 Storage Admin',
   'Web3 Storage Admin',
   'Web3 Storage Admin'


### PR DESCRIPTION
As specified in #990, these notification emails should go to support@web3.storage, rather than admin@web3.storage.

I considered changing all the associated mentions of "admin" (e.g. "adminUser") to "support" as well, but I don't think it's worth it for the amount of disruption it would cause, and "admin" is still a valid label, we're just changing the email address.