### PR TITLE
fix: Navigation accordion styles

### DIFF
--- a/packages/website/components/navigation/navigation.scss
+++ b/packages/website/components/navigation/navigation.scss
@@ -382,15 +382,23 @@
     @include fontSize_Small;
     @include fontWeight_Semibold;
   }
+  .accordion-header {
+    margin-bottom: 0;
+  }
   .accordion-content {
     margin-left: 2rem;
-    transition: height 300ms ease-in-out;
+    transition: 300ms ease-in-out;
+    a {
+      border-bottom: none;
+      padding-bottom: 0;
+    }
   }
   .accordion-section {
     margin-bottom: 0.375rem;
   }
   .button {
-    margin: 0.375rem 0;
+    margin-top: 0.75rem;
+    margin-bottom: 0.375rem;
   }
   .button {
     position: relative;

--- a/packages/website/components/navigation/navigation.scss
+++ b/packages/website/components/navigation/navigation.scss
@@ -388,6 +388,7 @@
   .accordion-content {
     margin-left: 2rem;
     transition: 300ms ease-in-out;
+    padding: 0.25rem 1rem 0.5rem 0rem !important;
     a {
       border-bottom: none;
       padding-bottom: 0;


### PR DESCRIPTION
Newer accordion styles added to the accordion block component were overriding previous nav styles. This PR fixes that.