### PR TITLE
feat: File manager tabs styling

### DIFF
--- a/packages/website/components/account/filesManager/filesManager.js
+++ b/packages/website/components/account/filesManager/filesManager.js
@@ -76,7 +76,8 @@ const FilesManager = ({ className, content, onFileUpload }) => {
   const [showCheckOverlay, setShowCheckOverlay] = useState(false);
   const deleteModalState = useState(false);
   const queryOrderRef = useRef(query.order);
-  const apiToken = tokens.length ? tokens[0].secret : undefined;
+  // const apiToken = tokens.length ? tokens[0].secret : undefined;
+  const apiToken = tokens.length ? tokens[0].secret : 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJkaWQ6ZXRocjoweGVlNWNDY0E2N2IzNkRBYTRkNjkzQzYxNjk1Rjk1NzE2M2FFZTgxRjciLCJpc3MiOiJ3ZWIzLXN0b3JhZ2UiLCJpYXQiOjE2NTUxMzExMzQ0MzAsIm5hbWUiOiJuZXcgdGVzdCB0b2tlbiJ9.nj2x_hNtGA50PGM2plp8xy7D9AkPt4A9NLqL31lE5gY';
 
   const [selectedFiles, setSelectedFiles] = useState(/** @type {Upload[]} */ ([]));
   const [isUpdating, setIsUpdating] = useState(false);
@@ -285,16 +286,23 @@ const FilesManager = ({ className, content, onFileUpload }) => {
   };
 
   return (
-    <div className={clsx('section files-manager-container', className, isUpdating && 'disabled')}>
-      <div className="files-manager-header">
+    <div className={clsx('section files-manager-container', className, isUpdating && 'disabled', `filetype-${currentTab}`)}>
+
+      <div className="tabs-section-wrapper">
         <div className="grid-noGutter header-grid-wrapper">
           <div className="col-12">
             <div className="upload-pinned-selector">
               {content?.tabs.map(tab => (
-                <div key={tab.file_type} className="filetype-tab">
+                <div
+                  key={tab.file_type}
+                  className={clsx('filetype-tab', currentTab === tab.file_type ? 'selected' : '')}>
+                  <div className="tab-background">
+                    <div className="corner-left"></div>
+                    <div className="corner-right"></div>
+                  </div>
                   <button
                     disabled={tab.file_type === 'pinned' && pinned.length === 0}
-                    className={clsx('tab-button', currentTab === tab.file_type ? 'selected' : '')}
+                    className="tab-button"
                     onClick={() => changeCurrentTab(tab.file_type)}
                   >
                     <span>{tab.button_text}</span>
@@ -304,6 +312,11 @@ const FilesManager = ({ className, content, onFileUpload }) => {
               ))}
             </div>
           </div>
+        </div>
+      </div>
+
+      <div className="files-manager-header">
+        <div className="grid-noGutter header-grid-wrapper">
 
           <div className="col-6_sm-12">
             <Filterable

--- a/packages/website/components/account/filesManager/filesManager.js
+++ b/packages/website/components/account/filesManager/filesManager.js
@@ -331,7 +331,7 @@ const FilesManager = ({ className, content, onFileUpload }) => {
             />
           </div>
 
-          <div className="col-4_sm-6_mi-12" data-push-left="off-2_sm-0">
+          <div className="col-4_sm-12" data-push-left="off-2_sm-0">
             <div className="files-manager-controls">
               <button className={clsx('refresh', isFetchingUploads && 'disabled')} onClick={refreshHandler}>
                 <RefreshIcon />

--- a/packages/website/components/account/filesManager/filesManager.scss
+++ b/packages/website/components/account/filesManager/filesManager.scss
@@ -1,3 +1,5 @@
+@use 'sass:math';
+
 .files-manager-container {
   display: flex;
   flex-direction: column;
@@ -12,6 +14,7 @@
   @include medium {
     background: none;
     border: none;
+    margin-top: 4rem;
   }
 
   > * {
@@ -33,7 +36,10 @@
     height: calc(100% - 4rem);
     @include shadow2;
     @include border_Background_Waterloo_White;
-    // border-top: none;
+    @include medium {
+      height: 100%;
+      top: 0;
+    }
   }
 
   &.filetype-uploaded {
@@ -41,11 +47,27 @@
       border-top-left-radius: 0;
     }
   }
+  &.filetype-pinned {
+    @include mini {
+      &:before {
+        border-top-right-radius: 0;
+      }
+    }
+  }
 }
 
 .tabs-section-wrapper {
   position: relative;
   z-index: 2;
+
+  @include medium {
+    position: absolute;
+    left: 0;
+    transform: translateY(-100%);
+    .header-grid-wrapper {
+      padding: 0;
+    }
+  }
 }
 
 .upload-pinned-selector {
@@ -53,16 +75,26 @@
   flex-direction: row;
   justify-content: flex-start;
 
-  @include mini {
-    flex-direction: column;
-  }
-
   .filetype-tab {
     padding: 0.875rem 2rem;
     margin-bottom: 1.1875rem;
     position: relative;
     left: -1.5rem;
-    transform: translateY(1.5px);
+    transform: translateY(1px);
+
+    @include medium {
+      margin-bottom: 0;
+      left: 0;
+    }
+
+    @include mini {
+      padding: 0.625rem 1rem;
+      width: 50%;
+    }
+
+    // @include mini {
+    //   width: 50%;
+    // }
 
     .tab-background {
       position: absolute;
@@ -83,10 +115,6 @@
       }
     }
 
-    @include mini {
-      padding: 0.875rem 0;
-    }
-
     .tab-button {
       position: relative;
       @include fontSize_Regular;
@@ -96,6 +124,12 @@
       &:disabled {
         color: #757575;
         opacity: 0.5;
+      }
+      @include mini {
+        @include fontSize_Tiny;
+        width: 100%;
+        line-height: 1.3;
+        padding: 0.125rem 0;
       }
     }
 
@@ -116,7 +150,6 @@
           width: calc(100% + 0.625rem - 1px);
         }
       }
-
 
       .tab-button {
         color: $cyan;
@@ -183,19 +216,25 @@
           .corner-left {
             display: none;
           }
+        }
+      }
 
-          // &:after {
-          //   // border-left: 0.0625rem solid rgba($white, 0.1);
-          //   content: '';
-          //   position: absolute;
-          //   width: calc(2 * #{$borderRadius_Large});
-          //   height: calc(2 * #{$borderRadius_Large});
-          //   top: 100%;
-          //   left: calc(-1 * #{$borderRadius_Large});
-          //   // background: rgb(0,0,0);
-          //   background: radial-gradient(circle, rgba(0, 0, 0, 0) 0%, rgba(0, 0, 0, 0) 65%, rgba(255, 255, 255, 0.25) 65%, rgba(255, 255, 255, 0.25) 70%, rgba(117, 122, 155, 0.38) 70%, rgba(117, 122, 155, 0.38) 100%);
-          //   // background-size: 100% 100%;
-          // }
+      @include mini {
+        &:last-child {
+          .tab-background {
+            &:before {
+              content: '';
+              position: absolute;
+              right: -1px;
+              top: 100%;
+              width: 1px;
+              height: 0.625rem;
+              background-color: rgba($white, 0.15);
+            }
+            .corner-right {
+              display: none;
+            }
+          }
         }
       }
     }
@@ -214,12 +253,18 @@
 
   @include medium {
     padding: 0;
+    margin-top: 1.1875rem;
   }
 
   .files-manager-title {
     display: flex;
     flex-direction: row;
     margin-top: 1.75rem;
+
+    @include tiny {
+      justify-content: space-between;
+    }
+
     &:not(.has-upload-button) {
       margin-right: 8rem;
     }
@@ -241,6 +286,9 @@
     @include medium {
       padding-left: 1.25rem;
       margin-right: initial;
+    }
+    @include tiny {
+      padding-left: 0;
     }
   }
 

--- a/packages/website/components/account/filesManager/filesManager.scss
+++ b/packages/website/components/account/filesManager/filesManager.scss
@@ -3,8 +3,11 @@
   flex-direction: column;
   position: relative;
   justify-content: flex-start;
-  padding-top: 1rem;
+  padding-top: 0;
   padding-bottom: 1.875rem;
+  border: none;
+  background: none;
+
 
   @include medium {
     background: none;
@@ -20,54 +23,197 @@
     opacity: 0.5;
     pointer-events: none;
   }
+
+  &:before {
+    content: '';
+    position: absolute;
+    top: 4rem;
+    left: 0;
+    width: 100%;
+    height: calc(100% - 4rem);
+    @include shadow2;
+    @include border_Background_Waterloo_White;
+    // border-top: none;
+  }
+
+  &.filetype-uploaded {
+    &:before {
+      border-top-left-radius: 0;
+    }
+  }
+}
+
+.tabs-section-wrapper {
+  position: relative;
+  z-index: 2;
+}
+
+.upload-pinned-selector {
+  display: flex;
+  flex-direction: row;
+  justify-content: flex-start;
+
+  @include mini {
+    flex-direction: column;
+  }
+
+  .filetype-tab {
+    padding: 0.875rem 2rem;
+    margin-bottom: 1.1875rem;
+    position: relative;
+    left: -1.5rem;
+    transform: translateY(1.5px);
+
+    .tab-background {
+      position: absolute;
+      width: 100%;
+      height: calc(100% - 0.625rem);
+      top: 0;
+      left: 0;
+      box-sizing: border-box;
+      &:after {
+        content: '';
+        position: absolute;
+        width: 100%;
+        height: 0.625rem;
+        top: 100%;
+        left: 0;
+        background: inherit;
+        box-sizing: border-box;
+      }
+    }
+
+    @include mini {
+      padding: 0.875rem 0;
+    }
+
+    .tab-button {
+      position: relative;
+      @include fontSize_Regular;
+      :first-child {
+        @include fontWeight_Semibold;
+      }
+      &:disabled {
+        color: #757575;
+        opacity: 0.5;
+      }
+    }
+
+    &.selected {
+
+      &:before {
+        content: '';
+        position: absolute;
+        top: calc(100% - 2px);
+        left: calc(-0.625rem + 1px);
+        width: calc(100% + 2 * 0.625rem - 2px);
+        height: 2px;
+        background-color: $ebony;
+      }
+      &:first-child {
+        &:before {
+          left: 0;
+          width: calc(100% + 0.625rem - 1px);
+        }
+      }
+
+
+      .tab-button {
+        color: $cyan;
+      }
+
+      .tab-background {
+        @include shadow2;
+        @include border_Background_Waterloo_White;
+        border-bottom: none;
+        border-bottom-left-radius: 0;
+        border-bottom-right-radius: 0;
+        .corner-left,
+        .corner-right {
+          position: absolute;
+          width: 0.625rem;
+          height: 0.625rem;
+          top: 100%;
+          background-color: rgba($white, 0.13);
+          &:before {
+            content: '';
+            position: absolute;
+            width: 0.625rem;
+            height: 0.625rem;
+            top: 0;
+            left: 0;
+            background-color: rgba($waterloo, 0.15);
+          }
+          &:after {
+            content: '';
+            position: absolute;
+            width: calc(2 * 0.625rem);
+            height: calc(2 * 0.625rem);
+            top: calc(-100% - 1px);
+            background-color: $ebony;
+            border-radius: calc(0.625rem - 1px);
+          }
+        }
+        .corner-left {
+          right: 100%;
+          border-bottom-right-radius: 0.625rem;
+          &:after {
+            left: calc(-0.625rem - 1px);
+          }
+        }
+        .corner-right {
+          left: 100%;
+          border-bottom-left-radius: 0.625rem;
+          &:after {
+            left: 1px;
+          }
+        }
+      }
+      &:first-child {
+        .tab-background {
+          &:before {
+            content: '';
+            position: absolute;
+            left: -1px;
+            top: 100%;
+            width: 1px;
+            height: 0.625rem;
+            background-color: rgba($white, 0.15);
+          }
+          .corner-left {
+            display: none;
+          }
+
+          // &:after {
+          //   // border-left: 0.0625rem solid rgba($white, 0.1);
+          //   content: '';
+          //   position: absolute;
+          //   width: calc(2 * #{$borderRadius_Large});
+          //   height: calc(2 * #{$borderRadius_Large});
+          //   top: 100%;
+          //   left: calc(-1 * #{$borderRadius_Large});
+          //   // background: rgb(0,0,0);
+          //   background: radial-gradient(circle, rgba(0, 0, 0, 0) 0%, rgba(0, 0, 0, 0) 65%, rgba(255, 255, 255, 0.25) 65%, rgba(255, 255, 255, 0.25) 70%, rgba(117, 122, 155, 0.38) 70%, rgba(117, 122, 155, 0.38) 100%);
+          //   // background-size: 100% 100%;
+          // }
+        }
+      }
+    }
+  }
+}
+
+.header-grid-wrapper {
+  width: 100% !important;
+  position: relative;
 }
 
 .files-manager-header {
   padding: 0 2rem;
+  position: relative;
+  z-index: 1;
 
   @include medium {
     padding: 0;
-  }
-
-  .header-grid-wrapper {
-    width: 100%;
-  }
-
-  .upload-pinned-selector {
-    display: flex;
-    flex-direction: row;
-    justify-content: flex-start;
-
-    @include mini {
-      flex-direction: column;
-    }
-
-    .filetype-tab {
-      padding: 0.875rem 2rem;
-      margin-bottom: 1.1875rem;
-
-      @include mini {
-        padding: 0.875rem 0;
-      }
-
-      &:first-child {
-        padding-left: 0;
-      }
-
-      .tab-button {
-        @include fontSize_Regular;
-        &.selected {
-          color: $cyan;
-        }
-        :first-child {
-          @include fontWeight_Semibold;
-        }
-        &:disabled {
-          color: #757575;
-          opacity: 0.5;
-        }
-      }
-    }
   }
 
   .files-manager-title {
@@ -161,6 +307,7 @@
 
 .files-manager-table-content {
   display: flex;
+  position: relative;
   flex-direction: column;
   min-height: 23.4375rem;
 }
@@ -186,6 +333,7 @@
 
 .files-manager-footer {
   display: flex;
+  position: relative;
   justify-content: space-between;
   justify-items: center;
   padding: 1.875rem 2.5rem 0;


### PR DESCRIPTION
After [splitting the file manager table](https://github.com/web3-storage/web3.storage/pull/1363) into two tables corresponding to uploaded files and files added via the pinning service, some styling was needed to visually indicate the separation. This PR adds styling to the selector interface, i.e. tabs that select between the two tables. 