### PR TITLE
chore: remove manual settings of release version for w3 package

### DIFF
--- a/.github/workflows/w3.yml
+++ b/.github/workflows/w3.yml
@@ -63,8 +63,6 @@ jobs:
           monorepo-tags: true
           package-name: w3
           changelog-types: '[{"type":"feat","section":"Features","hidden":false},{"type":"fix","section":"Bug Fixes","hidden":false},{"type":"chore","section":"Other Changes","hidden":false}]'
-          release-as: '2.6.1'
-          last-release-sha: 4da1a7dba4503ce73baf89a511158e29d0b8d0bf
       - uses: actions/checkout@v2
         if: ${{ steps.tag-release.outputs.releases_created }}
       - uses: actions/setup-node@v2


### PR DESCRIPTION
This undoes the manual setting of the version number and previous release commit sha in the release-please config for the `w3` package, which was added in #1799.

Once we've merged this **and** done another successful release of the `w3` package, we can call #1789 done. (Although maybe we just close #1789 and re-open it if something bad happens next time, as I don't think there are any other pending changes for `w3` that are likely to be released imminently.)