### PR TITLE
docs: make readmes more self contained

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,30 +99,50 @@ You need an account on https://magic.link, and Docker running locally.
 
 Copy the <.env.tpl> file to `.env` and set the values for the `MAGIC_SECRET_KEY` & `NEXT_PUBLIC_MAGIC`, from your magic.link account dashboard.
 
-Then install the deps with `npm` and then run all the things with `npm start`
+Install the deps with `npm`
 
 ```console
 # install deps
 npm install
+```
 
+To be able to run the APIs you need to make sure the underlying [DB is populated with the required tables](./packages/db/README.md). 
+
+```console
+# init the db. requires docker running locally
+npm run load-schema -w packages/db
+```
+
+Run all the things with `npm start`,
+
+```console
 # start the api and website
 npm start
 ```
 
-To be able to run the APIs you need to make sure the underlying DB is populated with the required tables.
-Please follow the instructions in the [Populate Database](./packages/db/README.md#2-populate-database) section in the db package README.
+## Monorepo
 
+This project is a monorepo that uses [npm workspaces](https://docs.npmjs.com/cli/v7/using-npm/workspaces).
 
-To add a new workspace to the repo:
+All `npm` commands should be run from the root of the repo. To run a command for a specific package add the `--workspace` or `-w` flag
 
 ```console
-npm init -w ./packages/website
+# Start just the api
+npm start -w packages/api
+```
+
+To add a new workspace (aka package) to the monorepo
+
+```console
+# adds the path to the `website` package to the `workspaces` property in package.json
+npm init -w packages/website
 ```
 
 To run an npm script in one or more workspaces
 
 ```console
-npm run test --workspace=a --workspace=b
+# run test commmand in package `a` and `b`
+npm run test --workspace=packages/a --workspace=packages/b
 ```
 
 ## Testing

--- a/README.md
+++ b/README.md
@@ -106,18 +106,18 @@ Install the deps with `npm`
 npm install
 ```
 
-To be able to run the APIs you need to make sure the underlying [DB is populated with the required tables](./packages/db/README.md). 
-
-```console
-# init the db. requires docker running locally
-npm run load-schema -w packages/db
-```
-
-Run all the things with `npm start`,
+Run all the things with `npm start`. Double check you have Docker running first.
 
 ```console
 # start the api and website
 npm start
+```
+
+If it's your first run you need to [create the database schema](./packages/db/README.md).
+
+```console
+# init the db. Run me once after `npm start`, on first set up.
+npm run load-schema -w packages/db
 ```
 
 ## Monorepo

--- a/packages/api/README.md
+++ b/packages/api/README.md
@@ -3,22 +3,30 @@
 The HTTP interface implemented as a Cloudflare Worker
 
 ## Getting started
-Please follow the instructions in the main monorepo [Readme](../../README.md#getting-started) to setup the project.
 
-We use miniflare to run the api locally, and docker to run ipfs-cluster and postgres with PostgREST.
+We use miniflare to run the api locally, and docker to run ipfs-cluster and postgres with PostgREST. 
 
-If you want to run this package in isolation, you can easily do it as follows:
-Please be aware that you will need to have the environment variable setup as described in the root [README](../../README.md#getting-started).
+This project uses node v16 and npm v7. It's a monorepo that use [npm workspaces](https://docs.npmjs.com/cli/v7/using-npm/workspaces) to handle resolving dependencies between the local `packages/*` folders.
+
+To run it you will need:
+
+- node.js >= v16 installed
+- The dependencies installed. Run `npm i` from the root of the project.
+- The environment variables setup as described in the root [README](../../README.md#getting-started).
+- The web3.storage [datebase setup](../db/README.md)
+
+With docker running locally, from the monorepo root:
 
 ```sh
-# Install the deps
-npm install
+# first run you will need to set up the db, from the repo root:
+npm run load-schema -w packages/db
 ```
 
-With docker running locally, start all the things:
+start just the api:
 
-```
-npm start
+```sh
+# run me from the root of the monorepo!
+npm start -w packages/api
 ```
 
 🎉 miniflare is running in watch mode; you can save changes to the api code and the worker will update.
@@ -26,11 +34,10 @@ npm start
 Kill the process to stop miniflare, then run `npm run stop` to shutdown the cluster and postgres
 
 ```sh
-npm run stop
+# run me from the root of the monorepo!
+npm run stop -w packages/api
 ```
 
-You may need to make sure the underlying DB is populated with the required tables.
-Please follow the instructions in the [Populate Database](../../packages/db/README.md#2-populate-database) section in the db package README.
 
 ## Setting up a cloudflare worker
 While in most cases the [Getting Started](#getting-started) section is enough to develop locally, if you want to test and preview you worker on Cloudflare's infrastructure here's the instructions to setup your worker and environment.

--- a/packages/api/README.md
+++ b/packages/api/README.md
@@ -15,14 +15,7 @@ To run it you will need:
 - The environment variables setup as described in the root [README](../../README.md#building-web3storage).
 - The web3.storage [datebase setup](../db/README.md)
 
-With docker running locally, from the monorepo root:
-
-```sh
-# first run you will need to set up the db, from the repo root:
-npm run load-schema -w packages/db
-```
-
-start just the api:
+With docker running locally, from the monorepo root, start just the api:
 
 ```sh
 # run me from the root of the monorepo!
@@ -30,6 +23,13 @@ npm start -w packages/api
 ```
 
 🎉 miniflare is running in watch mode; you can save changes to the api code and the worker will update.
+
+If it's your first run you need to [create the database schema](../db/README.md).
+
+```sh
+# init the db. Run me once after `npm start`, on first set up.
+npm run load-schema -w packages/db
+```
 
 Kill the process to stop miniflare, then run `npm run stop` to shutdown the cluster and postgres
 

--- a/packages/api/README.md
+++ b/packages/api/README.md
@@ -12,7 +12,7 @@ To run it you will need:
 
 - node.js >= v16 installed
 - The dependencies installed. Run `npm i` from the root of the project.
-- The environment variables setup as described in the root [README](../../README.md#getting-started).
+- The environment variables setup as described in the root [README](../../README.md#building-web3storage).
 - The web3.storage [datebase setup](../db/README.md)
 
 With docker running locally, from the monorepo root:


### PR DESCRIPTION
it's not super fun to have to read multiple readmes to get a project started.

Inspired by @joshJarr in #1353  this PR pulls the minimum steps to get a working set up into the main and api readme.

License: (Apache-2.0 AND MIT)
Signed-off-by: Oli Evans <oli@tableflip.io>