### PR TITLE
fix: build-cargo-connection-string

### DIFF
--- a/.env.tpl
+++ b/.env.tpl
@@ -14,8 +14,10 @@ PG_REST_URL=http://127.0.0.1:3000
 PG_CONNECTION=postgres://postgres:postgres@127.0.0.1:5432/postgres
 RO_PG_CONNECTION=postgres://postgres:postgres@127.0.0.1:5432/postgres
 
-CARGO_PG_CONNECTION=postgres://postgres:postgres@127.0.0.1:5432/postgres?currentSchema=cargo
-
+DAG_CARGO_HOST=127.0.0.1
+DAG_CARGO_DATABASE=postgres
+DAG_CARGO_USER=postgres
+DAG_CARGO_PASSWORD=postgres
 
 ## ---- api -------------------------------------------------------------------
 

--- a/.github/workflows/cron-dagcargo-sizes.yml
+++ b/.github/workflows/cron-dagcargo-sizes.yml
@@ -38,7 +38,6 @@ jobs:
           STAGING_RO_PG_CONNECTION: ${{ secrets.STAGING_PG_CONNECTION }} # no replica for staging
           PROD_PG_CONNECTION: ${{ secrets.PROD_PG_CONNECTION }}
           PROD_RO_PG_CONNECTION: ${{ secrets.PROD_RO_PG_CONNECTION }}
-          CARGO_PG_CONNECTION: ${{ secrets.CARGO_PG_CONNECTION }}
           AFTER: ${{ github.event.inputs.after }}
         run: npm run start:dagcargo:sizes -w packages/cron
 

--- a/.github/workflows/cron-dagcargo-sizes.yml
+++ b/.github/workflows/cron-dagcargo-sizes.yml
@@ -37,7 +37,10 @@ jobs:
           STAGING_PG_CONNECTION: ${{ secrets.STAGING_PG_CONNECTION }}
           STAGING_RO_PG_CONNECTION: ${{ secrets.STAGING_PG_CONNECTION }} # no replica for staging
           PROD_PG_CONNECTION: ${{ secrets.PROD_PG_CONNECTION }}
-          PROD_RO_PG_CONNECTION: ${{ secrets.PROD_RO_PG_CONNECTION }}
+          DAG_CARGO_HOST: ${{ secrets.DAG_CARGO_HOST }}
+          DAG_CARGO_DATABASE: ${{ secrets.DAG_CARGO_DATABASE }}
+          DAG_CARGO_USER: ${{ secrets.DAG_CARGO_USER }}
+          DAG_CARGO_PASSWORD: ${{ secrets.DAG_CARGO_PASSWORD }}
           AFTER: ${{ github.event.inputs.after }}
         run: npm run start:dagcargo:sizes -w packages/cron
 

--- a/packages/cron/README.md
+++ b/packages/cron/README.md
@@ -22,7 +22,10 @@ PG_REST_URL=http://localhost:3000
 PG_REST_JWT=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJyb2xlIjoicG9zdGdyZXMifQ.oM0SXF31Vs1nfwCaDxjlczE237KcNKhTpKEYxMX-jEU
 PG_CONNECTION=postgres://postgres:postgres@127.0.0.1:5432/postgres
 
-CARGO_PG_CONNECTION=postgres://postgres:postgres@127.0.0.1:5432/postgres?currentSchema=cargo
+DAG_CARGO_HOST=127.0.0.1
+DAG_CARGO_DATABASE=postgres
+DAG_CARGO_USER=postgres
+DAG_CARGO_PASSWORD=postgres
 
 CLUSTER_API_URL=http://127.0.0.1:9094/
 CLUSTER_IPFS_PROXY_API_URL=http://127.0.0.1:9095/api/v0/

--- a/packages/cron/src/lib/utils.js
+++ b/packages/cron/src/lib/utils.js
@@ -93,7 +93,7 @@ function getPgConnString (env, mode = 'rw') {
 }
 
 /**
- * Builds a post connections string
+ * Builds a pg connections string
  *
  * @param {object} dbOptions
  * @param {string} dbOptions.host

--- a/packages/cron/src/lib/utils.js
+++ b/packages/cron/src/lib/utils.js
@@ -110,7 +110,7 @@ function buildPgConnectionString ({
   password,
   port = 5432
 }) {
-  return `postgres//${user}:${password}@${host}:${port}/${database}`
+  return `postgres://${user}:${password}@${host}:${port}/${database}`
 }
 
 /**

--- a/packages/cron/src/lib/utils.js
+++ b/packages/cron/src/lib/utils.js
@@ -143,8 +143,6 @@ export function getCargoPgPool (env) {
     host: env.DAG_CARGO_HOST
   })
 
-  console.log(`Using ${connectionString}`)
-
   return new pg.Pool({
     connectionString,
     max: MAX_CONCURRENT_QUERIES

--- a/packages/cron/src/lib/utils.js
+++ b/packages/cron/src/lib/utils.js
@@ -123,31 +123,27 @@ function buildPgConnectionString ({
  * @param {Record<string, string|undefined>} env
  */
 export function getCargoPgPool (env) {
-  let connectionString = env.CARGO_PG_CONNECTION
-  // if a connection string isn't specified try to build the connection string from other variables.
-  if (!connectionString) {
-    const cargoEnvVariables = [
-      'DAG_CARGO_HOST',
-      'DAG_CARGO_DATABASE',
-      'DAG_CARGO_USER',
-      'DAG_CARGO_PASSWORD'
-    ]
+  const cargoEnvVariables = [
+    'DAG_CARGO_HOST',
+    'DAG_CARGO_DATABASE',
+    'DAG_CARGO_USER',
+    'DAG_CARGO_PASSWORD'
+  ]
 
-    cargoEnvVariables.forEach((variable) => {
-      if (!env[variable]) {
-        throw new Error(`Missing ${variable} string. Please add it to the environment.`)
-      }
-    })
+  cargoEnvVariables.forEach((variable) => {
+    if (!env[variable]) {
+      throw new Error(`Missing ${variable} string. Please add it to the environment.`)
+    }
+  })
 
-    connectionString = buildPgConnectionString({
-      user: env.DAG_CARGO_USER,
-      database: env.DAG_CARGO_DATABASE,
-      password: env.DAG_CARGO_PASSWORD,
-      host: env.DAG_CARGO_HOST
-    })
+  const connectionString = buildPgConnectionString({
+    user: env.DAG_CARGO_USER,
+    database: env.DAG_CARGO_DATABASE,
+    password: env.DAG_CARGO_PASSWORD,
+    host: env.DAG_CARGO_HOST
+  })
 
-    throw new Error('Missing CARGO_PG_CONNECTION string. Please add it to the environment.')
-  }
+  console.log(`Using ${connectionString}`)
 
   return new pg.Pool({
     connectionString,

--- a/packages/cron/src/lib/utils.js
+++ b/packages/cron/src/lib/utils.js
@@ -103,7 +103,7 @@ function getPgConnString (env, mode = 'rw') {
  * @param {number} [dbOptions.port]
  * @returns
  */
-function buildConnectionString ({
+function buildPgConnectionString ({
   host,
   database,
   user,
@@ -139,7 +139,7 @@ export function getCargoPgPool (env) {
       }
     })
 
-    connectionString = buildConnectionString({
+    connectionString = buildPgConnectionString({
       user: env.DAG_CARGO_USER,
       database: env.DAG_CARGO_DATABASE,
       password: env.DAG_CARGO_PASSWORD,

--- a/packages/cron/src/lib/utils.js
+++ b/packages/cron/src/lib/utils.js
@@ -93,6 +93,27 @@ function getPgConnString (env, mode = 'rw') {
 }
 
 /**
+ * Builds a post connections string
+ *
+ * @param {object} dbOptions
+ * @param {string} dbOptions.host
+ * @param {string} dbOptions.database
+ * @param {string} dbOptions.user
+ * @param {string} dbOptions.password
+ * @param {number} [dbOptions.port]
+ * @returns
+ */
+function buildConnectionString ({
+  host,
+  database,
+  user,
+  password,
+  port = 5432
+}) {
+  return `postgres//${user}:${password}@${host}:${port}/${database}`
+}
+
+/**
  * Create a new Postgres pool instance to connect directly to cargo replica from the passed environment variables.
  * This is a readOnly connection.
  *
@@ -102,13 +123,34 @@ function getPgConnString (env, mode = 'rw') {
  * @param {Record<string, string|undefined>} env
  */
 export function getCargoPgPool (env) {
-  const connection = env.CARGO_PG_CONNECTION
-  if (!connection) {
+  let connectionString = env.CARGO_PG_CONNECTION
+  // if a connection string isn't specified try to build the connection string from other variables.
+  if (!connectionString) {
+    const cargoEnvVariables = [
+      'DAG_CARGO_HOST',
+      'DAG_CARGO_DATABASE',
+      'DAG_CARGO_USER',
+      'DAG_CARGO_PASSWORD'
+    ]
+
+    cargoEnvVariables.forEach((variable) => {
+      if (!env[variable]) {
+        throw new Error(`Missing ${variable} string. Please add it to the environment.`)
+      }
+    })
+
+    connectionString = buildConnectionString({
+      user: env.DAG_CARGO_USER,
+      database: env.DAG_CARGO_DATABASE,
+      password: env.DAG_CARGO_PASSWORD,
+      host: env.DAG_CARGO_HOST
+    })
+
     throw new Error('Missing CARGO_PG_CONNECTION string. Please add it to the environment.')
   }
 
   return new pg.Pool({
-    connectionString: env.CARGO_PG_CONNECTION,
+    connectionString,
     max: MAX_CONCURRENT_QUERIES
   })
 }

--- a/packages/cron/test/cargo.spec.js
+++ b/packages/cron/test/cargo.spec.js
@@ -8,6 +8,8 @@ import { getCargoPgPool, getPg } from '../src/lib/utils.js'
 const env = {
   ...process.env,
   ENV: 'dev',
+  // These DB vars aren't necessary if you're using the latest .env.tpl, but are here
+  // to avoid errors if people are still using the old version before these were added
   DAG_CARGO_HOST: '127.0.0.1',
   DAG_CARGO_DATABASE: 'postgres',
   DAG_CARGO_USER: 'postgres',

--- a/packages/cron/test/cargo.spec.js
+++ b/packages/cron/test/cargo.spec.js
@@ -8,7 +8,10 @@ import { getCargoPgPool, getPg } from '../src/lib/utils.js'
 const env = {
   ...process.env,
   ENV: 'dev',
-  CARGO_PG_CONNECTION: 'postgres://postgres:postgres@127.0.0.1:5432/postgres?currentSchema=cargo'
+  DAG_CARGO_HOST: '127.0.0.1',
+  DAG_CARGO_DATABASE: 'postgres',
+  DAG_CARGO_USER: 'postgres',
+  DAG_CARGO_PASSWORD: 'postgres'
 }
 
 function getToBeUpdatedNull (cItem) {


### PR DESCRIPTION
We already have CARGO secrets in Github, let's build the connection string out of those instead of having a new one.