### PR TITLE
fix: optimise getUserByStorage query to avoid timeouts

### DIFF
--- a/packages/cron/README.md
+++ b/packages/cron/README.md
@@ -3,6 +3,8 @@
 
 Resist chaos! Periodically update the db with exciting new facts about the size of pins and anything else that doesn't need to be on the critical path.
 
+Notify users when they are approaching or exceeding their storage quota, and notify admins of any users who are exceeding their quota.
+
 ## Getting started
 
 Ensure you have all the dependencies, by running `npm i` in the parent project.


### PR DESCRIPTION
This is really just an inconsequential change to allow the creation of a "fix:" PR so that the release-please bot will make a release.

The reason for this is that #1405 was accidentally named with a "chore:" prefix rather than a "fix:" prefix, and so when it was merged the _release-please_ bot didn't create a release. I considered several possible ways to rectify this, but this solution seemed like the least messy: just create a new PR with a "fix:" prefix which makes an inconsequential change.

Hence, this branch name is prefixed `chore/` (because the change is insignificant), but this PR is prefixed "fix:" so that we now get a release generated for releasing #1405!