### PR TITLE
fix: update content dag_size only if it has changed

### DIFF
--- a/.github/workflows/cron-dagcargo-sizes.yml
+++ b/.github/workflows/cron-dagcargo-sizes.yml
@@ -9,6 +9,10 @@ on:
         required: false
         description: Date used as a starting point for dag_sizes updates. This should be a string value specified in a format recognized by the Date.parse() method
         type: string
+      before:
+        required: false
+        description: Date used as confine dag_sizes updates. This should be a string value specified in a format recognized by the Date.parse() method
+        type: string
 
 jobs:
   update:
@@ -42,6 +46,7 @@ jobs:
           DAG_CARGO_USER: ${{ secrets.DAG_CARGO_USER }}
           DAG_CARGO_PASSWORD: ${{ secrets.DAG_CARGO_PASSWORD }}
           AFTER: ${{ github.event.inputs.after }}
+          BEFORE: ${{ github.event.inputs.before }}
         run: npm run start:dagcargo:sizes -w packages/cron
 
       - name: Heartbeat

--- a/packages/cron/src/bin/dagcargo-sizes.js
+++ b/packages/cron/src/bin/dagcargo-sizes.js
@@ -16,7 +16,8 @@ async function main () {
 
   try {
     const after = new Date(process.env.AFTER || xDaysAgo(1))
-    await updateDagSizes({ rwPg, cargoPool, after })
+    const before = process.env.BEFORE ? new Date(process.env.BEFORE) : undefined
+    await updateDagSizes({ rwPg, cargoPool, after, before })
   } finally {
     await rwPg.end()
     await cargoPool.end()

--- a/packages/cron/src/jobs/dagcargo.js
+++ b/packages/cron/src/jobs/dagcargo.js
@@ -29,6 +29,17 @@ RETURNING cid
 /**
  * Sets dag_size for content that does not yet have a size.
  *
+ * The approach taken in this function has been iterated upon a few times.
+ * The current implementation uses a direct connection to cargo, given FDW cross-joins proved to be expensive.
+ * Given we can't cross check sizes easily, the current implementation uses a naive approach.
+ * We get all the cids, and sizes of dags that originally claimed the wrong dag_size. This implies getting also
+ * dags which size has already been updated and fixed.
+ *
+ * If that's the case, we don't update the size in w3 content.
+ *
+ * This means we're going through content that shouldn't really be "considered" by the cron, however given this happens in the background
+ * and we mostly run this on the latest day content, the implementation should be good enough.
+ *
  * @param {Object} config
  * @param {import('pg').Client} config.rwPg
  * @param {import('pg').Pool} config.cargoPool

--- a/packages/cron/test/cargo.spec.js
+++ b/packages/cron/test/cargo.spec.js
@@ -194,8 +194,8 @@ describe('Fix dag sizes migration', () => {
       const beforeContent = beforeContents.find((cBefore) => cAfter.cid === cBefore.cid)
       return beforeContent?.updated_at !== cAfter.updated_at
     })
-    toBeUpdatedCids = toBeUpdated.map(c => ci.cid)
-    assert.strictEqual(updatedCidsFirstRound.slice().sort(), toBeUpdatedCids.slice().sort())
+
+    assert.deepStrictEqual(updatedCidsFirstRound.map(c => c.cid).sort(), toBeUpdated.slice().sort())
 
     await updateDagSizesWrp({ user })
     const afterSecondRoundContents = await getContents(dbClient, toBeUpdated)

--- a/packages/cron/test/cargo.spec.js
+++ b/packages/cron/test/cargo.spec.js
@@ -194,7 +194,8 @@ describe('Fix dag sizes migration', () => {
       const beforeContent = beforeContents.find((cBefore) => cAfter.cid === cBefore.cid)
       return beforeContent?.updated_at !== cAfter.updated_at
     })
-    assert.strictEqual(updatedCidsFirstRound.length, toBeUpdated.length)
+    toBeUpdatedCids = toBeUpdated.map(c => ci.cid)
+    assert.strictEqual(updatedCidsFirstRound.slice().sort(), toBeUpdatedCids.slice().sort())
 
     await updateDagSizesWrp({ user })
     const afterSecondRoundContents = await getContents(dbClient, toBeUpdated)

--- a/packages/db/test/utils.js
+++ b/packages/db/test/utils.js
@@ -329,3 +329,16 @@ export async function createCargoDag (dbClient, dag = {}, source = {}) {
     console.error(errorSources)
   }
 }
+
+/**
+ * Get contents from cids
+ *
+ * @param {string[]} cids
+ */
+export async function getContents (dbClient, cids) {
+  const { data, error } = await dbClient._client
+    .from('content')
+    .select()
+    .in('cid', cids)
+  return data
+}

--- a/packages/db/test/utils.js
+++ b/packages/db/test/utils.js
@@ -3,6 +3,7 @@ import * as pb from '@ipld/dag-pb'
 import { CID } from 'multiformats/cid'
 import { PostgrestClient } from '@supabase/postgrest-js'
 import { normalizeCid } from '../../api/src/utils/cid.js'
+import { DBError } from '../errors.js'
 
 export const token = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJyb2xlIjoicG9zdGdyZXMifQ.oM0SXF31Vs1nfwCaDxjlczE237KcNKhTpKEYxMX-jEU'
 export const dbEndpoint = 'http://127.0.0.1:3000'
@@ -340,5 +341,8 @@ export async function getContents (dbClient, cids) {
     .from('content')
     .select()
     .in('cid', cids)
+  if (error``) {
+    throw new DBError(error)
+  }
   return data
 }

--- a/packages/db/test/utils.js
+++ b/packages/db/test/utils.js
@@ -341,7 +341,7 @@ export async function getContents (dbClient, cids) {
     .from('content')
     .select()
     .in('cid', cids)
-  if (error``) {
+  if (error) {
     throw new DBError(error)
   }
   return data


### PR DESCRIPTION
## Context 
In this #1535 we moved to use a direct connection to cargo to avoid expensive FDW cross-joins.

As you can read in the [PR](https://github.com/web3-storage/web3.storage/pull/1535) description we also assumed cargo would pull the updated `claimed_dag_size`.
Unfortunately, that is not the case and that means we are updating the same content multiple times, despite it having been already fixed by the previous run.


## Solution
While more optimized solutions exist, given this runs in a cron job and we've been changing it so many times, I'm going with a naive solution here, where I just update dag size if it has changed. 
That means we still have a go through lots of content that should really be looked at. 

However, this shouldn't be a big problem, given this happens in a cron, and we mostly run this on new content anyway.

The same job is meant to be used to update historical data, I've added a `before` input so that we can confine the updates to specific ranges.
