### PR TITLE
fix: cloudflare loader in #1361

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24218,7 +24218,7 @@
     },
     "packages/api": {
       "name": "@web3-storage/api",
-      "version": "5.7.3",
+      "version": "6.0.0",
       "license": "(Apache-2.0 OR MIT)",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.53.1",
@@ -27551,7 +27551,7 @@
     },
     "packages/website": {
       "name": "@web3-storage/website",
-      "version": "2.4.0",
+      "version": "2.4.1",
       "dependencies": {
         "@docsearch/react": "^3.0.0",
         "@magic-ext/oauth": "^0.7.0",

--- a/packages/website/.eslintrc.js
+++ b/packages/website/.eslintrc.js
@@ -12,6 +12,10 @@ module.exports = {
     'plugin:prettier/recommended',
     'plugin:cypress/recommended',
   ],
+  env: {
+    browser: true,
+    es2020: true,
+  },
   parser: '@typescript-eslint/parser',
   parserOptions: {
     ecmaVersion: 9, // Allows for the parsing of modern ECMAScript features
@@ -26,8 +30,8 @@ module.exports = {
       },
       alias: [
         ['ZeroComponents', './modules/zero/components'],
-        ['ZeroHooks', './modules/zero/hooks']
-      ]
+        ['ZeroHooks', './modules/zero/hooks'],
+      ],
     },
     react: {
       version: 'detect',

--- a/packages/website/.prettierrc
+++ b/packages/website/.prettierrc
@@ -1,7 +1,6 @@
 {
-    "arrowParens": "avoid",
-    "printWidth": 120,
-    "singleQuote": true,
-    "trailingComma": "es5"
-  }
-  
+  "arrowParens": "avoid",
+  "printWidth": 120,
+  "singleQuote": true,
+  "trailingComma": "es5"
+}

--- a/packages/website/assets/illustrations/blobs.js
+++ b/packages/website/assets/illustrations/blobs.js
@@ -1,10 +1,12 @@
-import Img from 'components/cloudflareImage';
+import Img from '../../components/cloudflareImage.js';
+import ImgBlobs from '../../public/images/illustrations/blobs.png';
+
 /**
  * @param {any} props
  */
 const Blobs = props => (
   <div {...props}>
-    <Img width="600" height="600" className="image-full-width" alt="" src="/images/illustrations/blobs.png" />
+    <Img alt="" src={ImgBlobs} />
   </div>
 );
 

--- a/packages/website/assets/illustrations/ring.js
+++ b/packages/website/assets/illustrations/ring.js
@@ -1,11 +1,12 @@
-import Img from 'components/cloudflareImage';
+import Img from '../../components/cloudflareImage.js';
+import ImgRing from '../../public/images/illustrations/ring.png';
 
 /**
  * @param {any} props
  */
 const Ring = props => (
   <div {...props}>
-    <Img width="900" height="900" className="image-full-width" alt="" src="/images/illustrations/ring.png" />
+    <Img alt="" src={ImgRing} priority />
   </div>
 );
 

--- a/packages/website/assets/illustrations/squiggle.js
+++ b/packages/website/assets/illustrations/squiggle.js
@@ -1,12 +1,14 @@
-import Img from 'components/cloudflareImage';
-
+import Img from '../../components/cloudflareImage.js';
+import ImgSquiggle from '../../public/images/illustrations/squiggle.png';
 /**
  * @param {any} props
  */
-const Squiggle = props => (
-  <div {...props}>
-    <Img className="image-full-width" alt="" src="/images/illustrations/squiggle.png" width="464" height="464" />
-  </div>
-);
+const Squiggle = props => {
+  return (
+    <div {...props}>
+      <Img src={ImgSquiggle} />
+    </div>
+  );
+};
 
 export default Squiggle;

--- a/packages/website/components/account/fileUploader/fileUploader.scss
+++ b/packages/website/components/account/fileUploader/fileUploader.scss
@@ -42,7 +42,7 @@
     padding: 1.875rem 0;
     background: rgba($white, 0.1);
     border: solid;
-    border-image: url('/images/illustration/dashed-border.png') 2 round;
+    border-image: url('/images/illustrations/dashed-border.png') 2 round;
     @include borderRadius_Large;
   }
 

--- a/packages/website/components/card/card.scss
+++ b/packages/website/components/card/card.scss
@@ -274,7 +274,7 @@
         width: 2.25rem;
         height: 100%;
         padding: 0.75rem 0;
-        background-image: url('/images/illustration/zigzag-tiny.png');
+        background-image: url('/images/illustrations/zigzag-tiny.png');
         background-position: 0 4px;
         background-size: 0 1.75rem;
         background-repeat: no-repeat;

--- a/packages/website/components/cloudflareImage.js
+++ b/packages/website/components/cloudflareImage.js
@@ -1,36 +1,49 @@
 import Image from 'next/image';
 
 /**
+ * @typedef {{src: string, height: number, width: number, blurDataURL: string}} ImageImport
+ */
+
+const normalizeSrc = (/** @type {string} */ src) => {
+  return src.startsWith('/') ? src.slice(1) : src;
+};
+/**
  * Logo Component
+ *
  * @param  {Object} logo
  * @param  {string} logo.src
  * @param  {number} logo.width
  * @param  {number} [logo.quality]
  */
-const cloudflareImageLoader = ({ src, width, quality = 75 }) =>
-  `/cdn-cgi/image/format=auto,width=${width},quality=${quality}${src}`;
+const cloudflareImageLoader = ({ src, width, quality = 75 }) => {
+  let source = normalizeSrc(src);
+
+  return `https://images.web3.storage/width=${width},quality=${quality}/${source}`;
+};
 
 /**
  * @param {{
- *  src: string
+ *  src: string | ImageImport
  *  width?: number | string
  *  height?: number | string
  *  alt?: string
  *  className?: string
  *  layout?: import('next/image').ImageProps['layout']
+ *  priority?: import('next/image').ImageProps['priority']
  * }} props
  * @returns
  */
-export default function Img({ src, alt, width, height, className, layout }) {
-  if (src.includes('.svg') || src.includes('https://')) {
+export default function Img({ src, alt, width, height, className, layout, priority }) {
+  if (typeof src === 'string' && src.includes('.svg')) {
     // eslint-disable-next-line @next/next/no-img-element
     return <img src={src} alt={alt} width={width} height={height} className={className} />;
   }
-  if (process.env.NODE_ENV === 'development') {
-    return (
-      <Image unoptimized src={src} alt={alt} width={width} height={height} className={className} layout={layout} />
-    );
+
+  if (typeof src === 'object' && src.src && src.src.includes('.svg')) {
+    // eslint-disable-next-line @next/next/no-img-element
+    return <img src={src.src} alt={alt} width={width} height={height} className={className} />;
   }
+
   return (
     <Image
       src={src}
@@ -40,6 +53,7 @@ export default function Img({ src, alt, width, height, className, layout }) {
       className={className}
       layout={layout}
       loader={cloudflareImageLoader}
+      priority={priority}
     />
   );
 }

--- a/packages/website/components/footer/footer.scss
+++ b/packages/website/components/footer/footer.scss
@@ -107,7 +107,7 @@ $footerLogoWidth: 2.25rem;
       width: 2.25rem;
       height: 100%;
       padding: 0.75rem 0;
-      background-image: url('/images/illustration/zigzag-tiny.png');
+      background-image: url('/images/illustrations/zigzag-tiny.png');
       background-position: 0 4px;
       background-size: 0 1.75rem;
       background-repeat: no-repeat;

--- a/packages/website/components/hero-illustration.js
+++ b/packages/website/components/hero-illustration.js
@@ -1,0 +1,18 @@
+import Img from './cloudflareImage.js';
+
+/**
+ * Hero Illustration Component
+ *
+ * @param {Object} props
+ * @param {string | import('./cloudflareImage.js').ImageImport} props.src
+ * @param {string} props.id - Wrapper id
+ * @param {string} [props.className] - Wrapper classname. Defaults: 'hero-illustration'
+ * @param {boolean} [props.priority] - Image priority
+ */
+const HeroIllustration = props => (
+  <div id={props.id} className={props.className || 'hero-illustration'}>
+    <Img alt="" src={props.src} priority={props.priority || true} />
+  </div>
+);
+
+export default HeroIllustration;

--- a/packages/website/components/hero/hero.js
+++ b/packages/website/components/hero/hero.js
@@ -15,6 +15,10 @@ import Spring from '../../assets/illustrations/spring';
 import Cone from '../../assets/illustrations/cone';
 import Fidget from '../../assets/illustrations/fidget';
 import Blobs from '../../assets/illustrations/blobs';
+import HeroIllustration from '../../components/hero-illustration';
+import ImageCorkscrew from '../../public/images/illustrations/corkscrew.png';
+import ImageRing from '../../public/images/illustrations/ring.png';
+import ImageSpring from '../../public/images/illustrations/spring.png';
 
 // ====================================================================== Params
 /**
@@ -34,9 +38,9 @@ export default function Hero({ block }) {
         <Triangle id="error_hero-triangle-3" className={'hero-illustration'} />
         <Cross id="error_hero-cross-1" className={'hero-illustration'} />
         <Cross id="error_hero-cross-2" className={'hero-illustration'} />
-        <Corkscrew id="error_hero-corkscrew" className={'hero-illustration'} />
-        <Ring id="error_hero-ring" className={'hero-illustration'} />
-        <Spring id="error_hero-spring" className={'hero-illustration'} />
+        <HeroIllustration id="error_hero-corkscrew" src={ImageCorkscrew} />
+        <HeroIllustration id="error_hero-ring" src={ImageRing} />
+        <HeroIllustration id="error_hero-spring" src={ImageSpring} />
       </>
     );
   };

--- a/packages/website/components/hero/hero.scss
+++ b/packages/website/components/hero/hero.scss
@@ -367,14 +367,14 @@
 #faq_hero_title-triangle {
   &:after {
     transform: scaleX(-1) rotate(-90deg);
-    background-image: url('/images/illustration/triangle.png');
+    background-image: url('/images/illustrations/triangle.png');
   }
 }
 
 #faq_hero_title-coil {
   &:after {
     transform: rotate(31deg);
-    background-image: url('/images/illustration/coil.png');
+    background-image: url('/images/illustrations/coil.png');
     @include small {
       display: none;
     }

--- a/packages/website/components/imageblock/imageblock.js
+++ b/packages/website/components/imageblock/imageblock.js
@@ -1,6 +1,6 @@
 import clsx from 'clsx';
 
-import Img from 'components/cloudflareImage';
+import Img from '../cloudflareImage.js';
 
 /**
  * @param {Object} props.block
@@ -10,7 +10,7 @@ export default function ImageBlock({ block }) {
     <>
       {block.src && (
         <div id={block.id} className={clsx('block', 'image-block')}>
-          <Img layout="fill" alt={block.alt} src={block.src} width={block.width} height={block.height} />
+          <Img layout="fill" alt={block.alt} src={block.src} />
           <div className={'image-label'}>{block.label}</div>
         </div>
       )}

--- a/packages/website/components/navigation/navigation.scss
+++ b/packages/website/components/navigation/navigation.scss
@@ -257,7 +257,7 @@
       width: 2.25rem;
       height: 100%;
       padding: 0.75rem 0;
-      background-image: url('/images/illustration/zigzag-tiny.png');
+      background-image: url('/images/illustrations/zigzag-tiny.png');
       background-position: 0 4px;
       background-size: 0 1.75rem;
       background-repeat: no-repeat;

--- a/packages/website/declaration.d.ts
+++ b/packages/website/declaration.d.ts
@@ -1,3 +1,6 @@
 declare module '*.css';
 declare module '*.scss';
 declare module '*.svg';
+declare module '*.png';
+declare module '*.jpg';
+declare module '*.gif';

--- a/packages/website/modules/docs-theme/index.scss
+++ b/packages/website/modules/docs-theme/index.scss
@@ -5,7 +5,7 @@
 @import 'docspagination/docspagination';
 
 .docs-site {
-  background-image: url('/images/illustration/corkscrewBlurred.jpg');
+  background-image: url('/images/illustrations/corkscrewBlurred.jpg');
   background-repeat: repeat;
   background-size: cover;
   word-break: break-word;
@@ -44,7 +44,7 @@
     position: relative;
 
     &:before {
-      background-image: url('/images/illustration/triangle1.png');
+      background-image: url('/images/illustrations/triangle1.png');
       background-repeat: no-repeat;
       background-size: contain;
       height: 72px;
@@ -62,7 +62,7 @@
     .docs-body-container {
       flex: 1;
       display: flex;
-      background-color: hsla(0,0%,95%,.6);
+      background-color: hsla(0, 0%, 95%, 0.6);
       border-radius: 0.375rem;
       box-shadow: 0 4px 15px rgb(0 0 0 / 15%);
       padding: 6.125vw 1.5vw 6.125vw 6.75vw;
@@ -84,7 +84,8 @@
         }
       }
 
-      ul, ol {
+      ul,
+      ol {
         padding-left: 1rem;
         li {
           padding-left: 3rem;
@@ -97,7 +98,8 @@
       tr {
         text-align: left;
         border-top: 1px solid rgb(204, 204, 204);
-        td, th {
+        td,
+        th {
           border: 1px solid #dbdada;
           padding: 0 10px;
         }
@@ -162,11 +164,10 @@
     pre {
       white-space: pre-wrap;
       word-wrap: break-word;
-      
     }
     code {
       @include monospace_Text;
-      font-size: .875rem;
+      font-size: 0.875rem;
       line-height: 1.25rem;
     }
     pre code {
@@ -177,7 +178,7 @@
       min-width: 100%;
       color: white;
       padding: 1rem;
-      font-size: .875rem;
+      font-size: 0.875rem;
       line-height: 1.25rem;
     }
     a {
@@ -186,7 +187,11 @@
       border-bottom: none;
       padding-bottom: 0;
     }
-    h1 a, h2 a, h3 a, h4 a, h5 a {
+    h1 a,
+    h2 a,
+    h3 a,
+    h4 a,
+    h5 a {
       color: $ebony;
     }
     img {

--- a/packages/website/modules/docs-theme/sidebar/sidebar.scss
+++ b/packages/website/modules/docs-theme/sidebar/sidebar.scss
@@ -62,7 +62,7 @@
     }
   }
   &:before {
-    background-image: url('/images/illustration/helix.png');
+    background-image: url('/images/illustrations/helix.png');
     background-size: cover;
     height: 18rem;
     left: -3.5rem;

--- a/packages/website/tsconfig.json
+++ b/packages/website/tsconfig.json
@@ -4,10 +4,7 @@
     "allowJs": true,
     "checkJs": true,
     "target": "esnext",
-    "lib": [
-      "ESNext",
-      "DOM"
-    ],
+    "lib": ["ESNext", "DOM", "DOM.Iterable"],
     "strict": true,
     "moduleResolution": "node",
     "sourceMap": true,
@@ -23,34 +20,14 @@
     "noImplicitAny": false,
     "baseUrl": "./",
     "paths": {
-      "ZeroComponents/*": [
-        "modules/zero/components/*"
-      ],
-      "ZeroHooks/*": [
-        "modules/zero/hooks/*"
-      ],
-      "web3.storage": [
-        "../client"
-      ]
+      "ZeroComponents/*": ["modules/zero/components/*"],
+      "ZeroHooks/*": ["modules/zero/hooks/*"],
+      "web3.storage": ["../client"]
     },
     "incremental": true
   },
-  "include": [
-    "lib",
-    "pages",
-    "components",
-    "content",
-    "hooks",
-    "modules",
-    "store",
-    "declaration.d.ts"
-  ],
-  "exclude": [
-    "node_modules",
-    ".next/",
-    "{pages,components,content,hooks,modules}/**/*.js",
-    "lib/countly.js"
-  ],
+  "include": ["lib", "pages", "components", "content", "hooks", "modules", "store", "declaration.d.ts"],
+  "exclude": ["node_modules", "public", ".next/", "{pages,components,content,hooks,modules}/**/*.js", "lib/countly.js"],
   "references": [
     {
       "path": "../client"


### PR DESCRIPTION
This PR is based on #1361 and should be merged to it directly not main! The changes in this PR should serve as a reference to be applied to the rest of the code, see notes below. 

- fix css urls for illustrations, there was several bad urls in css should probably check if the visuals are still good!!
- new cloudflare image loader that works in dev, preview urls and production.
- new HeroIllustration comp with good defaults and for hero images 

Notes:
- All images should be imported and not hardcoded as string paths
- HeroIllustration comp should be used instead of the per image component
- Local images should not have hardcoded width and height, these should come from the images import
- Per illustration component should be deleted in favor of HeroIllustration or similar.