### PR TITLE
feat: add to api GET /user/payment, add AuthorizationTestContext to encapsulate magic.link test bypass

### DIFF
--- a/packages/api/src/env.js
+++ b/packages/api/src/env.js
@@ -7,6 +7,7 @@ import { Cluster } from '@nftstorage/ipfs-cluster'
 import { DEFAULT_MODE } from './maintenance.js'
 import { Logging } from './utils/logs.js'
 import pkg from '../package.json'
+import { defaultBypassMagicLinkVariableName } from './magic.link.js'
 
 /**
  * @typedef {object} Env
@@ -117,9 +118,9 @@ export function envAll (req, env, ctx) {
   env.magic = new Magic(env.MAGIC_SECRET_KEY)
 
   // We can remove this when magic admin sdk supports test mode
-  if (new URL(req.url).origin === 'http://testing.web3.storage' && env.DANGEROUSLY_BYPASS_MAGIC_AUTH !== 'undefined') {
+  if (new URL(req.url).origin === 'http://testing.web3.storage' && env[defaultBypassMagicLinkVariableName] !== 'undefined') {
     // only set this in test/scripts/worker-globals.js
-    console.log(`!!! DANGEROUSLY_BYPASS_MAGIC_AUTH=${env.DANGEROUSLY_BYPASS_MAGIC_AUTH} !!!`)
+    console.log(`!!! ${defaultBypassMagicLinkVariableName}=${env[defaultBypassMagicLinkVariableName]} !!!`)
   }
 
   env.db = new DBClient({

--- a/packages/api/src/index.js
+++ b/packages/api/src/index.js
@@ -7,7 +7,20 @@ import { envAll } from './env.js'
 import { statusGet } from './status.js'
 import { carHead, carGet, carPut, carPost } from './car.js'
 import { uploadPost } from './upload.js'
-import { userLoginPost, userTokensPost, userTokensGet, userTokensDelete, userUploadsGet, userUploadsDelete, userAccountGet, userUploadsRename, userInfoGet, userRequestPost, userPinsGet } from './user.js'
+import {
+  userAccountGet,
+  userInfoGet,
+  userLoginPost,
+  userPaymentGet,
+  userPinsGet,
+  userRequestPost,
+  userTokensDelete,
+  userTokensGet,
+  userTokensPost,
+  userUploadsDelete,
+  userUploadsGet,
+  userUploadsRename
+} from './user.js'
 import { pinDelete, pinGet, pinPost, pinsGet } from './pins.js'
 import { blogSubscriptionCreate } from './blog.js'
 import { metricsGet } from './metrics.js'
@@ -98,6 +111,7 @@ router.delete('/user/tokens/:id',        auth['👤🗑️'](userTokensDelete))
 router.get('/user/account',              auth['👤'](userAccountGet))
 router.get('/user/info',                 auth['👤'](userInfoGet))
 router.get('/user/pins',                 auth['📌⚠️'](userPinsGet))
+router.get('/user/payment',              auth['👤'](userPaymentGet))
 
 /* eslint-enable no-multi-spaces */
 

--- a/packages/api/src/magic.link.js
+++ b/packages/api/src/magic.link.js
@@ -1,0 +1,25 @@
+export const createMagicTestTokenBypass = (
+  requiredVariableName,
+  requiredTokenValue
+) => {
+  return {
+    requiredVariableName,
+    requiredTokenValue,
+    defaults: {
+      issuer: 'test-magic-issuer'
+    },
+    summary: [
+      'This is a bypass for testing our APIs even though most of them require a valid magic token.',
+      'When testing, we\'ll use a special-use token.',
+      'And our token-validating middleware will allow that token,',
+      `but *only* when env.${requiredVariableName} is truthy.`
+    ].join(' ')
+  }
+}
+
+export const defaultBypassMagicLinkVariableName = 'DANGEROUSLY_BYPASS_MAGIC_AUTH'
+
+export const magicLinkBypass = createMagicTestTokenBypass(
+  defaultBypassMagicLinkVariableName,
+  'test-magic'
+)

--- a/packages/api/src/user.js
+++ b/packages/api/src/user.js
@@ -439,9 +439,8 @@ const notifySlack = async (
  * @param {import('./env').Env} env
  */
 export async function userPaymentGet (request, env) {
-  console.log('userPaymentGet', {
-    authorizationHeader: request.headers.get('authorization')
-  })
-  const userPaymentGetResponse = { working: true }
+  const userPaymentGetResponse = {
+    method: null
+  }
   return new JSONResponse(userPaymentGetResponse)
 }

--- a/packages/api/src/user.js
+++ b/packages/api/src/user.js
@@ -431,9 +431,7 @@ const notifySlack = async (
 }
 
 /**
- * List a user's pins regardless of the token used.
- * As we don't want to scope the Pinning Service API to users
- * we need a new endpoint as an umbrella.
+ * Get a user's payment settings.
  *
  * @param {AuthenticatedRequest} request
  * @param {import('./env').Env} env

--- a/packages/api/src/user.js
+++ b/packages/api/src/user.js
@@ -429,3 +429,19 @@ const notifySlack = async (
     })
   })
 }
+
+/**
+ * List a user's pins regardless of the token used.
+ * As we don't want to scope the Pinning Service API to users
+ * we need a new endpoint as an umbrella.
+ *
+ * @param {AuthenticatedRequest} request
+ * @param {import('./env').Env} env
+ */
+export async function userPaymentGet (request, env) {
+  console.log('userPaymentGet', {
+    authorizationHeader: request.headers.get('authorization')
+  })
+  const userPaymentGetResponse = { working: true }
+  return new JSONResponse(userPaymentGetResponse)
+}

--- a/packages/api/test/contexts/authorization.js
+++ b/packages/api/test/contexts/authorization.js
@@ -1,0 +1,47 @@
+const symbol = Symbol.for('AuthorizationTestContext')
+
+export const createMagicTestTokenHack = (
+  requiredVariableName,
+  requiredTokenValue
+) => {
+  return {
+    requiredVariableName,
+    requiredTokenValue,
+    summary: [
+      'This is a hack for testing our APIs even though most of them require a valid magic token.',
+      'When testing, we\'ll use a special-use token.',
+      'And our token-validating middleware will allow that token,',
+      `but *only* when env.${requiredVariableName} is truthy.`
+    ].join(' ')
+  }
+}
+
+export class AuthorizationTestContext {
+  static install (testContext, constructorArgs = []) {
+    const authzContext = new AuthorizationTestContext(...constructorArgs)
+    testContext[symbol] = authzContext
+  }
+
+  static use (testContext) {
+    if (!(symbol in testContext)) {
+      throw new Error('cant use AuthorizationTestContext because it hasnt been installed yet')
+    }
+    return testContext[symbol]
+  }
+
+  constructor (
+    magicBypassHack = createMagicTestTokenHack(
+      'DANGEROUSLY_BYPASS_MAGIC_AUTH',
+      'test-magic'
+    )
+  ) {
+    this.magicBypassHack = magicBypassHack
+  }
+
+  /**
+   * Create a bearer token that can be used by tests that require one to test something behind basic is-user checks
+   */
+  createUserToken () {
+    return this.magicBypassHack.requiredTokenValue
+  }
+}

--- a/packages/api/test/contexts/authorization.js
+++ b/packages/api/test/contexts/authorization.js
@@ -1,20 +1,6 @@
-const symbol = Symbol.for('AuthorizationTestContext')
+import * as magic from '../../src/magic.link.js'
 
-export const createMagicTestTokenHack = (
-  requiredVariableName,
-  requiredTokenValue
-) => {
-  return {
-    requiredVariableName,
-    requiredTokenValue,
-    summary: [
-      'This is a hack for testing our APIs even though most of them require a valid magic token.',
-      'When testing, we\'ll use a special-use token.',
-      'And our token-validating middleware will allow that token,',
-      `but *only* when env.${requiredVariableName} is truthy.`
-    ].join(' ')
-  }
-}
+const symbol = Symbol.for('AuthorizationTestContext')
 
 export class AuthorizationTestContext {
   static install (testContext, constructorArgs = []) {
@@ -30,18 +16,15 @@ export class AuthorizationTestContext {
   }
 
   constructor (
-    magicBypassHack = createMagicTestTokenHack(
-      'DANGEROUSLY_BYPASS_MAGIC_AUTH',
-      'test-magic'
-    )
+    bypass = magic.magicLinkBypass
   ) {
-    this.magicBypassHack = magicBypassHack
+    this.bypass = bypass
   }
 
   /**
    * Create a bearer token that can be used by tests that require one to test something behind basic is-user checks
    */
   createUserToken () {
-    return this.magicBypassHack.requiredTokenValue
+    return this.bypass.requiredTokenValue
   }
 }

--- a/packages/api/test/hooks.js
+++ b/packages/api/test/hooks.js
@@ -6,6 +6,7 @@ import execa from 'execa'
 import delay from 'delay'
 import { webcrypto } from 'crypto'
 import * as workerGlobals from './scripts/worker-globals.js'
+import { AuthorizationTestContext } from './contexts/authorization.js'
 
 global.crypto = webcrypto
 
@@ -29,6 +30,7 @@ export const mochaHooks = () => {
   return {
     async beforeAll () {
       this.timeout(120_000)
+      AuthorizationTestContext.install(this)
 
       console.log('⚡️ Starting Miniflare')
       srv = await new Miniflare({

--- a/packages/api/test/user-payment.spec.js
+++ b/packages/api/test/user-payment.spec.js
@@ -1,0 +1,55 @@
+/* eslint-env mocha */
+import assert from 'assert'
+import fetch, { Request } from '@web-std/fetch'
+import { endpoint } from './scripts/constants.js'
+import { getTestJWT } from './scripts/helpers.js'
+
+function createBearerAuthorization (bearerToken) {
+  return `Bearer ${bearerToken}`
+}
+
+function createUserPaymentRequest (arg) {
+  const { path, baseUrl, authorization } = {
+    authorization: undefined,
+    path: '/user/payment',
+    baseUrl: endpoint,
+    accept: 'application/json',
+    method: 'get',
+    ...arg
+  }
+  return new Request(
+    new URL(path, baseUrl),
+    {
+      headers: {
+        accept: 'application/json',
+        authorization
+      }
+    }
+  )
+}
+
+describe('GET /user/payment', () => {
+  it('error if not authenticated with magic.link', async () => {
+    const token = await getTestJWT()
+    const res = await fetch(createUserPaymentRequest({ authorization: createBearerAuthorization(token) }))
+    assert(!res.ok)
+    assert.strictEqual(res.status, 401)
+  })
+
+  // it('error if no auth header', async () => {
+  //   const res = await fetch(new URL('user/account', endpoint))
+  //   assert(!res.ok)
+  //   assert.strictEqual(res.status, 401)
+  // })
+
+  // it('retrieves user account data', async () => {
+  //   const token = 'test-magic'
+  //   const res = await fetch(new URL('user/account', endpoint), {
+  //     headers: { Authorization: `Bearer ${token}` }
+  //   })
+  //   assert(res.ok)
+  //   const data = await res.json()
+  //   assert.strictEqual(data.usedStorage.uploaded, 32000)
+  //   assert.strictEqual(data.usedStorage.psaPinned, 10000)
+  // })
+})

--- a/packages/api/test/user-payment.spec.js
+++ b/packages/api/test/user-payment.spec.js
@@ -2,7 +2,7 @@
 import assert from 'assert'
 import fetch, { Request } from '@web-std/fetch'
 import { endpoint } from './scripts/constants.js'
-import { getTestJWT } from './scripts/helpers.js'
+import { AuthorizationTestContext } from './contexts/authorization.js'
 
 function createBearerAuthorization (bearerToken) {
   return `Bearer ${bearerToken}`
@@ -29,27 +29,23 @@ function createUserPaymentRequest (arg) {
 }
 
 describe('GET /user/payment', () => {
-  it('error if not authenticated with magic.link', async () => {
-    const token = await getTestJWT()
-    const res = await fetch(createUserPaymentRequest({ authorization: createBearerAuthorization(token) }))
+  it('error if no auth header', async () => {
+    const res = await fetch(createUserPaymentRequest())
     assert(!res.ok)
-    assert.strictEqual(res.status, 401)
   })
-
-  // it('error if no auth header', async () => {
-  //   const res = await fetch(new URL('user/account', endpoint))
-  //   assert(!res.ok)
-  //   assert.strictEqual(res.status, 401)
-  // })
-
-  // it('retrieves user account data', async () => {
-  //   const token = 'test-magic'
-  //   const res = await fetch(new URL('user/account', endpoint), {
-  //     headers: { Authorization: `Bearer ${token}` }
-  //   })
-  //   assert(res.ok)
-  //   const data = await res.json()
-  //   assert.strictEqual(data.usedStorage.uploaded, 32000)
-  //   assert.strictEqual(data.usedStorage.psaPinned, 10000)
-  // })
+  it('error if bad auth header', async () => {
+    const createRandomString = () => Math.random().toString().slice(2)
+    const authorization = createBearerAuthorization(createRandomString())
+    const res = await fetch(createUserPaymentRequest({ authorization }))
+    assert(!res.ok)
+  })
+  it('retrieves user account data', async function () {
+    const token = AuthorizationTestContext.use(this).createUserToken()
+    const authorization = createBearerAuthorization(token)
+    const res = await fetch(createUserPaymentRequest({ authorization }))
+    assert(res.ok)
+    const userPaymentSettings = await res.json()
+    assert.equal(typeof userPaymentSettings, 'object')
+    assert.ok(!userPaymentSettings.method, 'userPaymentSettings.method is falsy')
+  })
 })


### PR DESCRIPTION
Motivation
* @cmunns is gonna use this in https://github.com/web3-storage/web3.storage/issues/1741

What
* add the route
* it always returns the same thing
  * I'll add a way of mutating it in followup PR
* test that this route requires auth
* hide 'test-magic' details from the test via new AuthorizationTestContext
  * mocha hooks installs this context
  * tests can use the context to `createUserToken()`
  * provides abstraction on how our tests get an authz token
    * followup pr can replace other repeated instances of 'test-magic' with `createUserToken()` https://github.com/web3-storage/web3.storage/search?q=test-magic