### PR TITLE
fix: overlap on token creator and a few mobile issues

### DIFF
--- a/packages/website/components/tokens/tokenCreator/tokenCreator.js
+++ b/packages/website/components/tokens/tokenCreator/tokenCreator.js
@@ -6,6 +6,7 @@ import countly from 'lib/countly';
 import Button, { ButtonVariant } from 'components/button/button';
 import { useTokens } from 'components/contexts/tokensContext';
 import { useUser } from 'hooks/use-user';
+import { BsPlus, BsArrowRight } from 'react-icons/bs';
 
 /**
  * @typedef {Object} TokenCreatorProps
@@ -18,8 +19,8 @@ import { useUser } from 'hooks/use-user';
  * @returns
  */
 const TokenCreator = ({ content }) => {
-  const inputRef = useRef(/** @type {HTMLInputElement|null} */ (null));
-  const [inputHasValue, setInputHasValue] = useState(/** @type {boolean} */ (false));
+  const inputRef = useRef(/** @type {HTMLInputElement|null} */(null));
+  const [inputHasValue, setInputHasValue] = useState(/** @type {boolean} */(false));
 
   const { query, push, replace } = useRouter();
   const { tokens, createToken, isCreating, getTokens, hasError, errorMessage } = useTokens();
@@ -33,13 +34,13 @@ const TokenCreator = ({ content }) => {
         countly.events.TOKEN_CREATE,
         !tokens.length
           ? {
-              ui: countly.ui.TOKENS_EMPTY,
-              action: 'New API Token',
-            }
+            ui: countly.ui.TOKENS_EMPTY,
+            action: 'New API Token',
+          }
           : {
-              ui: countly.ui.NEW_TOKEN,
-              action: 'Create new token',
-            }
+            ui: countly.ui.NEW_TOKEN,
+            action: 'Create new token',
+          }
       );
 
       e.preventDefault();
@@ -114,7 +115,9 @@ const TokenCreator = ({ content }) => {
                 inputRef.current?.classList.add('unfocused');
               }}
             />
-            <button className="token-creator-submit">{inputHasValue ? '→' : '+'}</button>
+            <button className="token-creator-submit">
+              {inputHasValue ? <BsArrowRight></BsArrowRight> : <BsPlus></BsPlus>}
+            </button>
           </form>
           {hasError ? (
             <>⚠ {errorMessage}</>

--- a/packages/website/components/tokens/tokenCreator/tokenCreator.js
+++ b/packages/website/components/tokens/tokenCreator/tokenCreator.js
@@ -1,3 +1,4 @@
+import { BsPlus, BsArrowRight } from 'react-icons/bs';
 import clsx from 'clsx';
 import { useRouter } from 'next/router';
 import { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react';
@@ -6,7 +7,6 @@ import countly from 'lib/countly';
 import Button, { ButtonVariant } from 'components/button/button';
 import { useTokens } from 'components/contexts/tokensContext';
 import { useUser } from 'hooks/use-user';
-import { BsPlus, BsArrowRight } from 'react-icons/bs';
 
 /**
  * @typedef {Object} TokenCreatorProps
@@ -19,8 +19,8 @@ import { BsPlus, BsArrowRight } from 'react-icons/bs';
  * @returns
  */
 const TokenCreator = ({ content }) => {
-  const inputRef = useRef(/** @type {HTMLInputElement|null} */(null));
-  const [inputHasValue, setInputHasValue] = useState(/** @type {boolean} */(false));
+  const inputRef = useRef(/** @type {HTMLInputElement|null} */ (null));
+  const [inputHasValue, setInputHasValue] = useState(/** @type {boolean} */ (false));
 
   const { query, push, replace } = useRouter();
   const { tokens, createToken, isCreating, getTokens, hasError, errorMessage } = useTokens();
@@ -34,13 +34,13 @@ const TokenCreator = ({ content }) => {
         countly.events.TOKEN_CREATE,
         !tokens.length
           ? {
-            ui: countly.ui.TOKENS_EMPTY,
-            action: 'New API Token',
-          }
+              ui: countly.ui.TOKENS_EMPTY,
+              action: 'New API Token',
+            }
           : {
-            ui: countly.ui.NEW_TOKEN,
-            action: 'Create new token',
-          }
+              ui: countly.ui.NEW_TOKEN,
+              action: 'Create new token',
+            }
       );
 
       e.preventDefault();

--- a/packages/website/components/tokens/tokenCreator/tokenCreator.js
+++ b/packages/website/components/tokens/tokenCreator/tokenCreator.js
@@ -111,9 +111,6 @@ const TokenCreator = ({ content }) => {
               className="token-creator-input"
               placeholder={content.placeholder}
               onChange={handleInputValueChange}
-              onBlur={() => {
-                inputRef.current?.classList.add('unfocused');
-              }}
             />
             <button className="token-creator-submit">
               {inputHasValue ? <BsArrowRight></BsArrowRight> : <BsPlus></BsPlus>}

--- a/packages/website/components/tokens/tokenCreator/tokenCreator.scss
+++ b/packages/website/components/tokens/tokenCreator/tokenCreator.scss
@@ -16,15 +16,6 @@
         align-items: end;
       }
     }
-
-    .token-creator-submit {
-      // font-size: 1rem;
-      // top: 50%;
-      // transform: translateY(-50%);
-      // &:hover {
-      //   transform: translateY(-50%) scale(1.1);
-      // }
-    }
   }
 }
 

--- a/packages/website/components/tokens/tokenCreator/tokenCreator.scss
+++ b/packages/website/components/tokens/tokenCreator/tokenCreator.scss
@@ -9,14 +9,21 @@
 
   @include fontSize_Mini;
   @include medium {
-    position: absolute;
-    top: 10rem;
     width: 100%;
     .button {
       width: 100%;
       button {
         align-items: end;
       }
+    }
+
+    .token-creator-submit {
+      // font-size: 1rem;
+      // top: 50%;
+      // transform: translateY(-50%);
+      // &:hover {
+      //   transform: translateY(-50%) scale(1.1);
+      // }
     }
   }
 }
@@ -87,6 +94,10 @@
 .token-creator-submit {
   position: absolute;
   right: 1.25rem;
+  height: 100%;
+  top: 0;
+  display: flex;
+  align-items: center;
   @include fontSize_MediumLarge;
   @include hoverScale;
   .token-creator-check {

--- a/packages/website/components/tokens/tokensManager/tokensManager.scss
+++ b/packages/website/components/tokens/tokensManager/tokensManager.scss
@@ -54,7 +54,7 @@
     margin-right: 4.6875rem;
     @include medium {
       flex-basis: 100%;
-      margin-top: 5rem;
+      margin-top: 1.5rem;
       order: 3;
       margin-right: 0;
     }

--- a/packages/website/pages/tokens/index.js
+++ b/packages/website/pages/tokens/index.js
@@ -1,5 +1,4 @@
 import clsx from 'clsx';
-import Link from 'next/link';
 import { useEffect, useState } from 'react';
 
 import TokenCreator from 'components/tokens/tokenCreator/tokenCreator';

--- a/packages/website/pages/tokens/index.js
+++ b/packages/website/pages/tokens/index.js
@@ -42,7 +42,7 @@ const Tokens = () => {
           href={content.ui.return.url}
           variant={content.ui.return.theme}
         >
-          <Link href={content.ui.return.url}>{content.ui.return.text}</Link>
+          {content.ui.return.text}
         </Button>
         <div dangerouslySetInnerHTML={{ __html: content.ui.test_token }} className="testing-cta-container"></div>
       </div>

--- a/packages/website/pages/tokens/index.scss
+++ b/packages/website/pages/tokens/index.scss
@@ -16,6 +16,13 @@
 .tokens-header {
   position: relative;
   z-index: 1;
+
+  @include medium {
+    margin-bottom: 2rem;
+    .table-heading {
+      display: none;
+    }
+  }
 }
 
 .tokens-header,
@@ -49,6 +56,9 @@
     margin-left: unset;
     order: 2;
     flex-basis: 100%;
+  }
+  .button-contents {
+    display: inline-block;
   }
   div {
     display: none;


### PR DESCRIPTION
closes #1608

The api tokens header is redundant especially on mobile. This PR changes the view from:
<img width="607" alt="Screen Shot 2022-07-19 at 11 56 12 AM" src="https://user-images.githubusercontent.com/1189523/179828347-711d2bd2-592c-45dc-80a7-ae26656656bb.png">

to this improved version here:
<img width="1367" alt="Screen Shot 2022-07-19 at 12 02 14 PM" src="https://user-images.githubusercontent.com/1189523/179828571-630e28ac-e096-4206-8493-30a56428ba08.png">


I also fixed a bad link in the footer which had nested link tags:
<img width="1092" alt="Screen Shot 2022-07-19 at 11 49 19 AM" src="https://user-images.githubusercontent.com/1189523/179828667-d43e4a74-e983-4c30-bb1d-f4674398b0ef.png">

Also changed the input button to use icons to avoid baseline issues with the font "+" so that it is correctly centered.
<img width="1333" alt="Screen Shot 2022-07-19 at 12 03 16 PM" src="https://user-images.githubusercontent.com/1189523/179828752-f20ca58a-2eb6-493d-b210-e7e2055442c1.png">

