### PR TITLE
chore: trigger crons workflow on conf change

### DIFF
--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -5,11 +5,11 @@ on:
       - main
     paths:
       - 'packages/cron/**'
-      - '.github/workflows/cron.yml'
+      - '.github/workflows/cron*'
   pull_request:
     paths:
       - 'packages/cron/**'
-      - '.github/workflows/cron.yml'
+      - '.github/workflows/cron*'
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
# Problem description
This [PR](https://github.com/web3-storage/web3.storage/pull/1371) did not create a related cron release.
At the moment we trigger the cron test and release workflows on `packages/cron/**` and `.github/workflows/cron.yml`.

## Expected behaviour
All cron conf changes should trigger it to make sure updates to those files create a new release. 

