### PR TITLE
chore: switch to org-level GH secret for Cloudflare token

### DIFF
--- a/.github/workflows/api.yml
+++ b/.github/workflows/api.yml
@@ -50,7 +50,7 @@ jobs:
           SENTRY_TOKEN: ${{ secrets.SENTRY_TOKEN}}
           SENTRY_UPLOAD: ${{ secrets.SENTRY_UPLOAD}}
         with:
-          apiToken: ${{ secrets.CF_API_TOKEN }}
+          apiToken: ${{ secrets.CF_TOKEN }}
           workingDirectory: 'packages/api'
           environment: 'staging'
       - name: Test upload to staging
@@ -90,6 +90,6 @@ jobs:
           SENTRY_TOKEN: ${{ secrets.SENTRY_TOKEN}}
           SENTRY_UPLOAD: ${{ secrets.SENTRY_UPLOAD}}
         with:
-          apiToken: ${{ secrets.CF_API_TOKEN }}
+          apiToken: ${{ secrets.CF_TOKEN }}
           workingDirectory: 'packages/api'
           environment: 'production'

--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -101,7 +101,7 @@ jobs:
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         run: npx dnslink-cloudflare --record staging --domain web3.storage --link /ipfs/${{ steps.ipfs.outputs.cid }}
         env:
-          CF_API_TOKEN: ${{ secrets.CF_API_TOKEN }}
+          CF_API_TOKEN: ${{ secrets.CF_TOKEN }}
       - name: Deploy preview build to Cloudflare Pages
         uses: mathiasvr/command-output@v1.1.0
         id: cloudflare
@@ -189,7 +189,7 @@ jobs:
       - name: Update IPFS DNSLink https://web3.storage
         run: npx dnslink-cloudflare --record _dnslink --domain web3.storage --link /ipfs/${{ steps.ipfs.outputs.cid }}
         env:
-          CF_API_TOKEN: ${{ secrets.CF_API_TOKEN }}
+          CF_API_TOKEN: ${{ secrets.CF_TOKEN }}
       - name: Deploy https://web3.storage to Cloudflare Pages
         run: npx wrangler pages publish --project-name web3-storage --branch "main" --commit-hash "$GITHUB_SHA" ./packages/website/out
         env:


### PR DESCRIPTION
Once this is merged, the `CF_API_TOKEN` secret can (and should) be deleted from this repo's secrets.