### PR TITLE
fix: optimise pin content cid query

### DIFF
--- a/packages/db/postgres/migrations/019-create-pin-content-cid-index.sql
+++ b/packages/db/postgres/migrations/019-create-pin-content-cid-index.sql
@@ -1,0 +1,1 @@
+CREATE INDEX IF NOT EXISTS pin_content_cid_status_idx ON pin (content_cid, status);

--- a/packages/db/postgres/migrations/019-create-pin-content-cid-index.sql
+++ b/packages/db/postgres/migrations/019-create-pin-content-cid-index.sql
@@ -1,1 +1,1 @@
-CREATE INDEX IF NOT EXISTS pin_content_cid_status_idx ON pin (content_cid, status);
+CREATE INDEX CONCURRENTLY IF NOT EXISTS pin_content_cid_status_idx ON pin (content_cid, status);

--- a/packages/db/postgres/tables.sql
+++ b/packages/db/postgres/tables.sql
@@ -241,6 +241,7 @@ CREATE INDEX IF NOT EXISTS pin_location_id_idx ON pin (pin_location_id);
 CREATE INDEX IF NOT EXISTS pin_updated_at_idx ON pin (updated_at);
 CREATE INDEX IF NOT EXISTS pin_status_idx ON pin (status);
 CREATE INDEX IF NOT EXISTS pin_composite_updated_at_and_content_cid_idx ON pin (updated_at, content_cid);
+CREATE INDEX IF NOT EXISTS pin_content_cid_status_idx ON pin (content_cid, status);
 
 -- An upload created by a user.
 CREATE TABLE IF NOT EXISTS upload


### PR DESCRIPTION
Create an index on `pin(content_cid, status)` to speed up `user_used_storage` joining and filtering.

I'll create a separate issue to audit the use of `CREATE INDEX IF NOT EXISTS pin_status_idx ON pin (status);` and to verify if it can be dropped in favor of this new one.


[Storage Limit Email Notifications Storage Limit Email Notifications #43](https://github.com/web3-storage/web3.storage/runs/7074203706?check_suite_focus=true) ran on staging in 11 minutes. ( staging amount of data is now comparable to prod).


🛑  The index has already been created in STAGING to test the performance against a large amount of data.