### PR TITLE
chore: fix tags in api user info

### DIFF
--- a/packages/api/test/fixtures/init-data.sql
+++ b/packages/api/test/fixtures/init-data.sql
@@ -97,7 +97,9 @@ VALUES (
 );
 
 INSERT INTO user_tag (user_id, tag, value, reason, deleted_at)
-VALUES  (4, 'HasPsaAccess', true, 'test', null),
+VALUES  (1, 'HasPsaAccess', true, 'test', '2021-07-14T19:27:14.934572+00:00'),
+        (1, 'HasPsaAccess', false, 'test', null),
+        (4, 'HasPsaAccess', true, 'test', null),
         (5, 'HasPsaAccess', true, 'test', null),
         (6, 'HasPsaAccess', true, 'test', null),
         (5, 'HasAccountRestriction', true, 'Revoked access', '2021-07-14T19:27:14.934572+00:00'),

--- a/packages/api/test/fixtures/init-data.sql
+++ b/packages/api/test/fixtures/init-data.sql
@@ -97,9 +97,7 @@ VALUES (
 );
 
 INSERT INTO user_tag (user_id, tag, value, reason, deleted_at)
-VALUES  (1, 'HasPsaAccess', true, 'test', '2021-07-14T19:27:14.934572+00:00'),
-        (1, 'HasPsaAccess', false, 'test', null),
-        (4, 'HasPsaAccess', true, 'test', null),
+VALUES  (4, 'HasPsaAccess', true, 'test', null),
         (5, 'HasPsaAccess', true, 'test', null),
         (6, 'HasPsaAccess', true, 'test', null),
         (5, 'HasAccountRestriction', true, 'Revoked access', '2021-07-14T19:27:14.934572+00:00'),

--- a/packages/api/test/scripts/helpers.js
+++ b/packages/api/test/scripts/helpers.js
@@ -10,6 +10,7 @@ import { JWT_ISSUER } from '../../src/constants.js'
 import { SALT } from './worker-globals.js'
 import { sha256 } from 'multiformats/hashes/sha2'
 import * as pb from '@ipld/dag-pb'
+import { DBClient } from '@web3-storage/db'
 
 const libp2pKeyCode = 0x72
 const lifetime = 1000 * 60 * 60
@@ -61,4 +62,19 @@ export function getTestJWT (sub = 'test-magic-issuer', name = 'test-magic-issuer
 export async function randomCid (code = pb.code) {
   const hash = await sha256.digest(Buffer.from(`${Math.random()}`))
   return CID.create(1, code, hash).toString()
+}
+
+/**
+ * Create a new DB client instance from the current environment variables.
+ */
+export function getDBClient () {
+  const token = process.env.PG_REST_JWT
+  const endpoint = process.env.PG_REST_URL
+  if (!token) {
+    throw new Error('missing PG_REST_JWT environment var')
+  }
+  if (!endpoint) {
+    throw new Error('missing PG_REST_URL environment var')
+  }
+  return new DBClient({ token, endpoint, postgres: true })
 }

--- a/packages/api/test/scripts/helpers.js
+++ b/packages/api/test/scripts/helpers.js
@@ -54,7 +54,6 @@ export async function updateNameRecord (privKey, existingRecord, newValue) {
 export function getTestJWT (sub = 'test-magic-issuer', name = 'test-magic-issuer') {
   return JWT.sign({ sub, iss: JWT_ISSUER, iat: 1633957389872, name }, SALT)
 }
-
 /**
  * @param {number} code
  * @returns {Promise<string>}

--- a/packages/api/test/user.spec.js
+++ b/packages/api/test/user.spec.js
@@ -2,8 +2,9 @@
 import assert from 'assert'
 import fetch from '@web-std/fetch'
 import { endpoint } from './scripts/constants.js'
-import { getTestJWT } from './scripts/helpers.js'
+import { getDBClient, getTestJWT } from './scripts/helpers.js'
 import userUploads from './fixtures/pgrest/get-user-uploads.js'
+import { createUser, createUserAuthKey } from '@web3-storage/db/test-utils'
 
 describe('GET /user/account', () => {
   it('error if not authenticated with magic.link', async () => {
@@ -30,6 +31,40 @@ describe('GET /user/account', () => {
     const data = await res.json()
     assert.strictEqual(data.usedStorage.uploaded, 32000)
     assert.strictEqual(data.usedStorage.psaPinned, 10000)
+  })
+})
+
+describe('GET /user/info', () => {
+  let dbClient
+
+  before(async () => {
+    dbClient = getDBClient()
+  })
+
+  it('error if not authenticated with magic.link', async () => {
+    const token = await getTestJWT()
+    const res = await fetch(new URL('user/account', endpoint), {
+      headers: { Authorization: `Bearer ${token}` }
+    })
+    assert(!res.ok)
+    assert.strictEqual(res.status, 401)
+  })
+
+  it('error if no auth header', async () => {
+    const res = await fetch(new URL('user/account', endpoint))
+    assert(!res.ok)
+    assert.strictEqual(res.status, 401)
+  })
+
+  it('retrieves user account data', async () => {
+    // Token of a user that has PSA enabled
+    const token = 'test-magic'
+
+    const res = await fetch(new URL('user/info', endpoint), {
+      headers: { Authorization: `Bearer ${token}` }
+    })
+    const userInfo = await res.json()
+    assert.strictEqual(userInfo.info.tags.HasPsaAccess, false)
   })
 })
 

--- a/packages/api/test/user.spec.js
+++ b/packages/api/test/user.spec.js
@@ -2,9 +2,8 @@
 import assert from 'assert'
 import fetch from '@web-std/fetch'
 import { endpoint } from './scripts/constants.js'
-import { getDBClient, getTestJWT } from './scripts/helpers.js'
+import { getTestJWT } from './scripts/helpers.js'
 import userUploads from './fixtures/pgrest/get-user-uploads.js'
-import { createUser, createUserAuthKey } from '@web3-storage/db/test-utils'
 
 describe('GET /user/account', () => {
   it('error if not authenticated with magic.link', async () => {
@@ -35,12 +34,6 @@ describe('GET /user/account', () => {
 })
 
 describe('GET /user/info', () => {
-  let dbClient
-
-  before(async () => {
-    dbClient = getDBClient()
-  })
-
   it('error if not authenticated with magic.link', async () => {
     const token = await getTestJWT()
     const res = await fetch(new URL('user/account', endpoint), {

--- a/packages/db/index.js
+++ b/packages/db/index.js
@@ -42,7 +42,7 @@ const userQueryWithTags = `
   publicAddress:public_address,
   created:inserted_at,
   updated:updated_at,
-  tags:user_tag_user_id_fkey(user_id,id,tag,value)
+  tags:user_tag_user_id_fkey(user_id,id,tag,value, deleted_at)
 `
 
 const psaPinRequestTableName = 'psa_pin_request'
@@ -173,7 +173,7 @@ export class DBClient {
 
   /**
    * Create a user tag
-   * @param {number} userId
+   * @param {string} userId
    * @param {Object} [tag]
    * @param {string} [tag.tag]
    * @param {string} [tag.value]


### PR DESCRIPTION
#1302 introduced showing a message to the user if their account is restricted, but the way that it fetches the rows from the `user_tag` table doesn't fetch the `deleted_at` column, so it will return the wrong value when there's a deleted tag. This fixes that bug.

I've done this as a "chore" because the changes in #1302 aren't deployed to the website yet, so if this can be merged before they're deployed then this won't become a user-facing bug, hence chore rather than fix.