### PR TITLE
fix: use dummy provider in staging

### DIFF
--- a/.github/workflows/cron-storage-limits.yaml
+++ b/.github/workflows/cron-storage-limits.yaml
@@ -38,4 +38,5 @@ jobs:
           PROD_PG_REST_URL: ${{ secrets.PROD_PG_REST_URL }}
           STAGING_PG_REST_URL: ${{ secrets.STAGING_PG_REST_URL }}
           MAILCHIMP_API_KEY: ${{ secrets.MAILCHIMP_API_KEY }}
+          EMAIL_PROVIDER: ${{ matrix.env == 'staging' && 'dummy'}}
         run: npm run start:storage -w packages/cron

--- a/.github/workflows/cron-storage-limits.yaml
+++ b/.github/workflows/cron-storage-limits.yaml
@@ -14,10 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        env: [
-          'staging',
-          # 'production'
-        ]
+        env: ['staging', 'production']
     timeout-minutes: 340
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/cron-storage-limits.yaml
+++ b/.github/workflows/cron-storage-limits.yaml
@@ -14,7 +14,10 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        env: ['staging', 'production']
+        env: [
+          'staging',
+          # 'production'
+        ]
     timeout-minutes: 340
     steps:
       - uses: actions/checkout@v2

--- a/packages/cron/src/lib/email/service.js
+++ b/packages/cron/src/lib/email/service.js
@@ -31,6 +31,8 @@ export class EmailService {
     this.providerStr = provider || process.env.EMAIL_PROVIDER || 'mailchimp'
     this.provider = new EMAIL_PROVIDERS_MAP[this.providerStr]()
 
+    log(`ℹ️ Using Email ${this.providerStr} provider`)
+
     this.fromAddr = EMAIL_FROM_ADDR
     this.fromName = EMAIL_FROM_NAME
   }


### PR DESCRIPTION
The staging DB is now a fork of prod that results in duplicated emails if we run the cron from both prod and staging environments.

Let's just log emails are sent in staging.

Tested [here](https://github.com/web3-storage/web3.storage/runs/6969064271?check_suite_focus=true)