### PR TITLE
fix: allow delete file modal to close on error

### DIFF
--- a/packages/website/components/account/filesManager/filesManager.js
+++ b/packages/website/components/account/filesManager/filesManager.js
@@ -116,7 +116,7 @@ const FilesManager = ({ className, content, onFileUpload }) => {
     }
   }, [fetchPinsDate, listPinned, isFetchingPinned, apiToken]);
   useEffect(() => {
-    getTokens()
+    getTokens();
   }, []);
 
   // Set displayed files based on tab selection: 'uploaded' or 'pinned'
@@ -215,11 +215,13 @@ const FilesManager = ({ className, content, onFileUpload }) => {
   const onDeleteSelected = useCallback(async () => {
     setIsUpdating(true);
 
-    if (deleteSingleCid !== '') {
-      await deleteUpload(deleteSingleCid);
-    } else {
-      await Promise.all(selectedFiles.map(({ cid }) => deleteUpload(cid)));
-    }
+    try {
+      if (deleteSingleCid !== '') {
+        await deleteUpload(deleteSingleCid);
+      } else {
+        await Promise.all(selectedFiles.map(({ cid }) => deleteUpload(cid)));
+      }
+    } catch (e) {}
 
     countly.trackEvent(countly.events.FILE_DELETE_CLICK, {
       ui: countly.ui.FILES,


### PR DESCRIPTION
If delete file fails, the app kinda breaks.  Delete file will fail when the user has delete restriction.  This just catches and ignores any errors so that the modal closes gracefully

Closes #1409