### PR TITLE
feat: dag size job improvements

### DIFF
--- a/.github/workflows/cron-dagcargo-sizes.yml
+++ b/.github/workflows/cron-dagcargo-sizes.yml
@@ -25,7 +25,7 @@ jobs:
   update:
     name: Populate Missing Content DAG Sizes
     runs-on: ubuntu-latest
-    timeout-minutes: 60
+    timeout-minutes: ${{ (github.event_name == 'workflow_dispatch' && 360) || 60  }}
     steps:
       - uses: actions/checkout@v2
         with: 

--- a/.github/workflows/cron-dagcargo-sizes.yml
+++ b/.github/workflows/cron-dagcargo-sizes.yml
@@ -2,7 +2,7 @@ name: Update Content DAG Sizes
 
 on:
   schedule:
-    - cron: '61 * * * *'
+    - cron: '38 * * * *'
   workflow_dispatch:
     inputs:
       env:

--- a/.github/workflows/cron-dagcargo-sizes.yml
+++ b/.github/workflows/cron-dagcargo-sizes.yml
@@ -2,9 +2,16 @@ name: Update Content DAG Sizes
 
 on:
   schedule:
-    - cron: '38 * * * *'
+    - cron: '61 * * * *'
   workflow_dispatch:
     inputs:
+      env:
+        required: true
+        description: The env to run the cron against. Default is staging.
+        options: 
+          - staging
+          - production
+        default: production
       after:
         required: false
         description: Date used as a starting point for dag_sizes updates. This should be a string value specified in a format recognized by the Date.parse() method
@@ -18,15 +25,14 @@ jobs:
   update:
     name: Populate Missing Content DAG Sizes
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        env: ['staging', 'production']
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@v2
         with: 
           fetch-depth: 0
       - name: Checkout latest cron release tag
+       # Be able to run from latest main in staging
+        if: github.event.inputs.env != 'staging'
         run: |
           LATEST_TAG=$(git describe --tags --abbrev=0 --match='cron-*')
           git checkout $LATEST_TAG
@@ -37,7 +43,8 @@ jobs:
       - name: Run job
         env:
           DEBUG: '*'
-          ENV: ${{ matrix.env }}
+          ## By default let's fix only dags in production
+          ENV: ${{ github.event.inputs.env || 'production' }}
           STAGING_PG_CONNECTION: ${{ secrets.STAGING_PG_CONNECTION }}
           STAGING_RO_PG_CONNECTION: ${{ secrets.STAGING_PG_CONNECTION }} # no replica for staging
           PROD_PG_CONNECTION: ${{ secrets.PROD_PG_CONNECTION }}

--- a/packages/cron/src/bin/dagcargo-sizes.js
+++ b/packages/cron/src/bin/dagcargo-sizes.js
@@ -6,16 +6,17 @@ import { getCargoPgPool, getPg } from '../lib/utils.js'
 
 /**
  *
- * @param {number} days
+ * @param {number} seconds
+ * @returns
  */
-const xDaysAgo = (days) => new Date().setDate(new Date().getDate() - days)
+const xSecondsAgo = (seconds) => new Date().setSeconds(new Date().getSeconds() - seconds)
 
 async function main () {
   const rwPg = await getPg(process.env, 'rw')
   const cargoPool = getCargoPgPool(process.env)
 
   try {
-    const after = new Date(process.env.AFTER || xDaysAgo(1))
+    const after = new Date(process.env.AFTER || xSecondsAgo(60 * 60 * 4))
     const before = process.env.BEFORE ? new Date(process.env.BEFORE) : undefined
     await updateDagSizes({ rwPg, cargoPool, after, before })
   } finally {


### PR DESCRIPTION
A few quick wins to improve dag size job:
- run in prod only (both staging and prod run against the same cargo replica, let's avoid adding unnecessary load)
  - still able to run against staging manually 
- run on a shorter time frame by default
- longer timeout for manual distpatch to be able to run in against longer timeranges