### PR TITLE
fix: remove incorrect 'last updated on' text

### DIFF
--- a/packages/website/modules/docs-theme/feedback/feedback.js
+++ b/packages/website/modules/docs-theme/feedback/feedback.js
@@ -6,7 +6,6 @@ import { trackEvent, events } from '../../../lib/countly';
 function Feedback({ strings: { title, yes, no, thanks, helpUsImprove } }) {
   const router = useRouter();
   const [voteSubmitted, setVoteSubmitted] = useState(false);
-  const lastUpdatedAt = process.env.NEXT_PUBLIC_DEPLOYDATE;
   const ISSUE_URL = 'https://github.com/web3-storage/web3.storage/issues/new/choose';
   const SUGGEST_CONTENT_URL = 'https://github.com/web3-storage/web3.storage/issues';
   const editUrl = `https://github.com/web3-storage/web3.storage/tree/main/packages/website/pages${router.pathname}.md`;
@@ -53,7 +52,6 @@ function Feedback({ strings: { title, yes, no, thanks, helpUsImprove } }) {
             Suggest new content
           </a>
         </div>
-        {lastUpdatedAt && <div className="last-updated">Last updated on {lastUpdatedAt}</div>}
       </div>
     </div>
   );

--- a/packages/website/modules/docs-theme/feedback/feedback.scss
+++ b/packages/website/modules/docs-theme/feedback/feedback.scss
@@ -30,9 +30,4 @@
       margin-bottom: toRem(5);
     }
   }
-  .last-updated {
-    margin-top: 0.25rem;
-    font-style: italic;
-    font-size: smaller;
-  }
 }


### PR DESCRIPTION
This is just using the latest deploy date for the "last updated on" date but that's not correct.  Since we don't have a good way of pulling when a specific *page* was updated, we're just going to remove this date for now.

closes #1549