### PR TITLE
fix: close connection at the end of cron

### DIFF
--- a/packages/cron/src/bin/storage.js
+++ b/packages/cron/src/bin/storage.js
@@ -9,7 +9,12 @@ async function main () {
   const db = getDBClient(process.env)
   const roPg = await getPg(process.env, 'ro')
   const emailService = new EmailService({ db })
-  await checkStorageUsed({ roPg, emailService })
+
+  try {
+    await checkStorageUsed({ roPg, emailService })
+  } finally {
+    await roPg.end()
+  }
 }
 
 envConfig()


### PR DESCRIPTION
We should clean after ourself and close the connection to the db at the end of the cron.