### PR TITLE
fix: stop navigating to account screen from token creator button

### DIFF
--- a/packages/website/components/tokens/tokenCreator/tokenCreator.js
+++ b/packages/website/components/tokens/tokenCreator/tokenCreator.js
@@ -122,7 +122,6 @@ const TokenCreator = ({ content }) => {
             <Button
               disabled={user?.info?.tags?.['HasAccountRestriction']}
               className={clsx('token-creator-create', query.create && 'hidden')}
-              href="/account"
               onClick={() => push('/tokens?create=true')}
               variant={ButtonVariant.TEXT}
               tooltip={


### PR DESCRIPTION
It looks like the href on this button was likely an accident originally, but my recent changes to the button component exposed it as a problem.

Closes #1520 