### PR TITLE
fix: use latest cron tag for running storage cron

### DIFF
--- a/.github/workflows/cron-storage-limits.yaml
+++ b/.github/workflows/cron-storage-limits.yaml
@@ -18,7 +18,10 @@ jobs:
     timeout-minutes: 340
     steps:
       - uses: actions/checkout@v2
-
+      - name: Checkout latest cron release tag
+        run: |
+          LATEST_TAG=$(git describe --tags --abbrev=0 --match='cron-*')
+          git checkout $LATEST_TAG
       - name: Setup node
         uses: actions/setup-node@v2
         with:


### PR DESCRIPTION
We introduced a cron workflow [here](https://github.com/web3-storage/web3.storage/pull/1281).

The storage limit notifications cron was being developed in parallel and missed the update.