### PR TITLE
chore: fix typedefs for user tag functions

### DIFF
--- a/packages/api/src/utils/tags.js
+++ b/packages/api/src/utils/tags.js
@@ -1,7 +1,7 @@
 /**
  * @param {import('@web3-storage/db/db-client-types').UserOutput} user
  * @param {string} tagName
- * @param {string|undefined} defaultValue
+ * @param {string} [defaultValue]
  * @returns {string|undefined}
  */
 export function getTagValue (user, tagName, defaultValue) {

--- a/packages/api/src/utils/tags.js
+++ b/packages/api/src/utils/tags.js
@@ -1,3 +1,9 @@
+/**
+ * @param {import('@web3-storage/db/db-client-types').UserOutput} user
+ * @param {string} tagName
+ * @param {string|undefined} defaultValue
+ * @returns {string|undefined}
+ */
 export function getTagValue (user, tagName, defaultValue) {
   return (
     user.tags?.find((tag) => tag.tag === tagName && !tag.deleted_at)?.value ||
@@ -5,6 +11,12 @@ export function getTagValue (user, tagName, defaultValue) {
   )
 }
 
+/**
+ * @param {import('@web3-storage/db/db-client-types').UserOutput} user
+ * @param {string} tagName
+ * @param {string} value
+ * @returns {boolean}
+ */
 export function hasTag (user, tagName, value) {
   return Boolean(
     user.tags?.find(

--- a/packages/db/db-client-types.ts
+++ b/packages/db/db-client-types.ts
@@ -15,6 +15,10 @@ export type UpsertUserOutput = {
   issuer: string
 }
 
+export type GetUserOptions = {
+  includeTags?: boolean
+}
+
 export type User = definitions['user']
 
 export type UserOutput = {
@@ -22,10 +26,17 @@ export type UserOutput = {
   name: definitions['user']['name'],
   email: definitions['user']['email'],
   issuer: definitions['user']['issuer'],
-  github?: definitions['user']['github']
-  publicAddress: definitions['user']['public_address']
+  github?: definitions['user']['github'],
+  publicAddress: definitions['user']['public_address'],
   created: definitions['user']['inserted_at'],
-  updated: definitions['user']['updated_at']
+  updated: definitions['user']['updated_at'],
+  tags?: Array<UserTagInfo>
+}
+
+export type UserTagInfo = {
+  tag: definitions['user_tag']['tag']
+  value: definitions['user_tag']['value']
+  deleted_at?: definitions['user_tag']['deleted_at']
 }
 
 export type UserTagInput = {

--- a/packages/db/index.d.ts
+++ b/packages/db/index.d.ts
@@ -32,6 +32,7 @@ import type {
   UserStorageUsedOutput,
   StorageUsedOutput,
   UserTagInput,
+  UserTagInfo,
   EmailSentInput,
   LogEmailSentInput,
   GetUserOptions,
@@ -44,7 +45,7 @@ export class DBClient {
   client: PostgrestClient
   getMetricsValue (key: string): Promise<{ total: number }>
   upsertUser (user: UpsertUserInput): Promise<UpsertUserOutput>
-  getUser (issuer: string): Promise<UserOutput>
+  getUser(issuer: string, options: GetUserOptions): Promise<UserOutput>
   getUserByEmail (email: string): Promise<UserOutput>
   getStorageUsed (userId: number): Promise<StorageUsedOutput>
   getUsersByStorageUsed (percentRange: UserStorageUsedInput): Promise<Array<UserStorageUsedOutput>>
@@ -78,7 +79,7 @@ export class DBClient {
   deleteKey (id: number): Promise<void>
   query<T, V>(document: RequestDocument, variables: V): Promise<T>
   createUserTag(userId: string, tag: UserTagInput): Promise<boolean>
-  getUserTags(userId: string, options: GetUserOptions): Promise<{ tag: string, value: string }[]>
+  getUserTags(userId: string): Promise<UserTagInfo[]>
 }
 
 export { EMAIL_TYPE } from './constants.js'

--- a/packages/db/index.d.ts
+++ b/packages/db/index.d.ts
@@ -34,6 +34,7 @@ import type {
   UserTagInput,
   EmailSentInput,
   LogEmailSentInput,
+  GetUserOptions,
 } from './db-client-types'
 
 export { gql }
@@ -76,8 +77,8 @@ export class DBClient {
   createContent (content: ContentInput, opt?: {updatePinRequests?: boolean}) : Promise<string>
   deleteKey (id: number): Promise<void>
   query<T, V>(document: RequestDocument, variables: V): Promise<T>
-  createUserTag(userId: number, tag: UserTagInput): Promise<boolean>
-  getUserTags (userId: number): Promise<{ tag: string, value: string }[]>
+  createUserTag(userId: string, tag: UserTagInput): Promise<boolean>
+  getUserTags(userId: string, options: GetUserOptions): Promise<{ tag: string, value: string }[]>
 }
 
 export { EMAIL_TYPE } from './constants.js'

--- a/packages/db/index.js
+++ b/packages/db/index.js
@@ -179,7 +179,7 @@ export class DBClient {
    * @returns {Promise<boolean>}
    */
   async createUserTag (userId, tag) {
-    if (!tag || !tag.tag) {
+    if (!tag?.tag) {
       throw new Error('createUserTag requires a tag')
     }
     const { data: deleteData, status: deleteStatus } = await this._client

--- a/packages/db/index.js
+++ b/packages/db/index.js
@@ -175,7 +175,7 @@ export class DBClient {
   /**
    * Create a user tag
    * @param {string} userId
-   * @param {import('./db-client-types').UserTagInput?} tag
+   * @param {import('./db-client-types').UserTagInput} tag
    * @returns {Promise<boolean>}
    */
   async createUserTag (userId, tag) {
@@ -244,8 +244,8 @@ export class DBClient {
   /**
    * Returns all the active (non-deleted) user tags for a user id.
    *
-   * @param {number} userId
-   * @returns {Promise<{ tag: string, value: string }[]>}
+   * @param {string} userId
+   * @returns {Promise<import('./db-client-types').UserTagInfo[]>}
    */
   async getUserTags (userId) {
     const { data, error } = await this._client

--- a/packages/db/index.js
+++ b/packages/db/index.js
@@ -178,7 +178,10 @@ export class DBClient {
    * @param {import('./db-client-types').UserTagInput?} tag
    * @returns {Promise<boolean>}
    */
-  async createUserTag (userId, tag = {}) {
+  async createUserTag (userId, tag) {
+    if (!tag || !tag.tag) {
+      throw new Error('createUserTag requires a tag')
+    }
     const { data: deleteData, status: deleteStatus } = await this._client
       .from('user_tag')
       .update({

--- a/packages/db/index.js
+++ b/packages/db/index.js
@@ -136,6 +136,7 @@ export class DBClient {
    * Get user by its issuer.
    *
    * @param {string} issuer
+   * @param {import('./db-client-types').GetUserOptions?} options
    * @return {Promise<import('./db-client-types').UserOutput | undefined>}
    */
   async getUser (issuer, { includeTags } = { includeTags: false }) {
@@ -174,10 +175,7 @@ export class DBClient {
   /**
    * Create a user tag
    * @param {string} userId
-   * @param {Object} [tag]
-   * @param {string} [tag.tag]
-   * @param {string} [tag.value]
-   * @param {string} [tag.reason]
+   * @param {import('./db-client-types').UserTagInput?} tag
    * @returns {Promise<boolean>}
    */
   async createUserTag (userId, tag = {}) {


### PR DESCRIPTION
This just tidies up the typedefs for some of the user tag related functions where were changed/added in #1322, and also improves the function signature of the `createUserTag` function.