### PR TITLE
fix: Make endpoint optional in Service interface

### DIFF
--- a/packages/client/src/lib/interface.ts
+++ b/packages/client/src/lib/interface.ts
@@ -13,7 +13,7 @@ import {
 export type Tagged<T, Tag> = T & { tag?: Tag }
 
 export interface Service {
-  endpoint: URL
+  endpoint?: URL
   token: string
   rateLimiter?: RateLimiter
   fetch?: typeof _fetch


### PR DESCRIPTION
The first example given [here](https://www.npmjs.com/package/web3.storage) fails with this error:
>Argument of type '{ token: string; }' is not assignable to parameter of type 'Service'.
  Property 'endpoint' is missing in type '{ token: string; }' but required in type 'Service'.ts(2345)
interface.d.ts(14, 5): 'endpoint' is declared here.

It looks like the type declaration for the Web3Storage constructor declares the options parameter type to be Service in the JSDoc and this gets picked up on for the TypeScript declaration.  This is one possible strategy which might fix it. 