### PR TITLE
chore: add API endpoint to test instanceof behaviour on Cloudflare

### DIFF
--- a/packages/api/src/index.js
+++ b/packages/api/src/index.js
@@ -19,6 +19,7 @@ import {
 import { notFound } from './utils/json-response.js'
 import { nameGet, nameWatchGet, namePost } from './name.js'
 import { compose } from './utils/fn.js'
+import { cloudflareInstanceofTest } from './temporary.js'
 
 const router = Router()
 router.all('*', envAll)
@@ -89,6 +90,8 @@ router.post('/user/tokens',              auth['👤'](userTokensPost))
 router.delete('/user/tokens/:id',        auth['👤🗑️'](userTokensDelete))
 router.get('/user/account',              auth['👤'](userAccountGet))
 router.get('/user/info',                 auth['👤'](userInfoGet))
+
+router.get('/cloudflare-instanceof-test', cloudflareInstanceofTest)
 /* eslint-enable no-multi-spaces */
 
 // Monitoring

--- a/packages/api/src/temporary.js
+++ b/packages/api/src/temporary.js
@@ -9,9 +9,9 @@ import { JSONResponse } from './utils/json-response.js'
  * to an ES6 module. So this view function is to allow us to test whether this problem
  * still occurs on Cloudflare or not.
  */
-export function cloudflareInstanceofTest(request, env) {
+export function cloudflareInstanceofTest (request, env) {
   const httpError = new HTTPError('I am an HTTP error')
-  const bugExhibited = httpError instanceof PinningServiceApiError;
+  const bugExhibited = httpError instanceof PinningServiceApiError
   const data = { bugExhibited }
   return new JSONResponse(data)
 }

--- a/packages/api/src/temporary.js
+++ b/packages/api/src/temporary.js
@@ -1,0 +1,17 @@
+import { HTTPError, PinningServiceApiError } from './errors.js'
+import { JSONResponse } from './utils/json-response.js'
+
+/** We have previously seen a bug where on a Cloudflare Worker
+ *     `err instanceof PinningServiceApiError`
+ * was true for any `err` which was a subclass of `Error`. But locally and in the CI it
+ * behaved as expected.
+ * We suspect that this problem may now have been fixed now that we've changed our worker
+ * to an ES6 module. So this view function is to allow us to test whether this problem
+ * still occurs on Cloudflare or not.
+ */
+export function cloudflareInstanceofTest(request, env) {
+  const httpError = new HTTPError('I am an HTTP error')
+  const bugExhibited = httpError instanceof PinningServiceApiError;
+  const data = { bugExhibited }
+  return new JSONResponse(data)
+}


### PR DESCRIPTION
This is for testing whether the strange behaviour that's described in #976 is still occurring on Cloudflare.