### PR TITLE
chore: ipns record migration to w3name

### DIFF
--- a/.github/workflows/cron-names.yml
+++ b/.github/workflows/cron-names.yml
@@ -1,0 +1,44 @@
+name: Cron migrate IPNS records to w3name
+
+on:
+  schedule:
+    - cron: '* */24 * * *'
+  workflow_dispatch:
+
+jobs:
+  update:
+    name: Export IPNS records to w3name
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        env: ['staging', 'production']
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v2
+        with: 
+          fetch-depth: 0
+      - name: Checkout latest cron release tag
+        run: |
+          LATEST_TAG=$(git describe --tags --abbrev=0 --match='cron-*')
+          git checkout $LATEST_TAG
+      - name: Setup node
+        uses: actions/setup-node@v1
+        with:
+          node-version: 16
+
+      - name: Install dependencies
+        uses: bahmutov/npm-install@v1
+
+      - name: Run job
+        env:
+          DEBUG: '*'
+          ENV: ${{ matrix.env }}
+          PROD_PG_REST_JWT: ${{ secrets.PROD_PG_REST_JWT }}
+          STAGING_PG_REST_JWT: ${{ secrets.STAGING_PG_REST_JWT }}
+          PROD_PG_REST_URL: ${{ secrets.PROD_PG_REST_URL }}
+          STAGING_PG_REST_URL: ${{ secrets.STAGING_PG_REST_URL }}
+          CLUSTER_API_URL: ${{ secrets.CLUSTER_API_URL }}
+          CLUSTER_BASIC_AUTH_TOKEN: ${{ secrets.CLUSTER_BASIC_AUTH_TOKEN }}
+          CLUSTER_IPFS_PROXY_API_URL: ${{ secrets.CLUSTER_IPFS_PROXY_API_URL }}
+          CLUSTER_IPFS_PROXY_BASIC_AUTH_TOKEN: ${{ secrets.CLUSTER_IPFS_PROXY_BASIC_AUTH_TOKEN }}
+        run: npm run start:names -w packages/cron

--- a/.github/workflows/cron-names.yml
+++ b/.github/workflows/cron-names.yml
@@ -4,6 +4,14 @@ on:
   schedule:
     - cron: '* */24 * * *'
   workflow_dispatch:
+    inputs:
+      env:
+        required: true
+        description: The env to run the cron against. Default is staging.
+        options: 
+          - staging
+          - production
+        default: staging
 
 jobs:
   update:

--- a/.github/workflows/cron-names.yml
+++ b/.github/workflows/cron-names.yml
@@ -8,7 +8,7 @@ on:
       env:
         required: true
         description: The env to run the cron against. Default is staging.
-        options: 
+        options:
           - staging
           - production
         default: staging
@@ -23,7 +23,7 @@ jobs:
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@v2
-        with: 
+        with:
           fetch-depth: 0
       - name: Checkout latest cron release tag
         run: |
@@ -40,7 +40,7 @@ jobs:
       - name: Run job
         env:
           DEBUG: '*'
-          ENV: ${{ matrix.env }}
+          ENV: ${{ github.event.inputs.env || matrix.env }}
           PROD_PG_REST_JWT: ${{ secrets.PROD_PG_REST_JWT }}
           STAGING_PG_REST_JWT: ${{ secrets.STAGING_PG_REST_JWT }}
           PROD_PG_REST_URL: ${{ secrets.PROD_PG_REST_URL }}

--- a/packages/cron/package.json
+++ b/packages/cron/package.json
@@ -12,6 +12,7 @@
     "start:dagcargo:sizes": "NODE_TLS_REJECT_UNAUTHORIZED=0 node src/bin/dagcargo-sizes.js",
     "start:storage": "NODE_TLS_REJECT_UNAUTHORIZED=0 node src/bin/storage.js",
     "start:delete-remote-pins": "NODE_TLS_REJECT_UNAUTHORIZED=0 node src/bin/delete-remote-pins.js",
+    "start:names": "NODE_TLS_REJECT_UNAUTHORIZED=0 node src/bin/names.js",
     "test": "npm-run-all -p -r test:e2e",
     "test:e2e": "mocha --require ./test/hooks.js test/*.spec.js --timeout 5000"
   },

--- a/packages/cron/src/bin/names.js
+++ b/packages/cron/src/bin/names.js
@@ -1,0 +1,20 @@
+#!/usr/bin/env node
+
+import fetch from '@web-std/fetch'
+import { postNamesToW3name } from '../jobs/names.js'
+import { envConfig } from '../lib/env.js'
+import { getCluster, getDBClient } from '../lib/utils.js'
+
+/** @ts-ignore */
+global.fetch = fetch
+
+async function main () {
+  const env = process.env.ENV || 'dev'
+  const db = getDBClient(process.env)
+
+  await postNamesToW3name({ env, db })
+}
+
+envConfig()
+
+main()

--- a/packages/cron/src/bin/names.js
+++ b/packages/cron/src/bin/names.js
@@ -17,4 +17,4 @@ async function main () {
 
 envConfig()
 
-await main()
+main()

--- a/packages/cron/src/bin/names.js
+++ b/packages/cron/src/bin/names.js
@@ -3,7 +3,7 @@
 import fetch from '@web-std/fetch'
 import { postNamesToW3name } from '../jobs/names.js'
 import { envConfig } from '../lib/env.js'
-import { getCluster, getDBClient } from '../lib/utils.js'
+import { getDBClient } from '../lib/utils.js'
 
 /** @ts-ignore */
 global.fetch = fetch

--- a/packages/cron/src/bin/names.js
+++ b/packages/cron/src/bin/names.js
@@ -17,4 +17,4 @@ async function main () {
 
 envConfig()
 
-main()
+await main()

--- a/packages/cron/src/jobs/names.js
+++ b/packages/cron/src/jobs/names.js
@@ -2,8 +2,8 @@ import debug from 'debug'
 import retry from 'p-retry'
 
 const MAX_REQUEST_PAGE = 10
-const W3NAME_API_URL_STAGING = 'https://w3name-staging.protocol-labs.workers.dev/'
-const W3NAME_API_URL_PRODUCTION = 'https://w3name-production.protocol-labs.workers.dev/'
+const W3NAME_API_URL_STAGING = 'https://name.web3.storage/'
+const W3NAME_API_URL_PRODUCTION = 'https://name-staging.web3.storage/'
 const log = debug('names:postNamesToW3name')
 
 /**

--- a/packages/cron/src/jobs/names.js
+++ b/packages/cron/src/jobs/names.js
@@ -1,0 +1,50 @@
+import debug from 'debug'
+import retry from 'p-retry'
+
+const MAX_REQUEST_PAGE = 10
+const W3NAME_URL = 'http://localhost:8989'
+const log = debug('names:postNamesToW3name')
+
+/**
+ * @param {{
+ *   db: import('@web3-storage/db').DBClient
+ * }} config
+ */
+export async function postNamesToW3name ({ db }) {
+    let from = 0
+    let to = MAX_REQUEST_PAGE - 1
+
+    while (true) {
+        if (log.enabled) {
+            console.log('Query page', from, to)
+        }
+        const queryRes = await retry(() => db.listNames({ from, to }), { onFailedAttempt: log })
+        if (queryRes.length > 0) {
+            await Promise.all(queryRes.map(postKeyW3Name))
+            from = to + 1
+            to = from + MAX_REQUEST_PAGE - 1
+        } else {
+            if (log.enabled) {
+                console.log('Finished')
+            }
+            break
+        }
+    }
+}
+
+/**
+ * @param {import('@web3-storage/db/db-client-types').NameItem} name
+ * @returns {Promise<void>}
+ */
+async function postKeyW3Name (name) {
+    const key = name.key
+
+    const res = await fetch(`${W3NAME_URL}/name/${key}`, {
+        method: 'POST',
+        body: name.record
+    })
+
+    if (log.enabled) {
+        console.log(res.status, res.statusText, await res.text())
+    }
+}

--- a/packages/cron/src/jobs/names.js
+++ b/packages/cron/src/jobs/names.js
@@ -2,15 +2,18 @@ import debug from 'debug'
 import retry from 'p-retry'
 
 const MAX_REQUEST_PAGE = 10
-const W3NAME_URL = 'http://localhost:8989'
+const W3NAME_API_URL_STAGING = 'https://w3name-staging.protocol-labs.workers.dev/'
+const W3NAME_API_URL_PRODUCTION = 'https://w3name-production.protocol-labs.workers.dev/'
 const log = debug('names:postNamesToW3name')
 
 /**
  * @param {{
+ *   env: string
  *   db: import('@web3-storage/db').DBClient
  * }} config
  */
-export async function postNamesToW3name ({ db }) {
+export async function postNamesToW3name ({ env, db }) {
+    const w3nameApiURL = getW3NameAPIURL(env)
     let from = 0
     let to = MAX_REQUEST_PAGE - 1
 
@@ -20,7 +23,7 @@ export async function postNamesToW3name ({ db }) {
         }
         const queryRes = await retry(() => db.listNames({ from, to }), { onFailedAttempt: log })
         if (queryRes.length > 0) {
-            await Promise.all(queryRes.map(postKeyW3Name))
+            await Promise.all(queryRes.map((name) => postKeyW3Name(name, w3nameApiURL)))
             from = to + 1
             to = from + MAX_REQUEST_PAGE - 1
         } else {
@@ -33,13 +36,31 @@ export async function postNamesToW3name ({ db }) {
 }
 
 /**
+ * @param {string} env
+ * @returns {string}
+ */
+function getW3NameAPIURL (env) {
+    switch (env) {
+        case 'dev':
+            return 'http://localhost:8989'
+        case 'staging':
+            return W3NAME_API_URL_STAGING
+        case 'production':
+            return W3NAME_API_URL_PRODUCTION
+    }
+    return ''
+}
+
+/**
  * @param {import('@web3-storage/db/db-client-types').NameItem} name
  * @returns {Promise<void>}
  */
-async function postKeyW3Name (name) {
+async function postKeyW3Name (name, w3nameApiURL='') {
     const key = name.key
 
-    const res = await fetch(`${W3NAME_URL}/name/${key}`, {
+    if (!w3nameApiURL) { return }
+
+    const res = await fetch(`${w3nameApiURL}/name/${key}`, {
         method: 'POST',
         body: name.record
     })

--- a/packages/cron/src/jobs/names.js
+++ b/packages/cron/src/jobs/names.js
@@ -12,7 +12,7 @@ const log = debug('names:postNamesToW3name')
  *   db: import('@web3-storage/db').DBClient
  * }} config
  */
-export async function postNamesToW3name({ env, db }) {
+export async function postNamesToW3name ({ env, db }) {
   const w3nameApiURL = getW3NameAPIURL(env)
   let from = 0
   let to = MAX_REQUEST_PAGE - 1
@@ -41,7 +41,7 @@ export async function postNamesToW3name({ env, db }) {
  * @param {string} env
  * @returns {string}
  */
-function getW3NameAPIURL(env) {
+function getW3NameAPIURL (env) {
   switch (env) {
     case 'dev':
       return 'http://localhost:8989'
@@ -57,7 +57,7 @@ function getW3NameAPIURL(env) {
  * @param {import('@web3-storage/db/db-client-types').NameItem} name
  * @returns {Promise<void>}
  */
-async function postKeyW3Name(name, w3nameApiURL = '') {
+async function postKeyW3Name (name, w3nameApiURL = '') {
   const key = name.key
 
   if (!w3nameApiURL) { return }

--- a/packages/cron/src/jobs/names.js
+++ b/packages/cron/src/jobs/names.js
@@ -12,60 +12,62 @@ const log = debug('names:postNamesToW3name')
  *   db: import('@web3-storage/db').DBClient
  * }} config
  */
-export async function postNamesToW3name ({ env, db }) {
-    const w3nameApiURL = getW3NameAPIURL(env)
-    let from = 0
-    let to = MAX_REQUEST_PAGE - 1
+export async function postNamesToW3name({ env, db }) {
+  const w3nameApiURL = getW3NameAPIURL(env)
+  let from = 0
+  let to = MAX_REQUEST_PAGE - 1
 
-    while (true) {
-        if (log.enabled) {
-            console.log('Query page', from, to)
-        }
-        const queryRes = await retry(() => db.listNames({ from, to }), { onFailedAttempt: log })
-        if (queryRes.length > 0) {
-            await Promise.all(queryRes.map((name) => postKeyW3Name(name, w3nameApiURL)))
-            from = to + 1
-            to = from + MAX_REQUEST_PAGE - 1
-        } else {
-            if (log.enabled) {
-                console.log('Finished')
-            }
-            break
-        }
+  while (true) {
+    if (log.enabled) {
+      console.log('Query page', from, to)
     }
+
+    const queryRes = await retry(() => db.listNames({ from, to }), { onFailedAttempt: log })
+
+    if (queryRes.length > 0) {
+      await Promise.all(queryRes.map((name) => postKeyW3Name(name, w3nameApiURL)))
+      from = to + 1
+      to = from + MAX_REQUEST_PAGE - 1
+    } else {
+      if (log.enabled) {
+        console.log('Finished')
+      }
+      break
+    }
+  }
 }
 
 /**
  * @param {string} env
  * @returns {string}
  */
-function getW3NameAPIURL (env) {
-    switch (env) {
-        case 'dev':
-            return 'http://localhost:8989'
-        case 'staging':
-            return W3NAME_API_URL_STAGING
-        case 'production':
-            return W3NAME_API_URL_PRODUCTION
-    }
-    return ''
+function getW3NameAPIURL(env) {
+  switch (env) {
+    case 'dev':
+      return 'http://localhost:8989'
+    case 'staging':
+      return W3NAME_API_URL_STAGING
+    case 'production':
+      return W3NAME_API_URL_PRODUCTION
+  }
+  return ''
 }
 
 /**
  * @param {import('@web3-storage/db/db-client-types').NameItem} name
  * @returns {Promise<void>}
  */
-async function postKeyW3Name (name, w3nameApiURL='') {
-    const key = name.key
+async function postKeyW3Name(name, w3nameApiURL = '') {
+  const key = name.key
 
-    if (!w3nameApiURL) { return }
+  if (!w3nameApiURL) { return }
 
-    const res = await fetch(`${w3nameApiURL}/name/${key}`, {
-        method: 'POST',
-        body: name.record
-    })
+  const res = await fetch(`${w3nameApiURL}/name/${key}`, {
+    method: 'POST',
+    body: name.record
+  })
 
-    if (log.enabled) {
-        console.log(res.status, res.statusText, await res.text())
-    }
+  if (log.enabled) {
+    console.log(res.status, res.statusText, await res.text())
+  }
 }

--- a/packages/db/index.js
+++ b/packages/db/index.js
@@ -1315,4 +1315,28 @@ export class DBClient {
       throw new DBError(error)
     }
   }
+
+
+  /**
+   * List IPNS records
+   *
+   * @param {{ from: number, to: number }} [opts]
+   * @returns {Promise<Array<import('./db-client-types').NameItem>>}
+   */
+  async listNames(opts = {}) {
+    const query = this._client
+      .from('name')
+      .select('*')
+      .order('inserted_at', { ascending: true })
+      .range(opts.from || 0, opts.to || 10)
+
+    /** @type {{ data: Array<import('./db-client-types').NameItem>, error: Error }} */
+    const { data: names, error } = await query
+
+    if (error) {
+      throw new DBError(error)
+    }
+
+    return names
+  }
 }

--- a/packages/db/index.js
+++ b/packages/db/index.js
@@ -1316,14 +1316,13 @@ export class DBClient {
     }
   }
 
-
   /**
    * List IPNS records
    *
    * @param {{ from: number, to: number }} [opts]
    * @returns {Promise<Array<import('./db-client-types').NameItem>>}
    */
-  async listNames(opts = {}) {
+  async listNames (opts = {}) {
     const query = this._client
       .from('name')
       .select('*')


### PR DESCRIPTION
This script will run as a CRON job to push name records to w3name.

If the record was already migrated or superseded you will see the following error message `400 Bad Request {"message":"invalid record: the record is outdated."}` otherwise `202 Accepted {"id":"k51qzi5uqu5dkf4iy7zpxjasuk2b6x4wqr9vp7cd8m3x2kdlav02ppw9d9ulwf"}`.