### PR TITLE
fix: cron test should run on db change

### DIFF
--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -6,10 +6,12 @@ on:
     paths:
       - 'packages/cron/**'
       - '.github/workflows/cron*'
+      - 'packages/db/**'
   pull_request:
     paths:
       - 'packages/cron/**'
       - '.github/workflows/cron*'
+      - 'packages/db/**'
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
We noticed DB changes did not trigger cron tests and cron uses DB, so it should