### PR TITLE
fix: update getPg to automatically connect to the db

### DIFF
--- a/packages/cron/src/bin/dagcargo-sizes.js
+++ b/packages/cron/src/bin/dagcargo-sizes.js
@@ -11,8 +11,8 @@ import { getPg } from '../lib/utils.js'
 const xDaysAgo = (days) => new Date().setDate(new Date().getDate() - days)
 
 async function main () {
-  const rwPg = getPg(process.env, 'rw')
-  const roPg = getPg(process.env, 'ro')
+  const rwPg = await getPg(process.env, 'rw')
+  const roPg = await getPg(process.env, 'ro')
 
   try {
     const after = new Date(process.env.AFTER || xDaysAgo(7))

--- a/packages/cron/src/bin/metrics.js
+++ b/packages/cron/src/bin/metrics.js
@@ -5,8 +5,8 @@ import { envConfig } from '../lib/env.js'
 import { getPgPool } from '../lib/utils.js'
 
 async function main () {
-  const rwPg = await getPgPool(process.env, 'rw')
-  const roPg = await getPgPool(process.env, 'ro')
+  const rwPg = getPgPool(process.env, 'rw')
+  const roPg = getPgPool(process.env, 'ro')
 
   try {
     await updateMetrics({ rwPg, roPg })

--- a/packages/cron/src/bin/metrics.js
+++ b/packages/cron/src/bin/metrics.js
@@ -5,8 +5,8 @@ import { envConfig } from '../lib/env.js'
 import { getPgPool } from '../lib/utils.js'
 
 async function main () {
-  const rwPg = getPgPool(process.env, 'rw')
-  const roPg = getPgPool(process.env, 'ro')
+  const rwPg = await getPgPool(process.env, 'rw')
+  const roPg = await getPgPool(process.env, 'ro')
 
   try {
     await updateMetrics({ rwPg, roPg })

--- a/packages/cron/src/bin/storage.js
+++ b/packages/cron/src/bin/storage.js
@@ -7,7 +7,7 @@ import { envConfig } from '../lib/env.js'
 
 async function main () {
   const db = getDBClient(process.env)
-  const roPg = getPg(process.env, 'ro')
+  const roPg = await getPg(process.env, 'ro')
   const emailService = new EmailService({ db })
   await checkStorageUsed({ roPg, emailService })
 }

--- a/packages/cron/src/lib/utils.js
+++ b/packages/cron/src/lib/utils.js
@@ -45,12 +45,14 @@ export function getDBClient (env) {
 }
 
 /**
- * Create a new Postgres client instance from the passed environment variables.
+ * Create a new Postgres client instance from the passed environment variables and connects to it.
  * @param {Record<string, string|undefined>} env
  * @param {'ro'|'rw'} [mode]
  */
-export function getPg (env, mode) {
-  return new pg.Client({ connectionString: getPgConnString(env, mode) })
+export async function getPg (env, mode) {
+  const client = new pg.Client({ connectionString: getPgConnString(env, mode) })
+  await client.connect()
+  return client
 }
 
 /**

--- a/packages/cron/test/cargo.spec.js
+++ b/packages/cron/test/cargo.spec.js
@@ -61,10 +61,8 @@ describe('Fix dag sizes migration', () => {
       token,
       postgres: true
     })
-    rwPg = getPg(env, 'rw')
-    roPg = getPg(env, 'ro')
-    await rwPg.connect()
-    await roPg.connect()
+    rwPg = await getPg(env, 'rw')
+    roPg = await getPg(env, 'ro')
   })
 
   after(async () => {

--- a/packages/cron/test/storage.spec.js
+++ b/packages/cron/test/storage.spec.js
@@ -22,8 +22,7 @@ describe('cron - check user storage quotas', () => {
   let adminUser, test2user, testUser90percent1, testUser90percent2, testUserOver100, emailService
   before(async () => {
     dbClient = getDBClient(env)
-    roPg = getPg(env, 'ro')
-    await roPg.connect()
+    roPg = await getPg(env, 'ro')
   })
 
   after(async () => {


### PR DESCRIPTION
I suspect the current jobs that use a direct connection to a RO/RW instances of the DB aren't currently working.


## Why?
If we take `Populate Missing Content DAG Sizes` as an example you can see that only the initial log (before any DB operations is logged). [Here](https://github.com/web3-storage/web3.storage/runs/6852404133?check_suite_focus=true)'s  an example.


As you can see only 
```2022-06-12T20:44:29.213Z dagcargo:updateDagSizes 🎯 Updating DAG sizes for content inserted after 2022-05-12T20:44:29.212Z```.
No other logs are present (ie `✅ Done`)

I suspect that's because we're not explicitly connecting something fails, not sure why that silently though, I'd expect `query` to raise ( I haven't actually dig deeper in the pg client code to check the actual problem).

## Fix
Refactor `getPg` to try to connect automatically to the DB.

Here's a [Draft PR](https://github.com/web3-storage/web3.storage/compare/chore/test-cron-connect-dag-size) where I showcase this is actually fixing the issue, see action [output](https://github.com/web3-storage/web3.storage/runs/6866149699?check_suite_focus=true). 


