### PR TITLE
fix: clone env so new each request

### DIFF
--- a/packages/api/src/index.js
+++ b/packages/api/src/index.js
@@ -130,6 +130,7 @@ export default {
   async fetch (request, env, ctx) {
     let response
     try {
+      env = { ...env } // new env object for every request (it is shared otherwise)!
       response = await router.handle(request, env, ctx)
     } catch (error) {
       response = serverError(error, request, env)


### PR DESCRIPTION
Not sure if this will fix the error but it's worth a try and feels unlikely to break anything.

Reading through [this](https://github.com/web3-storage/web3.storage/pull/1331) it sounds as though env is **not** a new object for each request 😱