### PR TITLE
feat: packages/api typecheck checks ./test dir

### DIFF
--- a/packages/api/test/car.spec.js
+++ b/packages/api/test/car.spec.js
@@ -103,7 +103,7 @@ describe('POST /car', () => {
     const listRes = await s3.send(new ListObjectsV2Command({
       Bucket: S3_BUCKET_NAME
     }))
-    assert.strictEqual(listRes.Contents.length, 1, '1 item uploaded')
+    assert.strictEqual(listRes?.Contents?.length, 1, '1 item uploaded')
 
     const getRes = await s3.send(new GetObjectCommand({
       Bucket: S3_BUCKET_NAME,
@@ -111,6 +111,7 @@ describe('POST /car', () => {
     }))
 
     const chunks = []
+    // @ts-ignore
     for await (const chunk of getRes.Body) {
       chunks.push(chunk)
     }

--- a/packages/api/test/hooks.js
+++ b/packages/api/test/hooks.js
@@ -8,6 +8,7 @@ import { webcrypto } from 'crypto'
 import * as workerGlobals from './scripts/worker-globals.js'
 import { AuthorizationTestContext } from './contexts/authorization.js'
 
+// @ts-ignore
 global.crypto = webcrypto
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url))

--- a/packages/api/test/maintenance.spec.js
+++ b/packages/api/test/maintenance.spec.js
@@ -62,7 +62,7 @@ describe('maintenance middleware', () => {
     invalidModes.forEach((m) => {
       assert.throws(() => block(() => {}, {
         MODE: m
-      }, /invalid maintenance mode/))
+      }), /invalid maintenance mode/)
     })
   })
 

--- a/packages/api/test/user-payment.spec.js
+++ b/packages/api/test/user-payment.spec.js
@@ -8,8 +8,13 @@ function createBearerAuthorization (bearerToken) {
   return `Bearer ${bearerToken}`
 }
 
-function createUserPaymentRequest (arg) {
-  const { path, baseUrl, authorization } = {
+/**
+ * @param {object} arg
+ * @param {string} [arg.method] - method of request
+ * @param {string} [arg.authorization] - authorization header value
+ */
+function createUserPaymentRequest (arg = {}) {
+  const { path, baseUrl, authorization, accept, method } = {
     authorization: undefined,
     path: '/user/payment',
     baseUrl: endpoint,
@@ -21,9 +26,10 @@ function createUserPaymentRequest (arg) {
     new URL(path, baseUrl),
     {
       headers: {
-        accept: 'application/json',
-        authorization
-      }
+        accept,
+        ...(authorization ? { authorization } : {})
+      },
+      method
     }
   )
 }
@@ -54,7 +60,8 @@ describe('GET /user/payment', () => {
 /**
  * Create a request to SaveUserPaymentSettings
  * @param {object} [arg]
- * @param {BodyInit|undefined|string} arg.body - body of request
+ * @param {BodyInit|undefined|string} [arg.body] - body of request
+ * @param {string} [arg.authorization] - authorization header value
  * @returns
  */
 function createSaveUserPaymentSettingsRequest (arg = {}) {
@@ -74,7 +81,7 @@ function createSaveUserPaymentSettingsRequest (arg = {}) {
       body,
       headers: {
         accept,
-        authorization
+        ...(authorization ? { authorization } : {})
       }
     }
   )
@@ -95,7 +102,7 @@ describe('PUT /user/payment', () => {
     const token = AuthorizationTestContext.use(this).createUserToken()
     const authorization = createBearerAuthorization(token)
     const desiredPaymentMethodId = `w3-test-${Math.random().toString().slice(2)}`
-    const res = await fetch(createSaveUserPaymentSettingsRequest({ authorization, body: { method: { id: desiredPaymentMethodId } } }))
+    const res = await fetch(createSaveUserPaymentSettingsRequest({ authorization, body: JSON.stringify({ method: { id: desiredPaymentMethodId } }) }))
     try {
       assert.equal(res.status, 202, 'response.status is 202')
     } catch (error) {
@@ -112,7 +119,7 @@ describe('PUT /user/payment', () => {
     assert.equal(typeof res.headers.get('location'), 'string', 'response.headers.location is a string')
 
     // see if we can then GET the response.headers.location url
-    const paymentSettingsUrl = new URL(res.headers.get('location'), res.url)
+    const paymentSettingsUrl = new URL(res.headers.get('location') ?? '', res.url)
     const paymentSettingsResponse = await fetch(paymentSettingsUrl, {
       headers: {
         authorization

--- a/packages/api/test/user.spec.js
+++ b/packages/api/test/user.spec.js
@@ -54,7 +54,7 @@ describe('GET /user/info', () => {
     const db = getDBClient()
     const authorization = AuthorizationTestContext.use(this)
     const token = authorization.createUserToken()
-    const user = await db.getUser(authorization.bypass.defaults.issuer)
+    const user = await db.getUser(authorization.bypass.defaults.issuer, {})
     let res, userInfo
 
     // Set PSA access to true and check response
@@ -343,8 +343,8 @@ describe('GET /user/pins', () => {
   it('accepts the `size` and `page` options', async () => {
     const size = 1
     const opts = new URLSearchParams({
-      page: 1,
-      size,
+      page: (1).toString(),
+      size: size.toString(),
       status: 'queued,pinning,pinned,failed'
     })
     const token = await getTestJWT('test-pinning', 'test-pinning')
@@ -353,17 +353,17 @@ describe('GET /user/pins', () => {
       headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' }
     })
     assert(res.ok)
-    const body = await res.json()
-    assert(body.results.length, size)
-    assert(res.headers.get('size'), size)
+    const body = (await res.json())
+    assert.equal(body.results.length, size)
+    assert.equal(res.headers.get('size'), size)
     assert.strictEqual(res.headers.get('link'), '</user/pins?size=1&page=2>; rel="next", </user/pins?size=1&page=8>; rel="last", </user/pins?size=1&page=1>; rel="first"')
   })
   it('returns the correct headers for pagination', async () => {
     const size = 1
     const page = 2
     const opts = new URLSearchParams({
-      page,
-      size,
+      page: page.toString(),
+      size: size.toString(),
       status: 'queued,pinning,pinned,failed'
     })
     const token = await getTestJWT('test-pinning', 'test-pinning')
@@ -373,10 +373,10 @@ describe('GET /user/pins', () => {
     })
     assert(res.ok)
     const body = await res.json()
-    assert(body.results.length, size)
-    assert(res.headers.get('size'), size)
+    assert.equal(body.results.length, size)
+    assert.equal(res.headers.get('size'), size)
     assert(res.headers.get('count'))
-    assert(res.headers.get('page'), page)
+    assert.equal(res.headers.get('page'), page)
     assert.strictEqual(res.headers.get('link'), '</user/pins?size=1&page=3>; rel="next", </user/pins?size=1&page=8>; rel="last", </user/pins?size=1&page=1>; rel="first", </user/pins?size=1&page=1>; rel="previous"')
   })
   it('returns all pins regardless of the token used', async () => {
@@ -391,6 +391,6 @@ describe('GET /user/pins', () => {
 
     assert(res.ok)
     const body = await res.json()
-    assert([...new Set(body.results.map(x => x.pin.authKey))].length, 2)
+    assert.equal([...new Set(body.results.map(x => x.pin.authKey))].length, 2)
   })
 })

--- a/packages/api/tsconfig.json
+++ b/packages/api/tsconfig.json
@@ -23,7 +23,10 @@
     },
     "incremental": true
   },
-  "include": ["./src"],
+  "include": [
+    "./src",
+    "./test"
+  ],
   "references": [
     {
       "path": "../client"


### PR DESCRIPTION
Motivation:
* followup to https://github.com/web3-storage/web3.storage/pull/1813
  * in that pr I didn't notice that `./test` dir would not be typechecked. This adds that