### PR TITLE
chore: bring back cron to remove remote status pins

### DIFF
--- a/.github/workflows/delete-remote-pins.yaml
+++ b/.github/workflows/delete-remote-pins.yaml
@@ -1,0 +1,46 @@
+name: Delete Remote Pins
+
+on:
+  workflow_dispatch:
+    inputs:
+      batch_size:
+        required: false
+        description: Size of a delete batch
+        type: number
+      env:
+        required: true
+        description: The env to run the cron against. Default is staging.
+        options: 
+          - staging
+          - production
+        default: staging
+
+jobs:
+  delete-remote-pins:
+    name: Delete remote pins
+    runs-on: ubuntu-latest
+    timeout-minutes: 360
+    steps:
+      - uses: actions/checkout@v2
+        with: 
+          fetch-depth: 0
+      - name: Checkout latest cron release tag
+        # Be able to run from latest main in staging
+        if: github.event.inputs.env == 'production'
+        run: |
+          LATEST_TAG=$(git describe --tags --abbrev=0 --match='cron-*')
+          git checkout $LATEST_TAG
+      - name: Setup node
+        uses: actions/setup-node@v2
+        with:
+          node-version: 16
+      - name: Install dependencies
+        uses: bahmutov/npm-install@v1
+      - name: Run job
+        env:
+          DEBUG: '*'
+          ENV: ${{ github.event.inputs.env }}
+          STAGING_PG_CONNECTION: ${{ secrets.STAGING_PG_CONNECTION }} # no replica for staging
+          PROD_PG_CONNECTION: ${{ secrets.PROD_PG_CONNECTION }}
+          BATCH_SIZE:  ${{ github.event.inputs.batch_size }}
+        run: npm run start:delete-remote-pins -w packages/cron

--- a/packages/cron/package.json
+++ b/packages/cron/package.json
@@ -11,6 +11,7 @@
     "start:pins": "node src/bin/pins.js",
     "start:dagcargo:sizes": "NODE_TLS_REJECT_UNAUTHORIZED=0 node src/bin/dagcargo-sizes.js",
     "start:storage": "NODE_TLS_REJECT_UNAUTHORIZED=0 node src/bin/storage.js",
+    "start:delete-remote-pins": "NODE_TLS_REJECT_UNAUTHORIZED=0 node src/bin/delete-remote-pins.js",
     "test": "npm-run-all -p -r test:e2e",
     "test:e2e": "mocha --require ./test/hooks.js test/*.spec.js --timeout 5000"
   },

--- a/packages/cron/src/bin/delete-remote-pins.js
+++ b/packages/cron/src/bin/delete-remote-pins.js
@@ -1,0 +1,19 @@
+#!/usr/bin/env node
+
+import { deleteRemotePins } from '../jobs/delete-remote-pins.js'
+import { envConfig } from '../lib/env.js'
+import { getPgPool } from '../lib/utils.js'
+
+async function main () {
+  const rwPgPool = getPgPool(process.env, 'rw')
+  const batchSize = process.env.BATCH_SIZE ? parseInt(process.env.BATCH_SIZE, 10) : undefined
+
+  try {
+    deleteRemotePins({ rwPgPool, batchSize })
+  } finally {
+    await rwPgPool.end()
+  }
+}
+
+envConfig()
+main()

--- a/packages/cron/src/jobs/delete-remote-pins.js
+++ b/packages/cron/src/jobs/delete-remote-pins.js
@@ -1,0 +1,45 @@
+import debug from 'debug'
+
+const BATCH_SIZE = 1_000_000
+
+const DELETE_QUERY = `
+WITH pins_to_delete as (SELECT id FROM pin WHERE status='Remote' LIMIT $1),
+p_sync_delete as (
+  DELETE FROM pin_sync_request WHERE pin_id IN (SELECT id FROM pins_to_delete)
+)
+DELETE FROM pin WHERE id IN (SELECT id FROM pins_to_delete) returning id;
+`
+
+const log = debug('pins:deleteRemotePins')
+
+/**
+ * It deletes "Remote" pins in batches
+ *
+ * Rationale behind going for a cron job instead of a data migration).
+ * 1. avoid to match strain on the DB a single operation on several thousands millions of rows.
+ * Deletes hold ROW EXCLUSIVE lock that might affect other process trying to update that data.
+ * Also updating that amount of rows might be holding quite a lot of stuff in memory.
+ * 2. cron can be easily run once deployed and does not require db write access.
+ * 3. it can easily be run again if any other Remote pins happen to slip in.
+ *
+ * @param {object} config
+ * @param {import('pg').Pool} config.rwPgPool
+ * @param {number} [config.batchSize]
+ */
+export async function deleteRemotePins ({ rwPgPool, batchSize = BATCH_SIZE }) {
+  if (!log.enabled) {
+    console.log('ℹ️ Enable logging by setting DEBUG=pins:deleteRemotePins')
+  }
+  let totalDeleted = 0
+
+  while (true) {
+    const result = await rwPgPool.query(DELETE_QUERY, [batchSize])
+    log(`💪 Succsesfully deleted ${result.rowCount} Remote pins in the current batch`)
+
+    if (result.rowCount === 0) {
+      break
+    }
+    totalDeleted += result.rowCount
+  }
+  log(`✅ Done. The Job succsesfully deleted ${totalDeleted} Remote pins in total.`)
+}


### PR DESCRIPTION
Brings back job from https://github.com/web3-storage/web3.storage/pull/1615 because of regression introduced with cron job https://github.com/web3-storage/web3.storage/pull/1660