### PR TITLE
chore: use NODE_TLS_REJECT_UNAUTHORIZED=0 env var for storage cron job

### DIFF
--- a/packages/cron/package.json
+++ b/packages/cron/package.json
@@ -10,7 +10,7 @@
     "start:metrics": "NODE_TLS_REJECT_UNAUTHORIZED=0 node src/bin/metrics.js",
     "start:pins": "node src/bin/pins.js",
     "start:dagcargo:sizes": "NODE_TLS_REJECT_UNAUTHORIZED=0 node src/bin/dagcargo-sizes.js",
-    "start:storage": "node src/bin/storage.js",
+    "start:storage": "NODE_TLS_REJECT_UNAUTHORIZED=0 node src/bin/storage.js",
     "test": "npm-run-all -p -r test:e2e",
     "test:e2e": "mocha --require ./test/hooks.js test/*.spec.js --timeout 5000"
   },


### PR DESCRIPTION
As with the other cron jobs, without this we get a connection error.
We might want to address this more properly at some point.