### PR TITLE
fix: limit production job should not fail if staging one fails

### DIFF
--- a/.github/workflows/cron-storage-limits.yaml
+++ b/.github/workflows/cron-storage-limits.yaml
@@ -13,6 +13,7 @@ jobs:
     name: Send notifications
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         env: ['staging', 'production']
     timeout-minutes: 340


### PR DESCRIPTION
## Context
The `Storage Limit Email Notifications` workflow use stategy matrix (as other worflows in the project, ie metrics, cron-pins etc) to run against different environments.

That's cool, however, by default strategy has `fail-fast: true` and that means all jobs are cancelled if one in the workflow fails.
This practically means that if staging fails prod is skipped/cancelled, creating a dependency/coupling between the 2 environments we don't want.

 