### PR TITLE
fix: nav active states

### DIFF
--- a/packages/website/components/navigation/navigation.scss
+++ b/packages/website/components/navigation/navigation.scss
@@ -168,6 +168,11 @@
           border: solid 2px $malibu;
         }
       }
+      &.current-page {
+        &:after {
+          border: solid 2px $white;
+        }
+      }
     }
   }
 }

--- a/packages/website/components/navigation/navigation.scss
+++ b/packages/website/components/navigation/navigation.scss
@@ -190,6 +190,7 @@
 // ///////////////////////////////////////////////////////////////////////// App
 .nav-account-button {
   position: relative;
+  display: contents;
   &:hover {
     .nav-account-dropdown {
       transform: translate(-50%, 0rem);
@@ -206,7 +207,7 @@
   padding: 1.5rem;
   padding-right: 3.5rem;
   top: calc(100% + 1rem);
-  left: 50%;
+  right: 0;
   opacity: 0;
   transform: translate(-50%, 1.5rem);
   transition: 250ms ease;

--- a/packages/website/modules/docs-theme/index.scss
+++ b/packages/website/modules/docs-theme/index.scss
@@ -28,10 +28,12 @@
     overflow: hidden;
   }
   // very top nav
-  .nav-item[href='/docs/'] {
-    transform: translateY(-0.5rem);
-    &:after {
-      opacity: 1;
+  .docs-site {
+    .nav-item[href='/docs/'] {
+      transform: translateY(-0.5rem);
+      &:after {
+        opacity: 1;
+      }
     }
   }
 


### PR DESCRIPTION
fixes #1458
This PR fixes a bug where the active state of `/docs` nav item was stuck "on" after the first visit. Also fixes the current state for dark backgrounds adding a light on state underline for active nav items on dark backgrounds.