### PR TITLE
feat: initial PUT /user/payment api to ui dev against

### DIFF
--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -4,6 +4,8 @@ on:
     branches:
       - main
     paths:
+      # test-e2e depends on api running too
+      - 'packages/api/**'
       - 'packages/website/**'
       - '.github/workflows/website.yml'
       - 'package-lock.json'

--- a/packages/api/src/env.js
+++ b/packages/api/src/env.js
@@ -153,4 +153,9 @@ export function envAll (req, env, ctx) {
       }
     )
   }
+
+  // via https://stripe.com/docs/api/payment_methods/object
+  // this can be used to mock realistic values of a stripe.com paymentMethod id
+  // after fulls tripe integration, this may not be needed on the env
+  env.mockStripePaymentMethodId = 'pm_1LZnQ1IfErzTm2rETa7IGoVm'
 }

--- a/packages/api/src/index.js
+++ b/packages/api/src/index.js
@@ -12,6 +12,7 @@ import {
   userInfoGet,
   userLoginPost,
   userPaymentGet,
+  userPaymentPut,
   userPinsGet,
   userRequestPost,
   userTokensDelete,
@@ -107,6 +108,7 @@ router.get('/user/account',              auth['👤'](userAccountGet))
 router.get('/user/info',                 auth['👤'](userInfoGet))
 router.get('/user/pins',                 auth['📌⚠️'](userPinsGet))
 router.get('/user/payment',              auth['👤'](userPaymentGet))
+router.put('/user/payment',              auth['👤'](userPaymentPut))
 
 /* eslint-enable no-multi-spaces */
 

--- a/packages/api/src/user.js
+++ b/packages/api/src/user.js
@@ -452,12 +452,15 @@ export async function userPaymentGet (request, env) {
  * @param {import('./env').Env} env
  */
 export async function userPaymentPut (request, env) {
-  const method = {
-    // stubbing this for now with the value from the docs.
-    //   https://stripe.com/docs/api/payment_methods/object
-    id: env.mockStripePaymentMethodId,
-    warning: 'this method is a stub. The id here is different than anything you might have sent in the request.'
-  }
+  const requestBody = await request.json()
+  const method = requestBody?.method?.id
+    ? { id: requestBody?.method?.id }
+    : {
+      // stubbing this for now with the value from the docs.
+      //   https://stripe.com/docs/api/payment_methods/object
+        id: env.mockStripePaymentMethodId,
+        warning: 'this method is a stub. The id here is different than anything you might have sent in the request.'
+      }
   const savePaymentSettingsResponse = {
     method
   }

--- a/packages/api/src/user.js
+++ b/packages/api/src/user.js
@@ -437,8 +437,10 @@ const notifySlack = async (
  * @param {import('./env').Env} env
  */
 export async function userPaymentGet (request, env) {
+  const { searchParams } = new URL(request.url)
+  const paramMethodId = searchParams.get('method.id')
   const userPaymentGetResponse = {
-    method: null
+    method: paramMethodId ? { id: paramMethodId } : null,
   }
   return new JSONResponse(userPaymentGetResponse)
 }
@@ -450,10 +452,19 @@ export async function userPaymentGet (request, env) {
  * @param {import('./env').Env} env
  */
 export async function userPaymentPut (request, env) {
+  const method = {
+    // stubbing this for now with the value from the docs.
+    //   https://stripe.com/docs/api/payment_methods/object
+    id: env.mockStripePaymentMethodId,
+    warning: 'this method is a stub. The id here is different than anything you might have sent in the request.'
+  }
   const savePaymentSettingsResponse = {
-    method: null
+    method
   }
   return new JSONResponse(savePaymentSettingsResponse, {
-    status: 202
+    status: 202,
+    headers: {
+      location: `/user/payment?method.id=${method.id}`
+    }
   })
 }

--- a/packages/api/src/user.js
+++ b/packages/api/src/user.js
@@ -442,3 +442,18 @@ export async function userPaymentGet (request, env) {
   }
   return new JSONResponse(userPaymentGetResponse)
 }
+
+/**
+ * Save a user's payment settings.
+ *
+ * @param {AuthenticatedRequest} request
+ * @param {import('./env').Env} env
+ */
+export async function userPaymentPut (request, env) {
+  const savePaymentSettingsResponse = {
+    method: null
+  }
+  return new JSONResponse(savePaymentSettingsResponse, {
+    status: 202
+  })
+}

--- a/packages/api/src/user.js
+++ b/packages/api/src/user.js
@@ -440,7 +440,7 @@ export async function userPaymentGet (request, env) {
   const { searchParams } = new URL(request.url)
   const paramMethodId = searchParams.get('method.id')
   const userPaymentGetResponse = {
-    method: paramMethodId ? { id: paramMethodId } : null,
+    method: paramMethodId ? { id: paramMethodId } : null
   }
   return new JSONResponse(userPaymentGetResponse)
 }

--- a/packages/api/test/user-payment.spec.js
+++ b/packages/api/test/user-payment.spec.js
@@ -52,11 +52,11 @@ describe('GET /user/payment', () => {
 
 /**
  * Create a request to SaveUserPaymentSettings
- * @param {object} arg
+ * @param {object} [arg]
  * @param {BodyInit|undefined|string} arg.body - body of request
  * @returns
  */
-function createSaveUserPaymentSettingsRequest (arg) {
+function createSaveUserPaymentSettingsRequest (arg = {}) {
   const body = (typeof arg.body === 'object') ? JSON.stringify(arg.body) : arg.body
   const { path, baseUrl, authorization, accept, method } = {
     authorization: undefined,

--- a/packages/api/test/user-payment.spec.js
+++ b/packages/api/test/user-payment.spec.js
@@ -57,7 +57,8 @@ describe('GET /user/payment', () => {
  * @returns
  */
 function createSaveUserPaymentSettingsRequest (arg) {
-  const { path, baseUrl, authorization, accept, body, method } = {
+  const body = (typeof arg.body === 'object') ? JSON.stringify(arg.body) : arg.body
+  const { path, baseUrl, authorization, accept, method } = {
     authorization: undefined,
     path: '/user/payment',
     baseUrl: endpoint,
@@ -92,7 +93,8 @@ describe('PUT /user/payment', () => {
   it('saves user payment settings', async function () {
     const token = AuthorizationTestContext.use(this).createUserToken()
     const authorization = createBearerAuthorization(token)
-    const res = await fetch(createSaveUserPaymentSettingsRequest({ authorization }))
+    const desiredPaymentMethodId = `w3-test-${Math.random().toString().slice(2)}`
+    const res = await fetch(createSaveUserPaymentSettingsRequest({ authorization, body: { method: { id: desiredPaymentMethodId } } }))
     try {
       assert.equal(res.status, 202, 'response.status is 202')
     } catch (error) {
@@ -104,6 +106,7 @@ describe('PUT /user/payment', () => {
     assert.ok('method' in savePaymentSettingsResponse, '"method" is in userPaymentSettings.method')
     assert.equal(typeof savePaymentSettingsResponse.method, 'object', 'response.method is an object')
     assert.equal(typeof savePaymentSettingsResponse.method?.id, 'string', 'response.method.id is a string')
+    assert.equal(savePaymentSettingsResponse.method?.id, desiredPaymentMethodId, `response.method.id is desiredPaymentMethodId=${desiredPaymentMethodId}`)
     const savedMethodId = savePaymentSettingsResponse.method.id
     assert.equal(typeof res.headers.get('location'), 'string', 'response.headers.location is a string')
 

--- a/packages/api/test/user-payment.spec.js
+++ b/packages/api/test/user-payment.spec.js
@@ -102,5 +102,20 @@ describe('PUT /user/payment', () => {
     const savePaymentSettingsResponse = await res.json()
     assert.equal(typeof savePaymentSettingsResponse, 'object')
     assert.ok('method' in savePaymentSettingsResponse, '"method" is in userPaymentSettings.method')
+    assert.equal(typeof savePaymentSettingsResponse.method, 'object', 'response.method is an object')
+    assert.equal(typeof savePaymentSettingsResponse.method?.id, 'string', 'response.method.id is a string')
+    const savedMethodId = savePaymentSettingsResponse.method.id
+    assert.equal(typeof res.headers.get('location'), 'string', 'response.headers.location is a string')
+
+    // see if we can then GET the response.headers.location url
+    const paymentSettingsUrl = new URL(res.headers.get('location'), res.url)
+    const paymentSettingsResponse = await fetch(paymentSettingsUrl, {
+      headers: {
+        authorization,
+      }
+    })
+    assert.equal(paymentSettingsResponse.status, 200, 'paymentSettingsResponse.status is 200')
+    const paymentSettings = await paymentSettingsResponse.json()
+    assert.equal(paymentSettings.method.id, savedMethodId, 'paymentSettings.method.id from location header is same as response to PUT')
   })
 })

--- a/packages/api/test/user-payment.spec.js
+++ b/packages/api/test/user-payment.spec.js
@@ -49,3 +49,58 @@ describe('GET /user/payment', () => {
     assert.ok(!userPaymentSettings.method, 'userPaymentSettings.method is falsy')
   })
 })
+
+/**
+ * Create a request to SaveUserPaymentSettings
+ * @param {object} arg
+ * @param {BodyInit|undefined|string} arg.body - body of request
+ * @returns
+ */
+function createSaveUserPaymentSettingsRequest (arg) {
+  const { path, baseUrl, authorization, accept, body, method } = {
+    authorization: undefined,
+    path: '/user/payment',
+    baseUrl: endpoint,
+    accept: 'application/json',
+    method: 'put',
+    ...arg
+  }
+  return new Request(
+    new URL(path, baseUrl),
+    {
+      method,
+      body,
+      headers: {
+        accept,
+        authorization
+      }
+    }
+  )
+}
+
+describe('PUT /user/payment', () => {
+  it('error if no auth header', async () => {
+    const res = await fetch(createSaveUserPaymentSettingsRequest())
+    assert(!res.ok)
+  })
+  it('error if bad auth header', async () => {
+    const createRandomString = () => Math.random().toString().slice(2)
+    const authorization = createBearerAuthorization(createRandomString())
+    const res = await fetch(createSaveUserPaymentSettingsRequest({ authorization }))
+    assert(!res.ok)
+  })
+  it('saves user payment settings', async function () {
+    const token = AuthorizationTestContext.use(this).createUserToken()
+    const authorization = createBearerAuthorization(token)
+    const res = await fetch(createSaveUserPaymentSettingsRequest({ authorization }))
+    try {
+      assert.equal(res.status, 202, 'response.status is 202')
+    } catch (error) {
+      console.log('response text is', await res.text())
+      throw error
+    }
+    const savePaymentSettingsResponse = await res.json()
+    assert.equal(typeof savePaymentSettingsResponse, 'object')
+    assert.ok('method' in savePaymentSettingsResponse, '"method" is in userPaymentSettings.method')
+  })
+})

--- a/packages/api/test/user-payment.spec.js
+++ b/packages/api/test/user-payment.spec.js
@@ -111,7 +111,7 @@ describe('PUT /user/payment', () => {
     const paymentSettingsUrl = new URL(res.headers.get('location'), res.url)
     const paymentSettingsResponse = await fetch(paymentSettingsUrl, {
       headers: {
-        authorization,
+        authorization
       }
     })
     assert.equal(paymentSettingsResponse.status, 200, 'paymentSettingsResponse.status is 200')

--- a/packages/tools/package.json
+++ b/packages/tools/package.json
@@ -16,6 +16,7 @@
   },
   "scripts": {
     "cluster:start": "./scripts/cli.js cluster --start",
+    "docker:ps": "docker ps -a | grep 'web3\\|ipfs0\\|minio0\\|cluster0'",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "keywords": [


### PR DESCRIPTION
Motivation:
* unblocking ui dev against our https api contract https://github.com/web3-storage/web3.storage/issues/1748

Note:
* this stubs the http api behavior so @cmunns can dev ui against it, but doesn't actually save to stripe.com or our db. I'll do that ASAP after that to unstub