### PR TITLE
fix: increase storage limit job timeout

### DIFF
--- a/.github/workflows/cron-storage-limits.yaml
+++ b/.github/workflows/cron-storage-limits.yaml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       matrix:
         env: ['staging', 'production']
-    timeout-minutes: 100
+    timeout-minutes: 340
     steps:
       - uses: actions/checkout@v2
 


### PR DESCRIPTION
Increasing the job timeout, as discussed with Vasco, to figure out if that is enough to go through all the users.