### PR TITLE
chore: correct w3name staging and prod urls in cron job.

### DIFF
--- a/packages/cron/src/jobs/names.js
+++ b/packages/cron/src/jobs/names.js
@@ -3,8 +3,8 @@ import retry from 'p-retry'
 import throttledQueue from 'throttled-queue'
 
 const MAX_REQUEST_PAGE = 10
-const W3NAME_API_URL_STAGING = 'https://name.web3.storage/'
-const W3NAME_API_URL_PRODUCTION = 'https://name-staging.web3.storage/'
+const W3NAME_API_URL_PRODUCTION = 'https://name.web3.storage/'
+const W3NAME_API_URL_STAGING = 'https://name-staging.web3.storage/'
 const log = debug('names:postNamesToW3name')
 const throttle = throttledQueue(2, 1000) // at most 2 requests per second
 


### PR DESCRIPTION
Noticed something a little off with the URL patterns, this should correct it!

Notes for reviewer(s): Worth ensuring these variables are being used correctly too