### PR TITLE
fix: only log user IDs, not names or email addresses

### DIFF
--- a/packages/cron/src/jobs/storage.js
+++ b/packages/cron/src/jobs/storage.js
@@ -152,9 +152,9 @@ export async function checkStorageUsed ({ roPg, emailService, userBatchSize = 20
 
         if (emailSent) {
           if (emailToSend.emailType === EMAIL_TYPE.User100PercentStorage) {
-            log(`📧 Sent a quota exceeded email to ${user.name}: ${user.percentStorageUsed}% of quota used`)
+            log(`📧 Sent a quota exceeded email to user ${user.id}: ${user.percentStorageUsed}% of quota used`)
           } else {
-            log(`📧 Sent an email to ${user.name}: ${user.percentStorageUsed}% of quota used`)
+            log(`📧 Sent an email to user ${user.id}: ${user.percentStorageUsed}% of quota used`)
           }
         }
       }

--- a/packages/cron/src/lib/email/service.js
+++ b/packages/cron/src/lib/email/service.js
@@ -65,17 +65,17 @@ export class EmailService {
         emailType: emailType,
         secondsSinceLastSent
       })) {
-        log(`📧 NOT sending email ${emailType} to ${user.name} (${user.email}), as it's been sent too recently.`)
+        log(`📧 NOT sending email ${emailType} to user ${user.id}, as it's been sent too recently.`)
         return false
       }
     }
 
     // Send the email
-    log(`📧 Sending email '${emailType}' to ${user.name} (${user.email}).`)
+    log(`📧 Sending email '${emailType}' to user ${user.id}.`)
     try {
       messageId = await this.provider.sendEmail(emailType, user.email, user.name, this.fromAddr, this.fromName, formattedVars)
     } catch (error) {
-      console.error(`📧 🚨 Failed to send ${emailType} email to ${user.name} (${user.email}) using ${this.providerStr}.`)
+      console.error(`📧 🚨 Failed to send ${emailType} email to user ${user.id} using ${this.providerStr}.`)
       if (failSilently && error instanceof EmailSendError) {
         console.error(error)
         return


### PR DESCRIPTION
Although these logs are only accessible to project members, not the public, it still seems a bit risqué to be logging user PII.