### PR TITLE
feat: `w3` command using w3s.link

### DIFF
--- a/packages/w3/index.js
+++ b/packages/w3/index.js
@@ -159,7 +159,7 @@ export async function put (firstPath, opts) {
     }
   })
   spinner.stopAndPersist({ symbol: '⁂', text: `Stored ${files.length} file${files.length === 1 ? '' : 's'}` })
-  console.log(`⁂ https://dweb.link/ipfs/${root}`)
+  console.log(`⁂ https://w3s.link/ipfs/${root}`)
 }
 
 /**
@@ -211,7 +211,7 @@ export async function putCar (firstPath, opts) {
     }
   })
   spinner.stopAndPersist({ symbol: '⁂', text: `Stored ${filesize(totalSize)}` })
-  console.log(`⁂ https://dweb.link/ipfs/${root}`)
+  console.log(`⁂ https://w3s.link/ipfs/${root}`)
 }
 
 function filesize (bytes) {


### PR DESCRIPTION
Makes more sense for our `w3` command to offer the user a link to our w3s.link gateway.

```bash
❯ w3 put olizilla.png --no-wrap
# Packed 1 file (0.1MB)
# bafkreiawm5lgdgchgrhep4kxo2g4tptewtpcnfzusyfcopytpuj2fnzf2m
⁂ Stored 1 file
⁂ https://w3s.link/ipfs/bafkreiawm5lgdgchgrhep4kxo2g4tptewtpcnfzusyfcopytpuj2fnzf2m
```

License: MIT
Signed-off-by: Oli Evans <oli@protocol.ai>