### PR TITLE
fix: change batching strategy for user storage cron

### DIFF
--- a/packages/cron/src/jobs/storage.js
+++ b/packages/cron/src/jobs/storage.js
@@ -18,7 +18,7 @@ SELECT max(id)::TEXT as max FROM (
   SELECT id FROM public.user
   WHERE id >= $1
   ORDER BY id
-  LIMIT $1
+  LIMIT $2
 ) as user_range
 `
 

--- a/packages/cron/src/jobs/storage.js
+++ b/packages/cron/src/jobs/storage.js
@@ -125,8 +125,8 @@ export async function checkStorageUsed ({ roPg, emailService, userBatchSize = 10
         }
       }
 
-      const maxFetchedId = users.pop().id
-      if (maxFetchedId >= maxId) {
+      const maxFetchedId = users.length ? users.pop().id : null
+      if (maxFetchedId === null || maxFetchedId >= maxId) {
         log('🗄 Reached last user')
         break
       } else {

--- a/packages/cron/src/jobs/storage.js
+++ b/packages/cron/src/jobs/storage.js
@@ -16,7 +16,7 @@ const MAX_USER_ID_QUERY = `
 const ID_RANGE_QUERY = `
 SELECT max(id)::TEXT as max FROM (
   SELECT id FROM public.user
-  WHERE id >= $1
+  WHERE id > $1
   ORDER BY id
   LIMIT $2
 ) as user_range
@@ -97,7 +97,7 @@ export async function checkStorageUsed ({ roPg, emailService, userBatchSize = 10
 
   for (const email of STORAGE_QUOTA_EMAILS) {
     const usersOverQuota = []
-    let startId = 0
+    let startId = BigInt(0)
 
     while (true) {
       // We iterate in batches, but we can't use a simple LIMIT/OFFSET approach, because
@@ -150,7 +150,7 @@ export async function checkStorageUsed ({ roPg, emailService, userBatchSize = 10
         log('🗄 Reached last user')
         break
       } else {
-        startId += userBatchSize
+        startId = maxIdOfBatch
       }
     }
 

--- a/packages/cron/src/jobs/storage.js
+++ b/packages/cron/src/jobs/storage.js
@@ -14,10 +14,12 @@ const MAX_USER_ID_QUERY = `
 `
 
 const ID_RANGE_QUERY = `
- SELECT max(id)::TEXT as max from public.user
- WHERE id >= $1
- ORDER BY id
- LIMIT $1
+SELECT max(id)::TEXT as max FROM (
+  SELECT id FROM public.user
+  WHERE id >= $1
+  ORDER BY id
+  LIMIT $1
+) as user_range
 `
 
 const USER_BY_EMAIL_QUERY = `

--- a/packages/cron/src/jobs/storage.js
+++ b/packages/cron/src/jobs/storage.js
@@ -125,7 +125,7 @@ export async function checkStorageUsed ({ roPg, emailService, userBatchSize = 10
         }
       }
 
-      const maxFetchedId = users.length ? users.pop().id : null
+      const maxFetchedId = users.length ? BigInt(users.pop().id) : null
       if (maxFetchedId === null || maxFetchedId >= maxId) {
         log('🗄 Reached last user')
         break

--- a/packages/db/postgres/functions.sql
+++ b/packages/db/postgres/functions.sql
@@ -296,8 +296,8 @@ $$;
 CREATE OR REPLACE FUNCTION users_by_storage_used(
   from_percent INTEGER,
   to_percent INTEGER DEFAULT NULL,
-  start_id BIGINT DEFAULT 0,
-  end_id BIGINT DEFAULT NULL
+  user_id_gt BIGINT DEFAULT 0,
+  user_id_lte BIGINT DEFAULT NULL
 )
   RETURNS TABLE
     (
@@ -333,8 +333,8 @@ BEGIN
         AND r.value ILIKE 'true'
         AND r.deleted_at IS NULL
       )
-      AND u.id >= start_id
-      AND u.id < end_id
+      AND u.id > user_id_gt
+      AND u.id <= user_id_lte
     )
     SELECT *
     FROM user_account

--- a/packages/db/postgres/functions.sql
+++ b/packages/db/postgres/functions.sql
@@ -297,7 +297,7 @@ CREATE OR REPLACE FUNCTION users_by_storage_used(
   from_percent INTEGER,
   to_percent INTEGER DEFAULT NULL,
   start_id BIGINT DEFAULT 0,
-  max_results INTEGER DEFAULT NULL
+  end_id BIGINT DEFAULT NULL
 )
   RETURNS TABLE
     (
@@ -334,8 +334,7 @@ BEGIN
         AND r.deleted_at IS NULL
       )
       AND u.id >= start_id
-      ORDER BY u.id
-      LIMIT max_results
+      AND u.id < end_id
     )
     SELECT *
     FROM user_account

--- a/packages/db/postgres/functions.sql
+++ b/packages/db/postgres/functions.sql
@@ -297,7 +297,7 @@ CREATE OR REPLACE FUNCTION users_by_storage_used(
   from_percent INTEGER,
   to_percent INTEGER DEFAULT NULL,
   start_id BIGINT DEFAULT 0,
-  end_id BIGINT DEFAULT NULL
+  max_results INTEGER DEFAULT NULL
 )
   RETURNS TABLE
     (
@@ -334,8 +334,8 @@ BEGIN
         AND r.deleted_at IS NULL
       )
       AND u.id >= start_id
-      AND (end_id is NULL OR  u.id < end_id)
-      ORDER BY u.inserted_at
+      ORDER BY u.id
+      LIMIT max_results
     )
     SELECT *
     FROM user_account

--- a/packages/db/postgres/migrations/015-update-user-by-storage-used.sql
+++ b/packages/db/postgres/migrations/015-update-user-by-storage-used.sql
@@ -51,22 +51,3 @@ BEGIN
     ORDER BY user_account.storage_used::BIGINT DESC;
 END
 $$;
-
-CREATE OR REPLACE FUNCTION upsert_pins(data json) RETURNS TEXT[]
-    LANGUAGE plpgsql
-    volatile
-    PARALLEL UNSAFE
-AS
-$$
-DECLARE
-  pin json;
-  pin_ids TEXT[];
-BEGIN
-  FOREACH pin IN array json_arr_to_json_element_array(data -> 'pins')
-  LOOP
-    SELECT pin_ids || upsert_pin(pin -> 'data') INTO pin_ids;
-  END LOOP;
-
-  RETURN pin_ids;
-END
-$$;

--- a/packages/db/postgres/migrations/015-update-user-by-storage-used.sql
+++ b/packages/db/postgres/migrations/015-update-user-by-storage-used.sql
@@ -5,7 +5,7 @@ CREATE OR REPLACE FUNCTION users_by_storage_used(
   from_percent INTEGER,
   to_percent INTEGER DEFAULT NULL,
   start_id BIGINT DEFAULT 0,
-  max_results INTEGER DEFAULT NULL
+  end_id BIGINT DEFAULT NULL
 )
   RETURNS TABLE
     (
@@ -42,8 +42,7 @@ BEGIN
         AND r.deleted_at IS NULL
       )
       AND u.id >= start_id
-      ORDER BY u.id
-      LIMIT max_results
+      AND u.id < end_id
     )
     SELECT *
     FROM user_account

--- a/packages/db/postgres/migrations/015-update-user-by-storage-used.sql
+++ b/packages/db/postgres/migrations/015-update-user-by-storage-used.sql
@@ -5,7 +5,7 @@ CREATE OR REPLACE FUNCTION users_by_storage_used(
   from_percent INTEGER,
   to_percent INTEGER DEFAULT NULL,
   start_id BIGINT DEFAULT 0,
-  end_id BIGINT DEFAULT NULL
+  max_results INTEGER DEFAULT NULL
 )
   RETURNS TABLE
     (
@@ -42,8 +42,8 @@ BEGIN
         AND r.deleted_at IS NULL
       )
       AND u.id >= start_id
-      AND (end_id is NULL OR  u.id < end_id)
-      ORDER BY u.inserted_at
+      ORDER BY u.id
+      LIMIT max_results
     )
     SELECT *
     FROM user_account

--- a/packages/db/postgres/migrations/016-add-upload-user-id-index.sql
+++ b/packages/db/postgres/migrations/016-add-upload-user-id-index.sql
@@ -1,0 +1,1 @@
+CREATE INDEX IF NOT EXISTS upload_user_id_idx ON upload (user_id);

--- a/packages/db/postgres/pg-rest-api-types.d.ts
+++ b/packages/db/postgres/pg-rest-api-types.d.ts
@@ -1626,6 +1626,10 @@ export interface paths {
             to_percent?: number;
             /** Format: integer */
             from_percent: number;
+            /** Format: integer */
+            start_id?: number;
+            /** Format: integer */
+            max_results?: number;
           };
         };
         header: {

--- a/packages/db/postgres/pg-rest-api-types.d.ts
+++ b/packages/db/postgres/pg-rest-api-types.d.ts
@@ -1627,9 +1627,9 @@ export interface paths {
             /** Format: integer */
             from_percent: number;
             /** Format: integer */
-            start_id?: number;
+            user_id_gt?: number;
             /** Format: integer */
-            max_results?: number;
+            user_id_lte?: number;
           };
         };
         header: {

--- a/packages/db/postgres/tables.sql
+++ b/packages/db/postgres/tables.sql
@@ -269,6 +269,7 @@ CREATE TABLE IF NOT EXISTS upload
 CREATE INDEX IF NOT EXISTS upload_auth_key_id_idx ON upload (auth_key_id);
 CREATE INDEX IF NOT EXISTS upload_content_cid_idx ON upload (content_cid);
 CREATE INDEX IF NOT EXISTS upload_updated_at_idx ON upload (updated_at);
+CREATE INDEX IF NOT EXISTS upload_user_id_idx ON upload (user_id);
 
 -- Tracks requests to replicate content to more nodes.
 CREATE TABLE IF NOT EXISTS pin_request


### PR DESCRIPTION
Previously we were using ID ranges. But the IDs of rows in the `public.user` table are not consecutive/sequential. So when we tried this on staging it went a bit like this:

1. Lowest user ID is 5, highest user ID is 314286764840715234.
2. It splits that range into chunks of 1000, giving us over 300 trillion batches to work through, just to iterate over 79 users.
3. The internet melts.

This PR changes the batches strategy to the form `SELECT ... WHERE id > highest_id_of_last_batch LIMIT users_per_batch`., which will hopefully go better.

Given that the `015` migration hasn't yet been run on production, I've modified it, rather than making a new one. It's already been run on staging, but running the modified version should be fine.