### PR TITLE
fix: pins missing

### DIFF
--- a/packages/website/components/account/filesManager/filesManager.js
+++ b/packages/website/components/account/filesManager/filesManager.js
@@ -62,7 +62,7 @@ const FilesManager = ({ className, content, onFileUpload }) => {
     storageData: { refetch },
     info,
   } = useUser();
-  const tokensContext = useTokens();
+  const { tokens, getTokens } = useTokens();
 
   const [currentTab, setCurrentTab] = useState('uploaded');
   const [files, setFiles] = useState(/** @type {any} */ (uploads));
@@ -75,6 +75,7 @@ const FilesManager = ({ className, content, onFileUpload }) => {
   const [showCheckOverlay, setShowCheckOverlay] = useState(false);
   const deleteModalState = useState(false);
   const queryOrderRef = useRef(query.order);
+  const apiToken = tokens.length ? tokens[0].secret : undefined;
 
   const [selectedFiles, setSelectedFiles] = useState(/** @type {Upload[]} */ ([]));
   const [isUpdating, setIsUpdating] = useState(false);
@@ -110,13 +111,12 @@ const FilesManager = ({ className, content, onFileUpload }) => {
 
   // Initial pinned files fetch on component load
   useEffect(() => {
-    const apiToken = tokensContext.tokens.length ? tokensContext.tokens[0].secret : undefined;
     if (!fetchPinsDate && !isFetchingPinned && apiToken) {
       listPinned('pinned', apiToken);
     }
-  }, [fetchPinsDate, listPinned, isFetchingPinned, tokensContext.tokens]);
+  }, [fetchPinsDate, listPinned, isFetchingPinned, apiToken]);
   useEffect(() => {
-    tokensContext.getTokens()
+    getTokens()
   }, []);
 
   // Set displayed files based on tab selection: 'uploaded' or 'pinned'
@@ -266,14 +266,13 @@ const FilesManager = ({ className, content, onFileUpload }) => {
   }, [setShowCheckOverlay]);
 
   const refreshHandler = useCallback(() => {
-    const apiToken = tokensContext.tokens.length ? tokensContext.tokens[0].secret : undefined;
     if (currentTab === 'uploaded') {
       getUploads();
     } else if (currentTab === 'pinned' && apiToken) {
       listPinned('pinned', apiToken);
     }
     showCheckOverlayHandler();
-  }, [currentTab, getUploads, listPinned, showCheckOverlayHandler, tokensContext.tokens]);
+  }, [currentTab, getUploads, listPinned, showCheckOverlayHandler, apiToken]);
 
   const tableContentLoading = tab => {
     switch (tab) {

--- a/packages/website/components/account/filesManager/filesManager.js
+++ b/packages/website/components/account/filesManager/filesManager.js
@@ -62,7 +62,7 @@ const FilesManager = ({ className, content, onFileUpload }) => {
     storageData: { refetch },
     info,
   } = useUser();
-  const { tokens } = useTokens();
+  const tokensContext = useTokens();
 
   const [currentTab, setCurrentTab] = useState('uploaded');
   const [files, setFiles] = useState(/** @type {any} */ (uploads));
@@ -75,7 +75,6 @@ const FilesManager = ({ className, content, onFileUpload }) => {
   const [showCheckOverlay, setShowCheckOverlay] = useState(false);
   const deleteModalState = useState(false);
   const queryOrderRef = useRef(query.order);
-  const apiToken = tokens.length ? tokens[0].secret : undefined;
 
   const [selectedFiles, setSelectedFiles] = useState(/** @type {Upload[]} */ ([]));
   const [isUpdating, setIsUpdating] = useState(false);
@@ -111,10 +110,14 @@ const FilesManager = ({ className, content, onFileUpload }) => {
 
   // Initial pinned files fetch on component load
   useEffect(() => {
+    const apiToken = tokensContext.tokens.length ? tokensContext.tokens[0].secret : undefined;
     if (!fetchPinsDate && !isFetchingPinned && apiToken) {
       listPinned('pinned', apiToken);
     }
-  }, [fetchPinsDate, listPinned, isFetchingPinned, apiToken]);
+  }, [fetchPinsDate, listPinned, isFetchingPinned, tokensContext.tokens]);
+  useEffect(() => {
+    tokensContext.getTokens()
+  }, []);
 
   // Set displayed files based on tab selection: 'uploaded' or 'pinned'
   useEffect(() => {
@@ -263,13 +266,14 @@ const FilesManager = ({ className, content, onFileUpload }) => {
   }, [setShowCheckOverlay]);
 
   const refreshHandler = useCallback(() => {
+    const apiToken = tokensContext.tokens.length ? tokensContext.tokens[0].secret : undefined;
     if (currentTab === 'uploaded') {
       getUploads();
     } else if (currentTab === 'pinned' && apiToken) {
       listPinned('pinned', apiToken);
     }
     showCheckOverlayHandler();
-  }, [currentTab, getUploads, listPinned, showCheckOverlayHandler, apiToken]);
+  }, [currentTab, getUploads, listPinned, showCheckOverlayHandler, tokensContext.tokens]);
 
   const tableContentLoading = tab => {
     switch (tab) {


### PR DESCRIPTION
You'll need to have a token setup in the API tokens screen + have used the API to pin a file (status has transitioned to "Pinned") in order to see the changes (see https://web3.storage/docs/how-tos/pinning-services-api/)

Before:
![image](https://user-images.githubusercontent.com/22156330/174115392-8bdd958e-f9c3-4511-8558-54b74019495f.png)


After:
![image](https://user-images.githubusercontent.com/22156330/174115257-d9a8e90c-7703-4ae5-9d7e-22944d1a599d.png)
![image](https://user-images.githubusercontent.com/22156330/174127357-b814811e-14be-4ec9-874e-ab710ce776f6.png)
