### PR TITLE
chore: use `instanceof` for error type inference

### DIFF
--- a/packages/api/src/error-handler.js
+++ b/packages/api/src/error-handler.js
@@ -1,9 +1,9 @@
 import { ErrorCode as MagicErrors } from '@magic-sdk/admin'
 import { JSONResponse } from './utils/json-response.js'
-import { HTTPError } from './errors.js'
+import { HTTPError, PinningServiceApiError } from './errors.js'
 
 /**
- * @param {Error & {status?: number;code?: string;reason?: string; details?: string; IS_PSA_ERROR?: boolean;}} err
+ * @param {Error & {status?: number;code?: string;reason?: string; details?: string; }} err
  * @param {import('./env').Env} env
  */
 export function errorHandler (err, { log }) {
@@ -13,9 +13,7 @@ export function errorHandler (err, { log }) {
 
   log.error(err)
 
-  // TODO: improve error handler
-  // https://github.com/web3-storage/web3.storage/issues/976
-  if (err.IS_PSA_ERROR) {
+  if (err instanceof PinningServiceApiError) {
     const error = {
       reason: err.reason,
       details: err.details


### PR DESCRIPTION
This is a fix for #976, which, if #1462 shows that the bug no longer exists, we can merge.