### PR TITLE
fix: explain api maintenance mode

### DIFF
--- a/packages/website/components/tokens/tokenCreator/tokenCreator.js
+++ b/packages/website/components/tokens/tokenCreator/tokenCreator.js
@@ -98,9 +98,9 @@ const TokenCreator = ({ content }) => {
   };
 
   return (
-    <div className={clsx('token-creator-container', isCreating && 'isDisabled')}>
+    <div className={clsx('token-creator-container', isCreating && !hasError && 'isDisabled')}>
       {isCreating ? (
-        content.loading_message
+        <> {hasError ? <span>⚠ {errorMessage}</span> : content.loading_message} </>
       ) : (
         <>
           <form className={clsx(!query.create && 'hidden', 'token-creator-input-container')} onSubmit={onTokenCreate}>
@@ -116,20 +116,24 @@ const TokenCreator = ({ content }) => {
             />
             <button className="token-creator-submit">{inputHasValue ? '→' : '+'}</button>
           </form>
-          <Button
-            disabled={user?.info?.tags?.['HasAccountRestriction']}
-            className={clsx('token-creator-create', query.create && 'hidden')}
-            href="/account"
-            onClick={() => push('/tokens?create=true')}
-            variant={ButtonVariant.TEXT}
-            tooltip={
-              user?.info?.tags?.['HasAccountRestriction']
-                ? 'You are unable to create API tokens when your account is blocked. Please contact support@web3.storage'
-                : ''
-            }
-          >
-            {content.prompt}
-          </Button>
+          {hasError ? (
+            <>⚠ {errorMessage}</>
+          ) : (
+            <Button
+              disabled={user?.info?.tags?.['HasAccountRestriction']}
+              className={clsx('token-creator-create', query.create && 'hidden')}
+              href="/account"
+              onClick={() => push('/tokens?create=true')}
+              variant={ButtonVariant.TEXT}
+              tooltip={
+                user?.info?.tags?.['HasAccountRestriction']
+                  ? 'You are unable to create API tokens when your account is blocked. Please contact support@web3.storage'
+                  : ''
+              }
+            >
+              {content.prompt}
+            </Button>
+          )}
         </>
       )}
     </div>

--- a/packages/website/components/tokens/tokenCreator/tokenCreator.js
+++ b/packages/website/components/tokens/tokenCreator/tokenCreator.js
@@ -22,7 +22,7 @@ const TokenCreator = ({ content }) => {
   const [inputHasValue, setInputHasValue] = useState(/** @type {boolean} */ (false));
 
   const { query, push, replace } = useRouter();
-  const { tokens, createToken, isCreating, getTokens } = useTokens();
+  const { tokens, createToken, isCreating, getTokens, hasError, errorMessage } = useTokens();
 
   const user = useUser();
 

--- a/packages/website/components/tokens/tokensManager/tokensManager.js
+++ b/packages/website/components/tokens/tokensManager/tokensManager.js
@@ -30,7 +30,7 @@ const defaultQueryOrder = 'a-z';
  * @returns
  */
 const TokensManager = ({ content }) => {
-  const { tokens, fetchDate, isFetchingTokens, deleteToken, getTokens, isCreating } = useTokens();
+  const { tokens, fetchDate, isFetchingTokens, deleteToken, getTokens, isCreating, hasError, errorMessage } = useTokens();
   const [deletingTokenId, setDeletingTokenId] = useState('');
   const { query, replace } = useRouter();
   const queryClient = useQueryClient();
@@ -128,7 +128,13 @@ const TokensManager = ({ content }) => {
         <TokenRowItem name={tokenRowLabels.name.label} secret={tokenRowLabels.secret.label} isHeader />
         <div className="tokens-manager-table-content">
           {isFetchingTokens || !fetchDate ? (
-            <Loading className={'tokens-manager-loading-spinner'} />
+            <>
+              {hasError ? (
+                <div className="table-error">⚠ {errorMessage}</div>
+              ) : (
+                <Loading className={'tokens-manager-loading-spinner'} />
+              )}
+            </>
           ) : !tokens.length ? (
             <span className="tokens-manager-upload-cta">
               {content.table.message}

--- a/packages/website/components/tokens/tokensManager/tokensManager.scss
+++ b/packages/website/components/tokens/tokensManager/tokensManager.scss
@@ -80,6 +80,12 @@
     min-height: auto;
   }
 
+  .table-error {
+    padding: 1.875rem;
+    text-align: center;
+    color: $cyan;
+  }
+
   .tokens-manager-upload-cta {
     position: relative;
     top: 1.5625rem;


### PR DESCRIPTION
fixes #1318 
This PR adds error messaging for the tokens section of the website when the API is in maintenance mode.

## How to Test
- Put the api in maintenance mode [README](https://github.com/web3-storage/web3.storage/blob/main/packages/api/README.md#maintenance-mode)
OR Locally `packages/api/src/maintenance.js ln:29`
- Visit `/tokens/` and `/tokens/?create=true`
- NO_READ_OR_WRITE will show error message for creation and retrieval of tokens
- READ_ONLY will successfully show tokens but show error when creating a new token