### PR TITLE
fix: run tests in jobs on package-lock change

### DIFF
--- a/.github/workflows/api.yml
+++ b/.github/workflows/api.yml
@@ -7,11 +7,13 @@ on:
       - 'packages/api/**'
       - 'packages/db/**'
       - '.github/workflows/api.yml'
+      - 'package-lock.json'
   pull_request:
     paths:
       - 'packages/api/**'
       - 'packages/db/**'
       - '.github/workflows/api.yml'
+      - 'package-lock.json'
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/client.yml
+++ b/.github/workflows/client.yml
@@ -6,12 +6,14 @@ on:
     paths:
       - 'packages/client/**'
       - '.github/workflows/client.yml'
+      - 'package-lock.json'
   pull_request:
     branches:
       - main
     paths:
       - 'packages/client/**'
       - '.github/workflows/client.yml'
+      - 'package-lock.json'
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -7,11 +7,13 @@ on:
       - 'packages/cron/**'
       - '.github/workflows/cron*'
       - 'packages/db/**'
+      - 'package-lock.json'
   pull_request:
     paths:
       - 'packages/cron/**'
       - '.github/workflows/cron*'
       - 'packages/db/**'
+      - 'package-lock.json'
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/db.yml
+++ b/.github/workflows/db.yml
@@ -6,6 +6,7 @@ on:
     paths:
       - 'packages/db/**'
       - '.github/workflows/db.yml'
+      - 'package-lock.json'
 
   # Nothing to do on PR yet, but having the check appear on the PR serves as a reminder 
   # that we don't have proper tests for db changes yet, and that merging it will deploy.
@@ -13,6 +14,7 @@ on:
     paths:
       - 'packages/db/**'
       - '.github/workflows/db.yml'
+      - 'package-lock.json'
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/w3.yml
+++ b/.github/workflows/w3.yml
@@ -6,12 +6,14 @@ on:
     paths:
       - 'packages/w3/**'
       - '.github/workflows/w3.yml'
+      - 'package-lock.json'
   pull_request:
     branches:
       - main
     paths:
       - 'packages/w3/**'
       - '.github/workflows/w3.yml'
+      - 'package-lock.json'
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -6,10 +6,12 @@ on:
     paths:
       - 'packages/website/**'
       - '.github/workflows/website.yml'
+      - 'package-lock.json'
   pull_request:
     paths:
       - 'packages/website/**'
       - '.github/workflows/website.yml'
+      - 'package-lock.json'
 jobs:
   test:
     name: Test


### PR DESCRIPTION
We already had regressions in the past because package lock was updated and it did not trigger tests of all the packages. This also brings other issues as workflows are not triggered like https://github.com/web3-storage/web3.storage/commit/000e4dcd9e1119361c29c0dad851a5ea6d6db1b5

