### PR TITLE
fix: sentry not receiving errors

### DIFF
--- a/packages/api/src/error-handler.js
+++ b/packages/api/src/error-handler.js
@@ -10,8 +10,9 @@ export function errorHandler (err, { log }) {
   console.error(err.stack)
 
   let status = err.status || 500
-
-  log.error(err)
+  if (status >= 500) {
+    log.error(err)
+  }
 
   // TODO: improve error handler
   // https://github.com/web3-storage/web3.storage/issues/976

--- a/packages/api/src/utils/logs.js
+++ b/packages/api/src/utils/logs.js
@@ -209,7 +209,7 @@ export class Logging {
         stack: message.stack,
         message: message.message
       }
-      if (this.opts.sentry && message.status >= 500 && !skipForSentry.some((cls) => message instanceof cls)) {
+      if (this.opts.sentry && !skipForSentry.some((cls) => message instanceof cls)) {
         this.opts.sentry.captureException(message)
       }
     } else {


### PR DESCRIPTION
The status property is not set to Error that is sent to logs. There is really no point in previous condition where log function had a check for status >= 500 given log function is used for error, warn and regular log. So, Error log should check if is a vaid error to log (500) before asking to log