### PR TITLE
fix: remove helix image that clashes with 'products' nav item

### DIFF
--- a/packages/website/components/hero/hero.js
+++ b/packages/website/components/hero/hero.js
@@ -94,7 +94,6 @@ export default function Hero({ block }) {
         <HeroIllustration id="index_hero-squiggle" src={ImageSquiggle} />
         <HeroIllustration id="index_hero-corkscrew" src={ImageCorkscrew} />
         <HeroIllustration id="index_hero-zigzag" src={ImageZigzag} />
-        <HeroIllustration id="index_hero-helix" src={ImageHelix} />
         <HeroIllustration id="index_hero-cross" src={ImageCross} />
         <HeroIllustration id="index_hero-triangle" src={ImageTriangle} />
       </>


### PR DESCRIPTION
Closes #1809 