### PR TITLE
chore: increase the timeout for the `beforeAll` hook for cron tests

### DIFF
--- a/packages/cron/test/hooks.js
+++ b/packages/cron/test/hooks.js
@@ -25,7 +25,7 @@ export const mochaHooks = () => {
 
   return {
     async beforeAll () {
-      this.timeout(60_000)
+      this.timeout(120_000)
 
       console.log('⚡️ Starting IPFS Cluster')
       projectCluster = `web3-storage-cluster-${Date.now()}`


### PR DESCRIPTION
Fixes #1450