### PR TITLE
chore: use CI build as website deploy artefact

### DIFF
--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -21,6 +21,7 @@ jobs:
           node-version: 16
       - uses: bahmutov/npm-install@v1
       - run: npm run lint:ts -w packages/website
+
   test-e2e:
     name: ${{ matrix.os }} (${{ matrix.browser }})
     strategy:
@@ -68,11 +69,10 @@ jobs:
         with:
           name: ${{ matrix.browser }}-${{ matrix.os }}-test-results
           path: ${{ matrix.test_results_path }}
-  build:
-    name: Build & Add to IPFS
+
+  preview:
+    name: Preview
     runs-on: ubuntu-latest
-    outputs:
-      cid: ${{ steps.ipfs.outputs.cid }}
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
@@ -87,8 +87,6 @@ jobs:
           NEXT_PUBLIC_MAGIC: ${{ secrets.STAGING_MAGIC_PUBLIC_KEY }}
           NEXT_PUBLIC_COUNTLY_URL: ${{ secrets.COUNTLY_URL }}
           NEXT_PUBLIC_COUNTLY_KEY: ${{ secrets.COUNTLY_KEY }}
-
-      # Add the site to web3.storage, output the cid as `steps.ipfs.outputs.cid`
       - name: Add to web3.storage
         uses: web3-storage/add-to-web3@v2
         id: ipfs
@@ -97,26 +95,24 @@ jobs:
           web3_token: ${{ secrets.WEB3_TOKEN }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - run: echo ${{ steps.ipfs.outputs.url }}
-
-  # Publish to the staging domain if it's a change on main 🚀
-  deploy:
-    name: Deploy https://staging.web3.storage
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-    needs: build
-    runs-on: ubuntu-latest
-    steps:
-      - run: npx dnslink-cloudflare --record staging --domain web3.storage --link /ipfs/${{ needs.build.outputs.cid }}
+      - name: Deploy https://staging.web3.storage to IPFS via DNSLink
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        run: npx dnslink-cloudflare --record staging --domain web3.storage --link /ipfs/${{ needs.build.outputs.cid }}
         env:
           CF_API_TOKEN: ${{ secrets.CF_API_TOKEN }}
-  release:
+      # Publish all branches to the Staging Cloudflare Pages project 🚀
+      # if this is `main` then CF will update the staging.web3.storage domain to point at this build.
+      - name: Deploy preview build to Cloudflare Pages
+        run: npx wrangler pages publish --project-name staging.web3.storage --branch $GITHUB_REF_NAME --commit-hash $GITHUB_SHA ./packages/website/out
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CF_API_TOKEN }}
+
+  changelog:
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-    name: Release
+    name: Changelog
     runs-on: ubuntu-latest
-    needs:
-      - test
-      - build
+    outputs:
+      releases_created: ${{ steps.tag-release.outputs.releases_created }}
     steps:
       - uses: GoogleCloudPlatform/release-please-action@v3
         id: tag-release
@@ -127,37 +123,31 @@ jobs:
           monorepo-tags: true
           package-name: website
           changelog-types: '[{"type":"feat","section":"Features","hidden":false},{"type":"fix","section":"Bug Fixes","hidden":false},{"type":"chore","section":"Other Changes","hidden":false}]'
+
+  release:
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main' && needs.changelog.outputs.releases_created
+    name: Release
+    runs-on: ubuntu-latest
+    needs:
+      - test
+      - preview
+      - changelog
+    steps:
       - uses: actions/checkout@v2
-        if: ${{ steps.tag-release.outputs.releases_created }}
       - uses: actions/setup-node@v2
-        if: ${{ steps.tag-release.outputs.releases_created }}
         with:
           node-version: '16'
           registry-url: https://registry.npmjs.org/
       - uses: bahmutov/npm-install@v1
-        if: ${{ steps.tag-release.outputs.releases_created }}
-      # --- Website deploy steps ----------------------------------------------
-      - name: Deploy to Cloudflare pages
-        if: ${{ steps.tag-release.outputs.releases_created }}
-        # Reset the `website-prod` branch to trigger a production build & deploy on Cloudflare Pages.
-        run: |
-          git push origin --delete website-prod
-          git push origin main:website-prod
-
       - run: npm run build -w packages/client
-        if: ${{ steps.tag-release.outputs.releases_created }}
       - run: npm run build -w packages/website
-        if: ${{ steps.tag-release.outputs.releases_created }}
         env:
           NEXT_PUBLIC_ENV: production
           NEXT_PUBLIC_API: https://api.web3.storage
           NEXT_PUBLIC_MAGIC: ${{ secrets.PROD_MAGIC_PUBLIC_KEY }}
           NEXT_PUBLIC_COUNTLY_URL: ${{ secrets.COUNTLY_URL }}
           NEXT_PUBLIC_COUNTLY_KEY: ${{ secrets.COUNTLY_KEY }}
-
-      # Add the site to web3.storage, output the cid as `steps.ipfs.outputs.cid`
       - name: Add to web3.storage
-        if: ${{ steps.tag-release.outputs.releases_created }}
         uses: web3-storage/add-to-web3@v2
         id: ipfs
         with:
@@ -165,9 +155,11 @@ jobs:
           web3_token: ${{ secrets.WEB3_TOKEN }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Deploy https://web3.storage
-        if: ${{ steps.tag-release.outputs.releases_created }}
+      - name: Deploy https://web3.storage to IPFS via DNSLink
         run: npx dnslink-cloudflare --record _dnslink --domain web3.storage --link /ipfs/${{ steps.ipfs.outputs.cid }}
         env:
           CF_API_TOKEN: ${{ secrets.CF_API_TOKEN }}
+      - name: Deploy https://web3.storage to Cloudflare Pages
+        run: npx wrangler pages publish --project-name web3.storage --branch main --commit-hash $GITHUB_SHA ./packages/website/out
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CF_API_TOKEN }}


### PR DESCRIPTION
Deploy the webite via the wrangler cli. The site we build in CI is the site that gets published to CF, instead of having to duplicate our build config and env vars in CF.

Move changlog / release-please into it's own job, so we can conditionally trigger the release job if a release was created, which removes many step level `if` checks

fixes #1469

License: (Apache-2.0 AND MIT)
Signed-off-by: Oli Evans <oli@tableflip.io>