### PR TITLE
feat: w3link docs

### DIFF
--- a/packages/website/pages/docs/concepts/w3link.md
+++ b/packages/website/pages/docs/concepts/w3link.md
@@ -1,0 +1,105 @@
+---
+title: IPFS Gateways
+description: An overview of IPFS Gateways background and w3link.
+---
+
+# IPFS Gateways
+
+Web3.Storage uses the [InterPlanetary File System (IPFS)](https://ipfs.io) as a key part of its [storage and retrieval infrastructure][concepts-decentralized-storage].
+
+The IPFS network is a peer-to-peer network of computers that share resources to efficiently provide content to anyone that requests it. Computers that join the IPFS network use a protocol called [Bitswap][ipfs-docs-bitswap] to request and supply blocks of data using a hash-based Content Identifier (CID) to uniquely identify each block.
+
+To make IPFS data accessible outside of the peer-to-peer network, [special IPFS nodes called "gateways"][ipfs-docs-gateway] act as bridges between the HTTP protocol that all web browsers understand and the peer-to-peer Bitswap protocol.
+
+As more browsers like [Brave][brave-ipfs] and [Opera][opera-ipfs] adopt native IPFS support, the need for gateways will naturally lessen over time. Today, you can reach the widest audience by using HTTP gateways in your web applications, but it's a great idea to also surface the original `ipfs://` URI for your content, so that IPFS-native browsers can access the content directly through Bitswap.
+
+This guide collects some helpful information about gateways, including how and why to use w3link, the [Web3.Storage gateway](#w3link) available at `w3s.link`.
+
+For more information about fetching content from gateways, see our [guide to data retrieval][howto-retrieve].
+
+## w3link
+
+Providing a great retrieval experience on the web is a key part of Web3.Storage's mission, as we work to make [decentralized data storage][concepts-decentralized-storage] the default choice for web3 developers.
+
+To further this goal, we created a new HTTP gateway that uses existing public IPFS infrastructure and cloud-native caching strategies to provide a high-performance, CID-based HTTP retrieval solution.
+
+### Architecture
+
+The Web3.Storage gateway is effectively a caching layer that sits in front of several other public IPFS gateways and "races" them against each other to provide the fastest response possible to end-user requests.
+
+This layered architecture has several benefits over using the "downstream" gateways directly. By using CloudFlare Workers to cache requests at the edge, the gateway can serve popular content quickly, while taking load off of the public IPFS gateways and peer-to-peer network.
+
+Requests for content that are not cached are served by making parallel requests to multiple public IPFS gateways and returning the first valid response. This gives you the performance of the fastest downstream gateway, which may vary from time to time due to network conditions and the state of the gateway's own local cache.
+
+Sending multiple requests also reduces the dependence on any single gateway and protects your app from experiencing degraded service if a gateway goes down for maintainence or has connectivity issues.
+
+Since Web3.Storage also knows what content that is stored with the service, the Web3.Storage gateway can be optimized and will be most performant for data stored on Web3.Storage.
+
+### Using the gateway
+
+The Web3.Storage gateway is accessible at the URL `https://w3s.link`, and you can use it just by creating URLs with `w3s.link` as the host.
+
+The gateway supports both ["path style"](#path-style-urls) and ["subdomain style"](#subdomain-style-urls) URLs, although you must make sure that your HTTP client follows redirects when using "path style" URLs. For example, when using `curl`, make sure to add the `-L` flag to follow the `Location` header redirect:
+
+```bash
+curl -L https://w3s.link/ipfs/bafybeid4gwmvbza257a7rx52bheeplwlaogshu4rgse3eaudfkfm7tx2my/hi-gateway.txt
+```
+
+The gateway always redirects path-style URLs into subdomain-style URLs, so that web content served through the gateway can be isolated with the [same-origin policy](https://en.wikipedia.org/wiki/Same-origin_policy). In some cases, this may result in the CID being re-encoded to a format that's compatible with subdomain addressing. In particular, "version 0" CIDs beginning with `Qm` will be encoded to CID version 1 (`bafy...`) in the base32 string encoding. Although the encodings are different, the CIDs are still equivalent for the purposes of content identification and verification, and you can convert back into CIDv0 without losing any information.
+
+You can avoid the redirect from path to subdomain URL by creating a [subdomain style URL](#subdomain-style-urls) directly, but you'll need to make sure that you're only using CIDv1, as CIDv0's case-sensitive encoding is incompatible with subdomain URLs. The Web3.Storage APIs always return CIDv1, but if you have other sources of IPFS CIDs you can [convert CIDv0 to v1][ipfs-docs-cid-convert] yourself before constructing the gateway URL.
+
+### Rate limits
+
+IPFS gateways are a public, shared resource, and they are often in high demand. To provide equitable access to all users, the Web3.Storage gateway imposes request limits on high-volume traffic sources.
+
+The Web3.Storage gateway is currently rate limited to 200 requests per minute for a given IP address. In the event of a rate limit, the IP will be blocked for 30 seconds.
+
+## Types of gateway
+
+The official [IPFS documentation on gateways][ipfs-docs-gateway] is helpful for understanding the types of gateways in the IPFS ecosystem and how they're used.
+
+One of the key things to understand for our purposes is the different [resolution styles][ipfs-docs-gateway-resolution] that can be used to fetch content using gateway URLs.
+
+If you check the [list of public gateways][public-gateway-checker], you'll see that some support "subdomain" style URLs, while others only support path-style URLs. Below is a short refresher on the distinction between the two styles. For more examples, see our [guide to retrieving data from IPFS][howto-retrieve].
+
+### Path style URLs
+
+A "path style" URL puts the IPFS CID into the path portion of the gateway URL, like this:
+
+<span className="overflow-wrap-breakword">
+https://w3s.link/ipfs/bafkreied5tvfci25k5td56w4zgj3owxypjgvmpwj5n7cvzgp5t4ittatfy
+</span>
+
+If the CID points to a directory listing, you can append the name of a file within the directory to fetch the file:
+
+<span className="overflow-wrap-breakword">
+https://w3s.link/ipfs/bafybeid4gwmvbza257a7rx52bheeplwlaogshu4rgse3eaudfkfm7tx2my/hi-gateway.txt
+</span>
+
+### Subdomain style URLs
+
+A "subdomain style" gateway URL puts the CID into the host portion of the URL, as a subdomain of the gateway host, like this:
+
+<span className="overflow-wrap-breakword">
+https://bafkreied5tvfci25k5td56w4zgj3owxypjgvmpwj5n7cvzgp5t4ittatfy.ipfs.w3s.link
+</span>
+
+If the CID points to a directory listing, you can use the path portion of the URL to specify the filename:
+
+<span className="overflow-wrap-breakword">
+https://bafybeid4gwmvbza257a7rx52bheeplwlaogshu4rgse3eaudfkfm7tx2my.ipfs.w3s.link/hi-gateway.txt
+</span>
+
+This is the preferred style for serving web assets over HTTP gateways, because web browsers provide security isolation on a per-domain basis. Using the subdomain style, every CID gets its own "namespace" for things like cookies and local storage, which isolates things from other web content stored on IPFS.
+
+[concepts-decentralized-storage]: /docs/concepts/decentralized-storage/
+[brave-ipfs]: https://brave.com/ipfs-support/
+[opera-ipfs]: https://blogs.opera.com/tips-and-tricks/2021/02/opera-crypto-files-for-keeps-ipfs-unstoppable-domains/
+[ipfs-docs-cid]: https://docs.ipfs.io/concepts/content-addressing
+[ipfs-docs-cid-convert]: https://docs.ipfs.io/concepts/content-addressing/#cid-conversion
+[ipfs-docs-gateway]: https://docs.ipfs.io/concepts/ipfs-gateway/
+[ipfs-docs-gateway-resolution]: https://docs.ipfs.io/concepts/ipfs-gateway/#resolution-style
+[ipfs-docs-bitswap]: https://docs.ipfs.io/concepts/bitswap/
+[public-gateway-checker]: https://ipfs.github.io/public-gateway-checker/
+[howto-retrieve]: /docs/how-tos/retrieve

--- a/packages/website/pages/docs/concepts/w3link.md
+++ b/packages/website/pages/docs/concepts/w3link.md
@@ -1,9 +1,9 @@
 ---
 title: IPFS Gateways
-description: An overview of IPFS Gateways background and w3link.
+description: An overview of IPFS HTTP Gateways and w3link.
 ---
 
-# IPFS Gateways
+# IPFS HTTP Gateways
 
 Web3.Storage uses the [InterPlanetary File System (IPFS)](https://ipfs.io) as a key part of its [storage and retrieval infrastructure][concepts-decentralized-storage].
 
@@ -19,7 +19,7 @@ For more information about fetching content from gateways, see our [guide to dat
 
 ## w3link
 
-Providing a great retrieval experience on the web is a key part of Web3.Storage's mission, as we work to make [decentralized data storage][concepts-decentralized-storage] the default choice for web3 developers.
+Providing a great retrieval experience on the web is a key part of the Web3.Storage platform, as we work to make [decentralized data storage][concepts-decentralized-storage] the default choice for web3 developers.
 
 To further this goal, we created a new HTTP gateway that uses existing public IPFS infrastructure and cloud-native caching strategies to provide a high-performance, CID-based HTTP retrieval solution.
 
@@ -48,6 +48,8 @@ curl -L https://w3s.link/ipfs/bafybeid4gwmvbza257a7rx52bheeplwlaogshu4rgse3eaudf
 The gateway always redirects path-style URLs into subdomain-style URLs, so that web content served through the gateway can be isolated with the [same-origin policy](https://en.wikipedia.org/wiki/Same-origin_policy). In some cases, this may result in the CID being re-encoded to a format that's compatible with subdomain addressing. In particular, "version 0" CIDs beginning with `Qm` will be encoded to CID version 1 (`bafy...`) in the base32 string encoding. Although the encodings are different, the CIDs are still equivalent for the purposes of content identification and verification, and you can convert back into CIDv0 without losing any information.
 
 You can avoid the redirect from path to subdomain URL by creating a [subdomain style URL](#subdomain-style-urls) directly, but you'll need to make sure that you're only using CIDv1, as CIDv0's case-sensitive encoding is incompatible with subdomain URLs. The Web3.Storage APIs always return CIDv1, but if you have other sources of IPFS CIDs you can [convert CIDv0 to v1][ipfs-docs-cid-convert] yourself before constructing the gateway URL.
+
+`w3s.link` is the default gateway used in your Web3.Storage uploads table to view and download content, but you can switch the gateway used for URLs to another popular gateway, `dweb.link`, by selecting it in the `Gateway` field in the dropdown menu at the top of the uploads table.
 
 ### Rate limits
 

--- a/packages/website/pages/docs/how-tos/retrieve.md
+++ b/packages/website/pages/docs/how-tos/retrieve.md
@@ -24,25 +24,25 @@ All data stored using Web3.Storage is made available for retrieval via [IPFS](ht
 
 ## Using an IPFS HTTP gateway
 
-You can easily fetch any data stored using Web3.Storage using an IPFS HTTP gateway. Because IPFS is a peer-to-peer, decentralized network, you can use any public HTTP gateway to fetch your data. In this guide, we'll use the gateway at `dweb.link`, but you can see more worldwide gateways on the [IPFS Public Gateway Checker](https://ipfs.github.io/public-gateway-checker/).
+You can easily fetch any data stored using Web3.Storage using an IPFS HTTP gateway. Because IPFS is a peer-to-peer, decentralized network, you can use any public HTTP gateway to fetch your data. In this guide, we'll use the gateway at `w3s.link`, but you can see more worldwide gateways on the [IPFS Public Gateway Checker](https://ipfs.github.io/public-gateway-checker/).
 
 When you [store data using the Web3.Storage client][howto-store], the `put` method returns an [IPFS content identifier (CID)][ipfs-docs-cid] string. That CID points to an IPFS directory that contains all the files you passed in using the `put` method.
 
-You can use an IPFS gateway to view a list of all the files in that directory from your browser. To do so, simply create a gateway URL. For example, if your CID is `bafybeidd2gyhagleh47qeg77xqndy2qy3yzn4vkxmk775bg2t5lpuy7pcu`, you can make a URL for the `dweb.link` gateway as follows: [bafybeidd2gyhagleh47qeg77xqndy2qy3yzn4vkxmk775bg2t5lpuy7pcu.ipfs.dweb.link](https://bafybeidd2gyhagleh47qeg77xqndy2qy3yzn4vkxmk775bg2t5lpuy7pcu.ipfs.dweb.link/). Follow that link, and you'll see a page similar to this:
+You can use an IPFS gateway to view a list of all the files in that directory from your browser. To do so, simply create a gateway URL. For example, if your CID is `bafybeidd2gyhagleh47qeg77xqndy2qy3yzn4vkxmk775bg2t5lpuy7pcu`, you can make a URL for the `w3s.link` gateway as follows: [bafybeidd2gyhagleh47qeg77xqndy2qy3yzn4vkxmk775bg2t5lpuy7pcu.ipfs.w3s.link](https://bafybeidd2gyhagleh47qeg77xqndy2qy3yzn4vkxmk775bg2t5lpuy7pcu.ipfs.w3s.link/). Follow that link, and you'll see a page similar to this:
 
 <Img src={ImgGatewayDir} alt="Screenshot of an IPFS gateway directory listing" />
 
-If you want to link directly to a file within that directory, just add the file path after the CID portion of the link. For example: [bafybeidd2gyhagleh47qeg77xqndy2qy3yzn4vkxmk775bg2t5lpuy7pcu.ipfs.dweb.link/not-distributed.jpg](https://bafybeidd2gyhagleh47qeg77xqndy2qy3yzn4vkxmk775bg2t5lpuy7pcu.ipfs.dweb.link/not-distributed.jpg) could be used as a shareable link for your new favorite wallpaper.
+If you want to link directly to a file within that directory, just add the file path after the CID portion of the link. For example: [bafybeidd2gyhagleh47qeg77xqndy2qy3yzn4vkxmk775bg2t5lpuy7pcu.ipfs.w3s.link/not-distributed.jpg](https://bafybeidd2gyhagleh47qeg77xqndy2qy3yzn4vkxmk775bg2t5lpuy7pcu.ipfs.w3s.link/not-distributed.jpg) could be used as a shareable link for your new favorite wallpaper.
 
-You can easily fetch any data stored using Web3.Storage using an IPFS HTTP gateway. Because IPFS is a peer-to-peer, decentralized network, you can use any public HTTP gateway to fetch your data. In this guide, we'll use the gateway at `dweb.link`, but you can see more worldwide gateways on the [IPFS Public Gateway Checker](https://ipfs.github.io/public-gateway-checker/).
+You can easily fetch any data stored using Web3.Storage using an IPFS HTTP gateway. Because IPFS is a peer-to-peer, decentralized network, you can use any public HTTP gateway to fetch your data. In this guide, we'll use the gateway at `w3s.link`, but you can see more worldwide gateways on the [IPFS Public Gateway Checker](https://ipfs.github.io/public-gateway-checker/).
 
 When you [store data using the Web3.Storage client][howto-store], the `put` method returns an [IPFS content identifier (CID)][ipfs-docs-cid] string. That CID points to an IPFS directory that contains all the files you passed in using the `put` method.
 
-You can use an IPFS gateway to view a list of all the files in that directory from your browser. To do so, simply create a gateway URL. For example, if your CID is `bafybeidd2gyhagleh47qeg77xqndy2qy3yzn4vkxmk775bg2t5lpuy7pcu`, you can make a URL for the `dweb.link` gateway as follows: [bafybeidd2gyhagleh47qeg77xqndy2qy3yzn4vkxmk775bg2t5lpuy7pcu.ipfs.dweb.link](https://bafybeidd2gyhagleh47qeg77xqndy2qy3yzn4vkxmk775bg2t5lpuy7pcu.ipfs.dweb.link/). Follow that link, and you'll see a page similar to this:
+You can use an IPFS gateway to view a list of all the files in that directory from your browser. To do so, simply create a gateway URL. For example, if your CID is `bafybeidd2gyhagleh47qeg77xqndy2qy3yzn4vkxmk775bg2t5lpuy7pcu`, you can make a URL for the `w3s.link` gateway as follows: [bafybeidd2gyhagleh47qeg77xqndy2qy3yzn4vkxmk775bg2t5lpuy7pcu.ipfs.w3s.link](https://bafybeidd2gyhagleh47qeg77xqndy2qy3yzn4vkxmk775bg2t5lpuy7pcu.ipfs.w3s.link/). Follow that link, and you'll see a page similar to this:
 
 <Img src={ImgGatewayDir} alt="Screenshot of an IPFS gateway directory listing" />
 
-If you want to link directly to a file within that directory, just add the file path after the CID portion of the link. For example: [bafybeidd2gyhagleh47qeg77xqndy2qy3yzn4vkxmk775bg2t5lpuy7pcu.ipfs.dweb.link/not-distributed.jpg](https://bafybeidd2gyhagleh47qeg77xqndy2qy3yzn4vkxmk775bg2t5lpuy7pcu.ipfs.dweb.link/not-distributed.jpg) could be used as a shareable link for your new favorite wallpaper.
+If you want to link directly to a file within that directory, just add the file path after the CID portion of the link. For example: [bafybeidd2gyhagleh47qeg77xqndy2qy3yzn4vkxmk775bg2t5lpuy7pcu.ipfs.w3s.link/not-distributed.jpg](https://bafybeidd2gyhagleh47qeg77xqndy2qy3yzn4vkxmk775bg2t5lpuy7pcu.ipfs.w3s.link/not-distributed.jpg) could be used as a shareable link for your new favorite wallpaper.
 
 <Callout type="info">
 ##### Tip
@@ -53,7 +53,7 @@ Your [Files page](https://web3.storage/account) on Web3.Storage includes IPFS ga
 
 When downloading files from an HTTP gateway, web browsers will set the default filename for the downloaded file based on the path component of the gateway link. For example, if you use your browser's "Save link as..." feature on the following link, it should prompt you to save a file named `treehouse.jpeg`:
 
-[https://bafybeicfnbaeigdtklwkrj35r4wtfppix732zromsadvgiu33mowah74yq.ipfs.dweb.link/treehouse.jpeg](https://bafybeicfnbaeigdtklwkrj35r4wtfppix732zromsadvgiu33mowah74yq.ipfs.dweb.link/treehouse.jpeg)
+[https://bafybeicfnbaeigdtklwkrj35r4wtfppix732zromsadvgiu33mowah74yq.ipfs.w3s.link/treehouse.jpeg](https://bafybeicfnbaeigdtklwkrj35r4wtfppix732zromsadvgiu33mowah74yq.ipfs.w3s.link/treehouse.jpeg)
 
 In the link above, the CID `bafybeicfnbaeigdtklwkrj35r4wtfppix732zromsadvgiu33mowah74yq` points to an IPFS directory listing, which maps from the filename `treehouse.jpeg` to the CID for the image itself.
 
@@ -61,7 +61,7 @@ Since the Web3.Storage client [wraps your uploaded files in a directory by defau
 
 However, the behavior is a bit different if you make a gateway link directly to the image CID:
 
-- [https://bafkreifvallbyfxnedeseuvkkswt5u3hbdb2fexcygbyjqy5a5rzmhrzei.ipfs.dweb.link/](https://bafkreifvallbyfxnedeseuvkkswt5u3hbdb2fexcygbyjqy5a5rzmhrzei.ipfs.dweb.link/)
+- [https://bafkreifvallbyfxnedeseuvkkswt5u3hbdb2fexcygbyjqy5a5rzmhrzei.ipfs.w3s.link/](https://bafkreifvallbyfxnedeseuvkkswt5u3hbdb2fexcygbyjqy5a5rzmhrzei.ipfs.w3s.link/)
 - [https://ipfs.io/ipfs/bafkreifvallbyfxnedeseuvkkswt5u3hbdb2fexcygbyjqy5a5rzmhrzei](https://ipfs.io/ipfs/bafkreifvallbyfxnedeseuvkkswt5u3hbdb2fexcygbyjqy5a5rzmhrzei)
 
 Both of the URLs above link directly to the CID of the image, without an associated filename. The first URL uses the recommended "subdomain" URL format for gateway links, while the second form uses a "path prefix" format that you may see in use elsewhere in the IPFS ecosystem.
@@ -70,7 +70,7 @@ Depending on which style of link you use, your browser will prompt you to save a
 
 If you have such a link, you can override the default filename by adding a query string parameter to your link of the form `?filename=<desired-filename>`. For example, the following link will save as `treehouse.jpeg`, even though it links directly to the image by CID:
 
-[https://bafkreifvallbyfxnedeseuvkkswt5u3hbdb2fexcygbyjqy5a5rzmhrzei.ipfs.dweb.link/?filename=treehouse.jpeg](https://bafkreifvallbyfxnedeseuvkkswt5u3hbdb2fexcygbyjqy5a5rzmhrzei.ipfs.dweb.link/?filename=treehouse.jpeg)
+[https://bafkreifvallbyfxnedeseuvkkswt5u3hbdb2fexcygbyjqy5a5rzmhrzei.ipfs.w3s.link/?filename=treehouse.jpeg](https://bafkreifvallbyfxnedeseuvkkswt5u3hbdb2fexcygbyjqy5a5rzmhrzei.ipfs.w3s.link/?filename=treehouse.jpeg)
 
 ## Using the client libraries
 
@@ -166,7 +166,7 @@ Sometimes you may need to just download a specific file to your computer using t
 1.  Use `curl` to download your file:
 
         ```bash
-        curl https://<YOUR CID>.ipfs.dweb.link/<FILE NAME> -o ~/<OUTPUT FILE>
+        curl https://<YOUR CID>.ipfs.w3s.link/<FILE NAME> -o ~/<OUTPUT FILE>
         ```
 
         Replace `<YOUR CID>`, `<FILE NAME>`, and `<OUTPUT FILE>` with their respective values.
@@ -180,7 +180,7 @@ Sometimes you may need to just download a specific file to your computer using t
         Your complete command should look something like this:
 
         ```bash
-        curl https://bafybeie2bjap32zi2yqh5jmpve5njwulnkualcbiszvwfu36jzjyqskceq.ipfs.dweb.link/example.txt -o ~/output-file.txt
+        curl https://bafybeie2bjap32zi2yqh5jmpve5njwulnkualcbiszvwfu36jzjyqskceq.ipfs.w3s.link/example.txt -o ~/output-file.txt
         ```
 
 </TabItem>
@@ -190,7 +190,7 @@ Sometimes you may need to just download a specific file to your computer using t
 1.  Use `curl` to download your file:
 
         ```bash
-        curl https://<YOUR CID>.ipfs.dweb.link/<FILE NAME> -o ~/<OUTPUT FILE>
+        curl https://<YOUR CID>.ipfs.w3s.link/<FILE NAME> -o ~/<OUTPUT FILE>
         ```
 
         Replace `<YOUR CID>`, `<FILE NAME>`, and `<OUTPUT FILE>` with their respective values.
@@ -204,7 +204,7 @@ Sometimes you may need to just download a specific file to your computer using t
         Your complete command should look something like this:
 
         ```bash
-        curl https://bafybeie2bjap32zi2yqh5jmpve5njwulnkualcbiszvwfu36jzjyqskceq.ipfs.dweb.link/example.txt -o ~/output-file.txt
+        curl https://bafybeie2bjap32zi2yqh5jmpve5njwulnkualcbiszvwfu36jzjyqskceq.ipfs.w3s.link/example.txt -o ~/output-file.txt
         ```
 
 </TabItem>
@@ -214,7 +214,7 @@ Sometimes you may need to just download a specific file to your computer using t
 1.  Use `Invoke-WebRequest` to download your file:
 
     ```powershell
-     Invoke-WebRequest -Uri "https://<YOUR_CID>.ipfs.dweb.link/<FILE NAME>" -OutFile "C:\Users\<USERNAME>\<OUTPUT FILE>
+     Invoke-WebRequest -Uri "https://<YOUR_CID>.ipfs.w3s.link/<FILE NAME>" -OutFile "C:\Users\<USERNAME>\<OUTPUT FILE>
     ```
 
     Replace `<YOUR CID>`, `<FILE NAME>`, `<USERNAME>`, and `<OUTPUT FILE>` with their respective values.
@@ -229,7 +229,7 @@ Sometimes you may need to just download a specific file to your computer using t
     Your complete command should look something like this:
 
     ```powershell
-    Invoke-WebRequest -Uri "https://bafybeie2bjap32zi2yqh5jmpve5njwulnkualcbiszvwfu36jzjyqskceq.ipfs.dweb.link/example.txt" -OutFile "C:\Users\Laika\Desktop\output-file.txt"
+    Invoke-WebRequest -Uri "https://bafybeie2bjap32zi2yqh5jmpve5njwulnkualcbiszvwfu36jzjyqskceq.ipfs.w3s.link/example.txt" -OutFile "C:\Users\Laika\Desktop\output-file.txt"
     ```
 
 </TabItem>

--- a/packages/website/pages/docs/nav.json
+++ b/packages/website/pages/docs/nav.json
@@ -71,6 +71,10 @@
       {
         "name": "Web3.Storage economics",
         "src": "concepts/storage-economics"
+      },
+      {
+        "name": "IPFS Gateways",
+        "src": "concepts/w3link"
       }
     ]
   },


### PR DESCRIPTION
This PR adds docs for w3link. For now, it is a copy of https://nft.storage/docs/concepts/gateways/ with minimal changes (i.e NFT -> Web3)

Preview: https://99bdf644.web3-storage-staging.pages.dev/docs/concepts/w3link/