### PR TITLE
fix: no page reload when pointing to relative path in docs

### DIFF
--- a/packages/website/modules/docs-theme/index.js
+++ b/packages/website/modules/docs-theme/index.js
@@ -30,8 +30,9 @@ export default function Docs(props) {
     localLinks?.forEach(link => {
       link.addEventListener('click', e => {
         e.preventDefault();
+        e.stopPropagation();
         // @ts-ignore
-        router.push(e.target.href);
+        router.push(e.currentTarget.href);
       });
     });
   }, [router]);

--- a/packages/website/modules/docs-theme/index.js
+++ b/packages/website/modules/docs-theme/index.js
@@ -2,12 +2,12 @@ import React, { useEffect } from 'react';
 import { MDXProvider } from '@mdx-js/react';
 
 import Head from 'next/head';
+import { useRouter } from 'next/router';
 import hljs from 'highlight.js/lib/core';
 import javascript from 'highlight.js/lib/languages/javascript';
 import shell from 'highlight.js/lib/languages/shell';
 import go from 'highlight.js/lib/languages/go';
 import json from 'highlight.js/lib/languages/json';
-
 import Sidebar from './sidebar/sidebar';
 import Feedback from './feedback/feedback';
 import Toc from './toc/toc';
@@ -20,10 +20,21 @@ hljs.registerLanguage('json', json);
 
 export default function Docs(props) {
   const { meta, route, ...rest } = props;
+  const router = useRouter();
 
   useEffect(() => {
     hljs.highlightAll();
-  });
+
+    // no reload on local links
+    const localLinks = document.querySelectorAll('.docs-body a[href^="/docs/"]');
+    localLinks?.forEach(link => {
+      link.addEventListener('click', e => {
+        e.preventDefault();
+        // @ts-ignore
+        router.push(e.target.href);
+      });
+    });
+  }, [router]);
 
   const sharedHead = (
     <Head>

--- a/packages/website/modules/docs-theme/index.js
+++ b/packages/website/modules/docs-theme/index.js
@@ -30,7 +30,6 @@ export default function Docs(props) {
     localLinks?.forEach(link => {
       link.addEventListener('click', e => {
         e.preventDefault();
-        e.stopPropagation();
         // @ts-ignore
         router.push(e.currentTarget.href);
       });

--- a/packages/website/modules/docs-theme/toc/toc.js
+++ b/packages/website/modules/docs-theme/toc/toc.js
@@ -11,7 +11,6 @@ if (typeof window !== 'undefined') {
 export default function Toc() {
   const [isOpen, setOpen] = useState(false);
   const [nestedHeadings, setNestedHeadings] = useState([]);
-  const [updateKey, setUpdateKey] = useState(0);
   const activeHeadings = useRef({});
   let controller;
 
@@ -35,15 +34,14 @@ export default function Toc() {
     return str;
   };
 
-  const updateHeadings = (id) => {
+  const updateHeadings = id => {
     for (const element in activeHeadings.current) {
       if (activeHeadings.current[element]) {
         activeHeadings.current[element] = false;
       }
     }
     activeHeadings.current[id] = true;
-    setUpdateKey(key => key + 1);
-  }
+  };
 
   const getNestedHeadings = headingElements => {
     const nestedHeadings = [];
@@ -63,17 +61,21 @@ export default function Toc() {
       }
 
       // scroll effects / add active class
-      const exitScene = (e) => {
+      const exitScene = e => {
         if (e.scrollDirection === 'REVERSE' && index !== 0) {
           updateHeadings(headingIds[index - 1]);
         }
-      }
+      };
 
       const scene = new ScrollMagic.Scene({
         triggerElement: `#${id}`,
         triggerHook: 0.25,
-        duration: 200
-      }).on('enter', () => { updateHeadings(id) }).addTo(controller);
+        duration: 200,
+      })
+        .on('enter', () => {
+          updateHeadings(id);
+        })
+        .addTo(controller);
       scene.on('leave', exitScene).addTo(controller);
     });
     return nestedHeadings;
@@ -83,18 +85,14 @@ export default function Toc() {
     <ul>
       {headings.map((heading, i) => (
         <li key={heading.id}>
-          <a
-            href={`#${heading.id}`}
-            className={clsx(activeHeadings.current[heading.id] ? 'active' : '')}>
+          <a href={`#${heading.id}`} className={clsx(activeHeadings.current[heading.id] ? 'active' : '')}>
             {heading.title}
           </a>
           {heading.items.length > 0 && (
             <ul>
               {heading.items.map((child, j) => (
                 <li key={child.id}>
-                  <a
-                    href={`#${child.id}`}
-                    className={clsx(activeHeadings.current[child.id] ? 'active' : '')}>
+                  <a href={`#${child.id}`} className={clsx(activeHeadings.current[child.id] ? 'active' : '')}>
                     {child.title}
                   </a>
                 </li>
@@ -107,6 +105,7 @@ export default function Toc() {
   );
 
   useEffect(() => {
+    // eslint-disable-next-line react-hooks/exhaustive-deps
     controller = new ScrollMagic.Controller();
     const headingElements = Array.from(document.querySelectorAll('.docs-body h2, .docs-body h3'));
     const newNestedHeadings = getNestedHeadings(headingElements);


### PR DESCRIPTION
Resolves an issue where, after docs links were tested and modified to use absolute paths, they all triggered a page reload. Because all links paths start with `/docs/foo`, they are treated as regular links that the client handles, rather than Next's built-in virtual routing.