### PR TITLE
fix: make the default batch size for storage limit cron smaller

### DIFF
--- a/packages/cron/src/jobs/storage.js
+++ b/packages/cron/src/jobs/storage.js
@@ -85,7 +85,7 @@ const STORAGE_QUOTA_EMAILS = [
  *  userBatchSize?: number
  * }} config
  */
-export async function checkStorageUsed ({ roPg, emailService, userBatchSize = 1000 }) {
+export async function checkStorageUsed ({ roPg, emailService, userBatchSize = 20 }) {
   if (!log.enabled) {
     console.log('ℹ️ Enable logging by setting DEBUG=storage:checkStorageUsed')
   }


### PR DESCRIPTION
Testing the query in prod highlighted it can be extremely slow if prod, decreasing the batch size.