### PR TITLE
fix: drop uploads user index

### DIFF
--- a/packages/db/postgres/migrations/016-add-upload-user-id-index.sql
+++ b/packages/db/postgres/migrations/016-add-upload-user-id-index.sql
@@ -1,1 +1,1 @@
-CREATE INDEX IF NOT EXISTS upload_user_id_idx ON upload (user_id);
+CREATE INDEX CONCURRENTLY upload_user_id_idx ON upload (user_id);

--- a/packages/db/postgres/migrations/018-drop-upload-user-d-index.sql
+++ b/packages/db/postgres/migrations/018-drop-upload-user-d-index.sql
@@ -1,0 +1,1 @@
+DROP INDEX upload_user_id_idx;

--- a/packages/db/postgres/tables.sql
+++ b/packages/db/postgres/tables.sql
@@ -269,7 +269,6 @@ CREATE TABLE IF NOT EXISTS upload
 CREATE INDEX IF NOT EXISTS upload_auth_key_id_idx ON upload (auth_key_id);
 CREATE INDEX IF NOT EXISTS upload_content_cid_idx ON upload (content_cid);
 CREATE INDEX IF NOT EXISTS upload_updated_at_idx ON upload (updated_at);
-CREATE INDEX IF NOT EXISTS upload_user_id_idx ON upload (user_id);
 
 -- Tracks requests to replicate content to more nodes.
 CREATE TABLE IF NOT EXISTS pin_request


### PR DESCRIPTION
With index added in https://github.com/web3-storage/web3.storage/pull/1466 this should not be needed, as it includes it and also has optimization for not deleted