### PR TITLE
fix: cron pins delete

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27328,7 +27328,7 @@
     },
     "packages/api": {
       "name": "@web3-storage/api",
-      "version": "7.0.1",
+      "version": "7.1.0",
       "license": "(Apache-2.0 OR MIT)",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.53.1",
@@ -28810,7 +28810,7 @@
     },
     "packages/cron": {
       "name": "@web3-storage/cron",
-      "version": "1.2.2",
+      "version": "1.5.0",
       "license": "(Apache-2.0 OR MIT)",
       "dependencies": {
         "@nftstorage/ipfs-cluster": "^5.0.1",
@@ -30693,7 +30693,7 @@
     },
     "packages/website": {
       "name": "@web3-storage/website",
-      "version": "2.8.4",
+      "version": "2.10.1",
       "dependencies": {
         "@docsearch/react": "^3.0.0",
         "@magic-ext/oauth": "^0.7.0",

--- a/packages/cron/src/jobs/pins.js
+++ b/packages/cron/src/jobs/pins.js
@@ -12,7 +12,7 @@ import { downgradeCid } from '../lib/cid.js'
  * Bounded by URL length for deleting pin sync requests.
  * e.g. DELEETE /pin_sync_request?id=in.%28227623241%2C227623242%2C227623243%2C227623244%2C227623245...
  */
-const MAX_PIN_REQUESTS_PER_RUN = 700
+const MAX_PIN_REQUESTS_PER_RUN = 500
 /**
  * 8k max request length to cluster for statusAll, we hit this at around 126 CIDs
  * http://nginx.org/en/docs/http/ngx_http_core_module.html#large_client_header_buffers


### PR DESCRIPTION
Diagnosed locally https://github.com/web3-storage/web3.storage/issues/1651 and got the underlying error throwed by pgrest: 414 URI Too Long response status code 

This seems a consequence of IDs of PINs increasing to a point where they have more digits resulting in a larger URL with query parameters. Reducing to 500 immediately ran for me locally

Once merged:
- [ ] Restart pins cron job

Closes #1651 