### PR TITLE
fix: increase cron pins timeout to 15 mins

### DIFF
--- a/.github/workflows/cron-pins.yml
+++ b/.github/workflows/cron-pins.yml
@@ -2,7 +2,7 @@ name: Cron Pins
 
 on:
   schedule:
-    - cron: '*/10 * * * *'
+    - cron: '*/15 * * * *'
   workflow_dispatch:
 
 jobs:
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         env: ['staging', 'production']
-    timeout-minutes: 10
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v2
         with: 


### PR DESCRIPTION
This cron job timeouts once in a while https://github.com/web3-storage/web3.storage/actions/workflows/cron-pins.yml. Let's use 15min instead