### PR TITLE
fix: reuse Service type sig for client options

### DIFF
--- a/packages/client/src/lib.js
+++ b/packages/client/src/lib.js
@@ -83,7 +83,7 @@ class Web3Storage {
    * const client = new Web3Storage({ token: API_TOKEN })
    * ```
    *
-   * @param {{token: string, endpoint?:URL, rateLimiter?: RateLimiter, fetch: typeof _fetch}} options
+    @param {Service} options
    */
   constructor ({
     token,

--- a/packages/client/test/custom-fetch.spec.js
+++ b/packages/client/test/custom-fetch.spec.js
@@ -3,34 +3,16 @@ import * as assert from 'uvu/assert'
 import { Web3Storage } from 'web3.storage'
 import { File, fetch } from '../src/platform.js'
 
-describe('test customFetch', () => {
+describe('test custom fetch', () => {
   const { AUTH_TOKEN, API_PORT } = process.env
   const token = AUTH_TOKEN || 'good'
   const endpoint = new URL(API_PORT ? `http://localhost:${API_PORT}` : '')
 
-  it('without customFetch', async () => {
-    // @ts-ignore
-    const client = new Web3Storage({ endpoint, token })
-    const files = prepareFiles()
-    const cid = 'bafkreifzjut3te2nhyekklss27nh3k72ysco7y32koao5eei66wof36n5e'
-    const result = false
-
-    await client.put(files)
-    await client.get(cid)
-    await client.list()
-
-    assert.is(result, false)
-    assert.is(result, false)
-    assert.is(result, false)
-  })
-
-  it('with customFetch', async () => {
-    // @ts-ignore
+  it('with custom fetch', async () => {
     let result = false
 
     function customFetch (...opts) {
       result = true
-
       return fetch(...opts)
     }
 


### PR DESCRIPTION
- remove duplicated service options definition, to fix unintended manditory `fetch` property on js client constructor
- remove redundant test from #1324

License: (Apache-2.0 AND MIT)
Signed-off-by: Oli Evans <oli@tableflip.io>