### PR TITLE
Fix/cron storage provider prod

### DIFF
--- a/.github/workflows/cron-storage-limits.yaml
+++ b/.github/workflows/cron-storage-limits.yaml
@@ -41,6 +41,6 @@ jobs:
           PROD_PG_REST_URL: ${{ secrets.PROD_PG_REST_URL }}
           STAGING_PG_REST_URL: ${{ secrets.STAGING_PG_REST_URL }}
           MAILCHIMP_API_KEY: ${{ secrets.MAILCHIMP_API_KEY }}
-          EMAIL_PROVIDER: ${{ matrix.env == 'staging' && 'dummy' || ''}}
+          EMAIL_PROVIDER: ${{ (matrix.env == 'staging' && 'dummy') || '' }} # use dummy provider in staging, while using the default provider in prod.
         run: npm run start:storage -w packages/cron
-        
+

--- a/.github/workflows/cron-storage-limits.yaml
+++ b/.github/workflows/cron-storage-limits.yaml
@@ -28,10 +28,8 @@ jobs:
         uses: actions/setup-node@v2
         with:
           node-version: 16
-
       - name: Install dependencies
         uses: bahmutov/npm-install@v1
-
       - name: Run job
         env:
           DEBUG: '*'
@@ -43,5 +41,6 @@ jobs:
           PROD_PG_REST_URL: ${{ secrets.PROD_PG_REST_URL }}
           STAGING_PG_REST_URL: ${{ secrets.STAGING_PG_REST_URL }}
           MAILCHIMP_API_KEY: ${{ secrets.MAILCHIMP_API_KEY }}
-          EMAIL_PROVIDER: ${{ matrix.env == 'staging' && 'dummy'}}
+          EMAIL_PROVIDER: ${{ matrix.env == 'staging' && 'dummy' || ''}}
         run: npm run start:storage -w packages/cron
+        


### PR DESCRIPTION
## Problem 
[Storage cron](https://github.com/web3-storage/web3.storage/runs/6983956763?check_suite_focus=true#step:6:35) is failing in production.
The problem is that EMAIL_PROVIDER: `${{ matrix.env == 'staging' && 'dummy'}}` results in the string "false" for prod.

## Solutions
While there are better fixes, (ie splitting up the jobs, use a default conf and override the variables), going for the quick fix here, setting the variable to empty string for prod.