### PR TITLE
fix: make sure null claimed sizes are updated

### DIFF
--- a/packages/cron/src/jobs/dagcargo.js
+++ b/packages/cron/src/jobs/dagcargo.js
@@ -8,8 +8,8 @@ SELECT d.cid_v1 as cid, d.size_actual
   JOIN cargo.dags d using ( cid_v1 )
   JOIN cargo.sources s USING ( srcid )
 WHERE
-  d.size_actual > 0 AND 
-  d.size_actual != ds.size_claimed AND 
+  d.size_actual IS NOT NULL AND
+  (d.size_actual != ds.size_claimed OR ds.size_claimed is NULL) AND 
   ds.entry_last_updated > $1 AND
   s.project = 1
 LIMIT $2

--- a/packages/cron/test/cargo.spec.js
+++ b/packages/cron/test/cargo.spec.js
@@ -36,14 +36,14 @@ describe('Fix dag sizes migration', () => {
   let rwPg
 
   async function updateDagSizesWrp ({ user, after = new Date(1990, 1, 1), limit = 1000 }) {
-    const allUploadsBefore = await listUploads(dbClient, user._id)
+    const allUploadsBefore = (await listUploads(dbClient, user._id)).uploads
     await updateDagSizes({
       cargoPool,
       rwPg,
       after,
       limit
     })
-    const allUploadsAfter = await listUploads(dbClient, user._id)
+    const allUploadsAfter = (await listUploads(dbClient, user._id)).uploads
     const updatedCids = allUploadsAfter.filter((uAfter) => {
       const beforeUpload = allUploadsBefore.find((uBefore) => uAfter.cid === uBefore.cid)
       return beforeUpload?.dagSize !== uAfter.dagSize
@@ -100,6 +100,10 @@ describe('Fix dag sizes migration', () => {
         cid: await randomCid(),
         dagSize: 100,
         actualSize: null
+      }, {
+        cid: await randomCid(),
+        dagSize: null,
+        actualSize: 10
       }, {
         cid: await randomCid(),
         dagSize: null,


### PR DESCRIPTION
## Context
In SQL comparisons with null are a bit funky,
Given this query

```
SELECT d.cid_v1 as cid, d.size_actual
  FROM cargo.dag_sources ds
  JOIN cargo.dags d using ( cid_v1 )
  JOIN cargo.sources s USING ( srcid )
WHERE
  d.size_actual > 0 AND 
  d.size_actual != ds.size_claimed AND 
  ds.entry_last_updated > $1 AND
  s.project = 1
LIMIT $2
OFFSET $3
```

is wouldn't actually select rows with d.size_actual= 10 and  ds.size_claimed=null. While we should make sure those content rows do get updated.
