### PR TITLE
feat: add w3s.link url on files table

### DIFF
--- a/packages/website/components/account/filesManager/fileRowItem.js
+++ b/packages/website/components/account/filesManager/fileRowItem.js
@@ -133,7 +133,7 @@ const FileRowItem = props => {
         ) : (
           <a
             className="cid-truncate underline medium-up-only"
-            href={`https://dweb.link/ipfs/${cid}`}
+            href={`https://w3s.link/ipfs/${cid}`}
             target="_blank"
             rel="noreferrer"
           >


### PR DESCRIPTION
This PR changes gateway link on files table to w3s.link instead of dweb.link

Needs #1728 