### PR TITLE
fix: Make PSA Errors compliant

### DIFF
--- a/packages/api/src/error-handler.js
+++ b/packages/api/src/error-handler.js
@@ -17,11 +17,11 @@ export function errorHandler (err, { log }, request) {
   // As the pinning service requires a certain specification
   // Always return the nested error object for any pinning service endpoints
   const requestUrl = new URL(request.url)
-  if (err instanceof PinningServiceApiError || requestUrl.pathname.test(/^\/pins$/)) {
+  if (err instanceof PinningServiceApiError || (requestUrl && /^\/pins/.test(requestUrl.pathname))) {
     const error = {
       error: {
-        reason: err.reason || err.message,
-        details: err.details || err.code
+        reason: err.reason || err.code,
+        details: err.details || err.message
       }
     }
     return new JSONResponse(error, { status })

--- a/packages/api/src/error-handler.js
+++ b/packages/api/src/error-handler.js
@@ -18,7 +18,7 @@ export function errorHandler (err, { log }, request) {
   // As the pinning service requires a certain specification
   // Always return the nested error object for any pinning service endpoints
   const requestUrl = new URL(request.url)
-  if (err instanceof PinningServiceApiError || (requestUrl && /^\/pins/.test(requestUrl.pathname))) {
+  if (err instanceof PinningServiceApiError || /^\/pins/.test(requestUrl.pathname)) {
     const error = {
       error: {
         reason: err.reason || err.code,

--- a/packages/api/src/error-handler.js
+++ b/packages/api/src/error-handler.js
@@ -5,6 +5,7 @@ import { HTTPError, PinningServiceApiError } from './errors.js'
 /**
  * @param {Error & {status?: number;code?: string;reason?: string; details?: string; }} err
  * @param {import('./env').Env} env
+ * @param {Request} request
  */
 export function errorHandler (err, { log }, request) {
   console.error(err.stack)

--- a/packages/api/src/error-handler.js
+++ b/packages/api/src/error-handler.js
@@ -6,7 +6,7 @@ import { HTTPError, PinningServiceApiError } from './errors.js'
  * @param {Error & {status?: number;code?: string;reason?: string; details?: string; }} err
  * @param {import('./env').Env} env
  */
-export function errorHandler (err, { log }) {
+export function errorHandler (err, { log }, request) {
   console.error(err.stack)
 
   let status = err.status || 500
@@ -14,10 +14,13 @@ export function errorHandler (err, { log }) {
     log.error(err)
   }
 
-  if (err instanceof PinningServiceApiError) {
+  const requestUrl = new URL(request.url)
+  if (err instanceof PinningServiceApiError || requestUrl.pathname.test(/^\/pins$/)) {
     const error = {
-      reason: err.reason,
-      details: err.details
+      error: {
+        reason: err.reason || err.message,
+        details: err.details || err.code
+      }
     }
     return new JSONResponse(error, { status })
   }

--- a/packages/api/src/error-handler.js
+++ b/packages/api/src/error-handler.js
@@ -14,6 +14,8 @@ export function errorHandler (err, { log }, request) {
     log.error(err)
   }
 
+  // As the pinning service requires a certain specification
+  // Always return the nested error object for any pinning service endpoints
   const requestUrl = new URL(request.url)
   if (err instanceof PinningServiceApiError || requestUrl.pathname.test(/^\/pins$/)) {
     const error = {

--- a/packages/api/src/errors.js
+++ b/packages/api/src/errors.js
@@ -50,7 +50,7 @@ export class PinningUnauthorizedError extends PinningServiceApiError {
   constructor (msg = 'Pinning not authorized for this user, email support@web3.storage to request authorization.') {
     super(msg, 403)
     this.name = 'PinningUnauthorizedError'
-    this.code = PinningUnauthorizedError.CODE
+    this.reason = PinningUnauthorizedError.CODE
   }
 }
 PinningUnauthorizedError.CODE = 'ERROR_PINNING_UNAUTHORIZED'

--- a/packages/api/src/errors.js
+++ b/packages/api/src/errors.js
@@ -49,7 +49,6 @@ UserNotFoundError.CODE = 'ERROR_USER_NOT_FOUND'
 export class PinningUnauthorizedError extends PinningServiceApiError {
   constructor (msg = 'Pinning not authorized for this user, email support@web3.storage to request authorization.') {
     super(msg, 403)
-    this.name = 'PinningUnauthorizedError'
     this.reason = PinningUnauthorizedError.CODE
   }
 }

--- a/packages/api/src/errors.js
+++ b/packages/api/src/errors.js
@@ -22,6 +22,21 @@ export class HTTPError extends Error {
   }
 }
 
+export class PinningServiceApiError extends Error {
+  /**
+   *
+   * @param {string} [message]
+   * @param {number} [status]
+   * @param {string} code
+   */
+  constructor (message, status = 400, code = 'PSA_ERROR') {
+    super(message)
+    this.details = message
+    this.status = status
+    this.reason = code
+  }
+}
+
 export class UserNotFoundError extends HTTPError {
   constructor (msg = 'No user found for user token') {
     super(msg, 401)
@@ -31,7 +46,7 @@ export class UserNotFoundError extends HTTPError {
 }
 UserNotFoundError.CODE = 'ERROR_USER_NOT_FOUND'
 
-export class PinningUnauthorizedError extends HTTPError {
+export class PinningUnauthorizedError extends PinningServiceApiError {
   constructor (msg = 'Pinning not authorized for this user, email support@web3.storage to request authorization.') {
     super(msg, 403)
     this.name = 'PinningUnauthorizedError'
@@ -141,21 +156,6 @@ export class MaintenanceError extends Error {
   }
 }
 MaintenanceError.CODE = 'ERROR_MAINTENANCE'
-
-export class PinningServiceApiError extends Error {
-  /**
-   *
-   * @param {string} [message]
-   * @param {number} [status]
-   * @param {string} code
-   */
-  constructor (message, status = 400, code = 'PSA_ERROR') {
-    super(message)
-    this.details = message
-    this.status = status
-    this.reason = code
-  }
-}
 
 export class PSAErrorInvalidData extends PinningServiceApiError {
   /**

--- a/packages/api/src/index.js
+++ b/packages/api/src/index.js
@@ -134,7 +134,7 @@ router.all('*', auth['🌍'](() => notFound()))
  * @param {import('./env').Env} env
  */
 function serverError (error, request, env) {
-  return addCorsHeaders(request, errorHandler(error, env))
+  return addCorsHeaders(request, errorHandler(error, env, request))
 }
 
 // https://developer.mozilla.org/en-US/docs/Web/API/FetchEvent

--- a/packages/api/test/auth.spec.js
+++ b/packages/api/test/auth.spec.js
@@ -30,9 +30,9 @@ describe('Pinning service API access', () => {
       })
 
       assert(!res.ok)
-      const { message, code } = await res.json()
-      assert.match(message, SUPPORT_EMAIL_CHECK, EMAIL_ERROR_MESSAGE)
-      assert.strictEqual(code, PinningUnauthorizedError.CODE)
+      const { error: { reason, details } } = await res.json()
+      assert.match(details, SUPPORT_EMAIL_CHECK, EMAIL_ERROR_MESSAGE)
+      assert.strictEqual(reason, PinningUnauthorizedError.CODE)
     })
   })
 
@@ -48,9 +48,9 @@ describe('Pinning service API access', () => {
       })
 
       assert(!res.ok)
-      const { message, code } = await res.json()
-      assert.match(message, SUPPORT_EMAIL_CHECK, EMAIL_ERROR_MESSAGE)
-      assert.strictEqual(code, PinningUnauthorizedError.CODE)
+      const { error: { reason, details } } = await res.json()
+      assert.match(details, SUPPORT_EMAIL_CHECK, EMAIL_ERROR_MESSAGE)
+      assert.strictEqual(reason, PinningUnauthorizedError.CODE)
     })
   })
 
@@ -66,9 +66,9 @@ describe('Pinning service API access', () => {
       })
 
       assert(!res.ok)
-      const { message, code } = await res.json()
-      assert.match(message, SUPPORT_EMAIL_CHECK, EMAIL_ERROR_MESSAGE)
-      assert.strictEqual(code, PinningUnauthorizedError.CODE)
+      const { error: { reason, details } } = await res.json()
+      assert.match(details, SUPPORT_EMAIL_CHECK, EMAIL_ERROR_MESSAGE)
+      assert.strictEqual(reason, PinningUnauthorizedError.CODE)
     })
   })
 
@@ -83,9 +83,9 @@ describe('Pinning service API access', () => {
       })
 
       assert(!res.ok)
-      const { message, code } = await res.json()
-      assert.match(message, SUPPORT_EMAIL_CHECK, EMAIL_ERROR_MESSAGE)
-      assert.strictEqual(code, PinningUnauthorizedError.CODE)
+      const { error: { reason, details } } = await res.json()
+      assert.match(details, SUPPORT_EMAIL_CHECK, EMAIL_ERROR_MESSAGE)
+      assert.strictEqual(reason, PinningUnauthorizedError.CODE)
     })
   })
 
@@ -100,9 +100,9 @@ describe('Pinning service API access', () => {
       })
 
       assert(!res.ok)
-      const { message, code } = await res.json()
-      assert.match(message, SUPPORT_EMAIL_CHECK, EMAIL_ERROR_MESSAGE)
-      assert.strictEqual(code, PinningUnauthorizedError.CODE)
+      const { error: { reason, details } } = await res.json()
+      assert.match(details, SUPPORT_EMAIL_CHECK, EMAIL_ERROR_MESSAGE)
+      assert.strictEqual(reason, PinningUnauthorizedError.CODE)
     })
   })
 })
@@ -178,10 +178,10 @@ describe('Account restriction', () => {
 
       assert(res, 'Server responded')
       assert.strictEqual(res.status, 403)
-      const { code, message } = await res.json()
-      assert.strictEqual(code, AccountRestrictedError.CODE)
-      assert.match(message, RESTRICTED_ERROR_CHECK)
-      assert.match(message, SUPPORT_EMAIL_CHECK, EMAIL_ERROR_MESSAGE)
+      const { error: { reason, details } } = await res.json()
+      assert.strictEqual(reason, AccountRestrictedError.CODE)
+      assert.match(details, RESTRICTED_ERROR_CHECK)
+      assert.match(details, SUPPORT_EMAIL_CHECK, EMAIL_ERROR_MESSAGE)
     })
 
     it('should throw if account is restricted', async () => {
@@ -197,10 +197,10 @@ describe('Account restriction', () => {
 
       assert(res, 'Server responded')
       assert.strictEqual(res.status, 403)
-      const { code, message } = await res.json()
-      assert.strictEqual(code, AccountRestrictedError.CODE)
-      assert.match(message, RESTRICTED_ERROR_CHECK)
-      assert.match(message, SUPPORT_EMAIL_CHECK, EMAIL_ERROR_MESSAGE)
+      const { error: { reason, details } } = await res.json()
+      assert.strictEqual(reason, AccountRestrictedError.CODE)
+      assert.match(details, RESTRICTED_ERROR_CHECK)
+      assert.match(details, SUPPORT_EMAIL_CHECK, EMAIL_ERROR_MESSAGE)
     })
   })
 
@@ -224,10 +224,10 @@ describe('Account restriction', () => {
 
       assert(res, 'Server responded')
       assert.strictEqual(res.status, 403)
-      const { code, message } = await res.json()
-      assert.strictEqual(code, AccountRestrictedError.CODE)
-      assert.match(message, RESTRICTED_ERROR_CHECK)
-      assert.match(message, SUPPORT_EMAIL_CHECK, EMAIL_ERROR_MESSAGE)
+      const { error: { reason, details } } = await res.json()
+      assert.strictEqual(reason, AccountRestrictedError.CODE)
+      assert.match(details, RESTRICTED_ERROR_CHECK)
+      assert.match(details, SUPPORT_EMAIL_CHECK, EMAIL_ERROR_MESSAGE)
     })
 
     it('should throw if account is restricted', async () => {
@@ -243,10 +243,10 @@ describe('Account restriction', () => {
 
       assert(res, 'Server responded')
       assert.strictEqual(res.status, 403)
-      const { code, message } = await res.json()
-      assert.strictEqual(code, AccountRestrictedError.CODE)
-      assert.match(message, RESTRICTED_ERROR_CHECK)
-      assert.match(message, SUPPORT_EMAIL_CHECK, EMAIL_ERROR_MESSAGE)
+      const { error: { reason, details } } = await res.json()
+      assert.strictEqual(reason, AccountRestrictedError.CODE)
+      assert.match(details, RESTRICTED_ERROR_CHECK)
+      assert.match(details, SUPPORT_EMAIL_CHECK, EMAIL_ERROR_MESSAGE)
     })
   })
 

--- a/packages/api/test/pin.spec.js
+++ b/packages/api/test/pin.spec.js
@@ -117,7 +117,7 @@ describe('Pinning APIs endpoints', () => {
 
       assert(res, 'Server responded')
       assert.strictEqual(res.status, ERROR_CODE)
-      const error = await res.json()
+      const { error } = await res.json()
       assert.strictEqual(error.reason, PSAErrorInvalidData.CODE)
       assert.strictEqual(error.details, '#/limit: Instance type "number" is invalid. Expected "integer".')
     })
@@ -135,7 +135,7 @@ describe('Pinning APIs endpoints', () => {
 
       assert(res, 'Server responded')
       assert.strictEqual(res.status, ERROR_CODE)
-      const error = await res.json()
+      const { error } = await res.json()
       assert.strictEqual(error.reason, PSAErrorRequiredData.CODE)
       assert.strictEqual(error.details, 'Instance does not have required property "status".')
     })
@@ -159,7 +159,7 @@ describe('Pinning APIs endpoints', () => {
 
       assert(res, 'Server responded')
       assert.strictEqual(res.status, ERROR_CODE)
-      const error = await res.json()
+      const { error } = await res.json()
       assert.strictEqual(error.reason, PSAErrorInvalidData.CODE)
       assert.strictEqual(error.details, '#/meta: Instance type "array" is invalid. Expected "object".')
     })
@@ -183,7 +183,7 @@ describe('Pinning APIs endpoints', () => {
 
       assert(res, 'Server responded')
       assert.strictEqual(res.status, ERROR_CODE)
-      const error = await res.json()
+      const { error } = await res.json()
       assert.strictEqual(error.reason, PSAErrorInvalidData.CODE)
       assert.strictEqual(error.details, '#/meta/not-a-string-value: Instance type "number" is invalid. Expected "string".')
     })
@@ -206,7 +206,7 @@ describe('Pinning APIs endpoints', () => {
         })
 
       assert.strictEqual(res.status, ERROR_CODE)
-      const error = await res.json()
+      const { error } = await res.json()
       assert.strictEqual(error.reason, PSAErrorInvalidData.CODE)
       assert.strictEqual(error.details, INVALID_CID)
     })
@@ -226,7 +226,7 @@ describe('Pinning APIs endpoints', () => {
         })
 
       assert.strictEqual(res.status, ERROR_CODE)
-      const error = await res.json()
+      const { error } = await res.json()
       assert.strictEqual(error.reason, PSAErrorInvalidData.CODE)
       assert.strictEqual(error.details, '#/status/1: Instance does not match any of ["queued","pinning","pinned","failed"].')
     })
@@ -246,7 +246,7 @@ describe('Pinning APIs endpoints', () => {
         })
 
       assert.strictEqual(res.status, ERROR_CODE)
-      const error = await res.json()
+      const { error } = await res.json()
       assert.strictEqual(error.reason, PSAErrorInvalidData.CODE)
       assert.strictEqual(error.details, '#/match: Instance does not match any of ["exact","iexact","ipartial","partial"].')
     })
@@ -527,7 +527,7 @@ describe('Pinning APIs endpoints', () => {
 
       assert(res, 'Server responded')
       assert.strictEqual(res.status, ERROR_CODE)
-      const error = await res.json()
+      const { error } = await res.json()
       assert.strictEqual(error.reason, PSAErrorRequiredData.CODE)
       assert.strictEqual(error.details, 'Instance does not have required property "cid".')
     })
@@ -545,7 +545,7 @@ describe('Pinning APIs endpoints', () => {
 
       assert(res, 'Server responded')
       assert.strictEqual(res.status, ERROR_CODE)
-      const error = await res.json()
+      const { error } = await res.json()
       assert.strictEqual(error.reason, PSAErrorInvalidData.CODE)
       assert.strictEqual(error.details, INVALID_CID)
     })
@@ -596,7 +596,7 @@ describe('Pinning APIs endpoints', () => {
 
       assert(res, 'Server responded')
       assert.strictEqual(res.status, ERROR_CODE)
-      const error = await res.json()
+      const { error } = await res.json()
       assert.strictEqual(error.reason, PSAErrorInvalidData.CODE)
       assert.strictEqual(error.details, '#/name: Instance type "number" is invalid. Expected "string".')
     })
@@ -616,7 +616,7 @@ describe('Pinning APIs endpoints', () => {
 
       assert(res, 'Server responded')
       assert.strictEqual(res.status, ERROR_CODE)
-      const error = await res.json()
+      const { error } = await res.json()
       assert.strictEqual(error.reason, PSAErrorInvalidData.CODE)
       assert.strictEqual(error.details, '#/origins: Instance type "number" is invalid. Expected "array".')
     })
@@ -636,7 +636,7 @@ describe('Pinning APIs endpoints', () => {
 
       assert(res, 'Server responded')
       assert.strictEqual(res.status, ERROR_CODE)
-      const error = await res.json()
+      const { error } = await res.json()
       assert.strictEqual(error.reason, PSAErrorInvalidData.CODE)
       assert.strictEqual(error.details, '#/meta: Instance type "number" is invalid. Expected "object".')
     })
@@ -866,7 +866,7 @@ describe('Pinning APIs endpoints', () => {
 
       assert(res, 'Server responded')
       assert.deepEqual(res.status, 404)
-      const error = await res.json()
+      const { error } = await res.json()
       assert.deepEqual(error.reason, PSAErrorResourceNotFound.CODE)
       assert.deepEqual(error.details, DATA_NOT_FOUND)
     })
@@ -936,7 +936,7 @@ describe('Pinning APIs endpoints', () => {
 
       assert(res, 'Server responded')
       assert.equal(res.status, 404)
-      const error = await res.json()
+      const { error } = await res.json()
       assert.equal(error.reason, PSAErrorResourceNotFound.CODE)
       assert.equal(error.details, DATA_NOT_FOUND)
     })
@@ -1004,7 +1004,7 @@ describe('Pinning APIs endpoints', () => {
       assert(res, 'Server responded')
       assert(!res.ok)
       assert.equal(res.status, ERROR_CODE)
-      const error = await res.json()
+      const { error } = await res.json()
       assert.equal(error.details, INVALID_REPLACE)
     })
   })


### PR DESCRIPTION
Resolves #1320

In investigating the issue above, we discovered that the pinning service API was not compliant with the IPFS Spec when throwing errors. Hence, why for the CLI, there were no errors shown.

To make the pinning service compliant with the spec (found [here](https://ipfs.github.io/pinning-services-api-spec/#operation/getPins)). I have nested the error and updated the properties to `reason` and `details`. I have updated the tests to match the specification.

The logic to decide whether we should use the IPFS style errors is in the error handler and based on the request path.
This seemed like the cleanest way to do it, but please let me know if you have other ideas.

@flea89 and I came up with other solutions:
1. Pass a "type" to the middleware that checks for PSA Authorization and then throws either HTTPErrors or PSAErrors.
2. Create new middleware that clones the other but uses PSAErrors