### PR TITLE
fix: hide status column from account page upload view only

### DIFF
--- a/packages/website/components/account/filesManager/fileRowItem.js
+++ b/packages/website/components/account/filesManager/fileRowItem.js
@@ -94,6 +94,7 @@ const FileRowItem = props => {
     <div
       className={clsx(
         'files-manager-row',
+        tabType,
         className,
         isHeader && 'files-manager-row-header',
         isSelected && 'files-manager-row-active'

--- a/packages/website/components/account/filesManager/fileRowItem.scss
+++ b/packages/website/components/account/filesManager/fileRowItem.scss
@@ -3,9 +3,10 @@
 $base-row-width: 75.125rem;
 $file-select: calculateWidthPercentage(3.5rem, $base-row-width);
 $file-name: calculateWidthPercentage(23rem, $base-row-width);
-$file-cid: calculateWidthPercentage(20rem, $base-row-width);
+$file-cid: calculateWidthPercentage(16rem, $base-row-width);
 $file-availability: calculateWidthPercentage(0rem, $base-row-width);
-$file-storage-providers: calculateWidthPercentage(14rem, $base-row-width);
+$file-pin-status: calculateWidthPercentage(8rem, $base-row-width);
+$file-storage-providers: calculateWidthPercentage(10rem, $base-row-width);
 $file-size: calculateWidthPercentage(8rem, $base-row-width);
 $file-date: auto;
 
@@ -16,10 +17,10 @@ $file-date: auto;
   letter-spacing: 0;
   display: grid;
   position: relative;
-  grid-template-columns: $file-select $file-name $file-cid $file-storage-providers $file-size $file-date;
+  grid-template-columns: $file-select $file-name $file-cid $file-pin-status $file-storage-providers $file-size $file-date ;
   align-items: flex-start;
-  padding: 0.75rem 2rem;
-  transition: all 0.2s ease-in-out;
+  padding: .75rem 2rem;
+  transition: all .2s ease-in-out;
   border-bottom: 0.078125rem solid rgba(white, 0.05);
 
   &:nth-child(even) {
@@ -52,7 +53,7 @@ $file-date: auto;
     word-break: break-word;
     @include fontWeight_Regular;
     @include medium {
-      padding: 0.5rem 0.75rem 0.5rem 1.5rem;
+      padding: .5rem .75rem .5rem 1.5rem;
       justify-content: flex-start;
       border-bottom: 0.078125rem solid rgba(white, 0.05);
       &.file-name {
@@ -178,7 +179,7 @@ $file-date: auto;
       }
       svg.pencil-icon {
         flex-shrink: 0;
-        margin: 4px 0px 0px 0.5rem;
+        margin: 4px 0px 0px .5rem;
         @include hoverSvg;
         @include medium {
           display: none;
@@ -210,7 +211,7 @@ $file-date: auto;
     }
     &-cid {
       padding-right: 2rem;
-      margin-top: -0.1rem;
+      margin-top: -.1rem;
       justify-content: flex-start;
       align-items: center;
       .cid-truncate,
@@ -236,6 +237,14 @@ $file-date: auto;
         padding-right: 1.25rem;
       }
     }
+    &-pin-status {
+      justify-content: flex-start;
+      align-items: center;
+      gap: 0.625rem;
+      @include medium {
+        gap: 0;
+      }
+    }
     &-storage-providers {
       justify-content: flex-start;
       align-items: center;
@@ -246,7 +255,7 @@ $file-date: auto;
         gap: 0;
       }
 
-      a[href*='filfox'] {
+      a[href*="filfox"] {
         @include monospace_Text;
       }
 
@@ -308,7 +317,7 @@ $file-date: auto;
   }
 
   &.files-manager-row-active {
-    background: rgba(0, 0, 0, 0.25);
+    background: rgba(0,0,0,0.25);
   }
 
   // Header overrides

--- a/packages/website/components/account/filesManager/fileRowItem.scss
+++ b/packages/website/components/account/filesManager/fileRowItem.scss
@@ -7,7 +7,9 @@ $file-cid: calculateWidthPercentage(16rem, $base-row-width);
 $file-availability: calculateWidthPercentage(0rem, $base-row-width);
 $file-pin-status: calculateWidthPercentage(8rem, $base-row-width);
 $file-storage-providers: calculateWidthPercentage(10rem, $base-row-width);
-$file-size: calculateWidthPercentage(8rem, $base-row-width);
+$file-storage-providers-wide: calculateWidthPercentage(14rem, $base-row-width);
+$file-size: calculateWidthPercentage(12rem, $base-row-width);
+$file-size-wide: calculateWidthPercentage(8rem, $base-row-width);
 $file-date: auto;
 
 .files-manager-row {
@@ -17,11 +19,15 @@ $file-date: auto;
   letter-spacing: 0;
   display: grid;
   position: relative;
-  grid-template-columns: $file-select $file-name $file-cid $file-pin-status $file-storage-providers $file-size $file-date ;
+  grid-template-columns: $file-select $file-name $file-cid $file-pin-status $file-storage-providers $file-size $file-date;
   align-items: flex-start;
-  padding: .75rem 2rem;
-  transition: all .2s ease-in-out;
+  padding: 0.75rem 2rem;
+  transition: all 0.2s ease-in-out;
   border-bottom: 0.078125rem solid rgba(white, 0.05);
+
+  &.uploaded {
+    grid-template-columns: $file-select $file-name $file-cid $file-storage-providers-wide $file-size-wide $file-date;
+  }
 
   &:nth-child(even) {
     background-color: rgba(255, 255, 255, 0.05);
@@ -45,6 +51,10 @@ $file-date: auto;
     border-bottom: 0.15625rem solid rgba(white, 0.15);
   }
 
+  &.uploaded .file-pin-status {
+    display: none;
+  }
+
   // Targeting all columns
   > span {
     display: flex;
@@ -53,7 +63,7 @@ $file-date: auto;
     word-break: break-word;
     @include fontWeight_Regular;
     @include medium {
-      padding: .5rem .75rem .5rem 1.5rem;
+      padding: 0.5rem 0.75rem 0.5rem 1.5rem;
       justify-content: flex-start;
       border-bottom: 0.078125rem solid rgba(white, 0.05);
       &.file-name {
@@ -179,7 +189,7 @@ $file-date: auto;
       }
       svg.pencil-icon {
         flex-shrink: 0;
-        margin: 4px 0px 0px .5rem;
+        margin: 4px 0px 0px 0.5rem;
         @include hoverSvg;
         @include medium {
           display: none;
@@ -211,7 +221,7 @@ $file-date: auto;
     }
     &-cid {
       padding-right: 2rem;
-      margin-top: -.1rem;
+      margin-top: -0.1rem;
       justify-content: flex-start;
       align-items: center;
       .cid-truncate,
@@ -255,7 +265,7 @@ $file-date: auto;
         gap: 0;
       }
 
-      a[href*="filfox"] {
+      a[href*='filfox'] {
         @include monospace_Text;
       }
 
@@ -317,7 +327,7 @@ $file-date: auto;
   }
 
   &.files-manager-row-active {
-    background: rgba(0,0,0,0.25);
+    background: rgba(0, 0, 0, 0.25);
   }
 
   // Header overrides

--- a/packages/website/components/account/filesManager/filesManager.js
+++ b/packages/website/components/account/filesManager/filesManager.js
@@ -18,7 +18,7 @@ import { useTokens } from 'components/contexts/tokensContext';
 import CheckIcon from 'assets/icons/check';
 import SearchIcon from 'assets/icons/search';
 import RefreshIcon from 'assets/icons/refresh';
-import FileRowItem from './fileRowItem';
+import FileRowItem, { PinStatus } from './fileRowItem';
 import GradientBackground from '../../gradientbackground/gradientbackground.js';
 
 const defaultQueryOrder = 'newest';
@@ -363,6 +363,7 @@ const FilesManager = ({ className, content, onFileUpload }) => {
         date={fileRowLabels.date.label}
         name={fileRowLabels.name.label}
         cid={fileRowLabels.cid.label}
+        status={fileRowLabels.status.label}
         storageProviders={currentTab === 'uploaded' ? fileRowLabels.storage_providers.label : null}
         size={fileRowLabels.size.label}
         linkPrefix={linkPrefix}
@@ -403,6 +404,10 @@ const FilesManager = ({ className, content, onFileUpload }) => {
               date={item.created}
               name={item.name}
               cid={item.cid}
+              status={
+                Object.values(PinStatus).find(status => item.pins.some(pin => status === pin.status)) ||
+                PinStatus.QUEUING
+              }
               storageProviders={
                 Array.isArray(item.deals)
                   ? item.deals
@@ -427,6 +432,7 @@ const FilesManager = ({ className, content, onFileUpload }) => {
               }
               linkPrefix={linkPrefix}
               highlight={{ target: 'name', text: keyword?.toString() || '' }}
+              numberOfPins={item.pins.length}
               isSelected={!!selectedFiles.find(fileSelected => fileSelected === item)}
               onDelete={() => onDeleteSingle(item.cid)}
               isEditingName={item.cid === nameEditingId}


### PR DESCRIPTION
This reverts the previous removal of the Status column and instead specifically hides the column on the uploads (not pinning) table.