### PR TITLE
feat: add error tooltips to file uploader

### DIFF
--- a/packages/website/components/account/fileUploader/fileUploader.js
+++ b/packages/website/components/account/fileUploader/fileUploader.js
@@ -64,11 +64,12 @@ const FileUploader = ({ className = '', content, uploadModalState, background })
   // Mapped out file progress info
   const filesInfo = useMemo(
     () =>
-      Object.values(uploadsProgress.files).map(({ inputFile, progress, uploadId, status }, i) => ({
+      Object.values(uploadsProgress.files).map(({ inputFile, progress, uploadId, status, error }, i) => ({
         uploadId,
         name: inputFile.name,
         progress: progress.percentage,
         failed: status === STATUS.FAILED,
+        error,
       })),
     [uploadsProgress]
   );

--- a/packages/website/modules/zero/components/dropzone/dropzone.js
+++ b/packages/website/modules/zero/components/dropzone/dropzone.js
@@ -1,6 +1,8 @@
 import clsx from 'clsx';
 import { useCallback, Fragment, useState } from 'react';
 import { useDropzone } from 'react-dropzone';
+import Tooltip from 'ZeroComponents/tooltip/tooltip';
+
 import UploadProgress from './uploadProgress';
 
 /**
@@ -18,6 +20,7 @@ import UploadProgress from './uploadProgress';
  *          name: string, uploadId:
  *          string,
  *          failed: boolean,
+ *          error: Error
  *        }[]} [filesInfo] external upload information of files
  * @prop {{loading: string, complete: string, failed: string}} [content]
  */
@@ -69,14 +72,16 @@ const Dropzone = ({
           <Fragment key={`file-${fileInfo.uploadId}`}>
             <div className="filename">{fileInfo.name}</div>
             <div className="status">
-              {!!fileInfo.failed
-                ? content.failed
-                : fileInfo.progress !== 100
-                ? <UploadProgress
-                    label={content.loading}
-                    progress={fileInfo.progress}
-                  />
-                : content.complete}
+              {!!fileInfo.failed ? (
+                <>
+                  {content.failed}{' '}
+                  {fileInfo?.error?.message && <Tooltip content={fileInfo.error.message} position="right" />}
+                </>
+              ) : fileInfo.progress !== 100 ? (
+                <UploadProgress label={content.loading} progress={fileInfo.progress} />
+              ) : (
+                content.complete
+              )}
             </div>
           </Fragment>
         ))}


### PR DESCRIPTION
Closes #1552 

Adds a tooltip next to the "Failed" text on file uploads that displays the error from the API.