### PR TITLE
fix: sourcemap stacktraces in sentry

### DIFF
--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "type": "module",
   "license": "(Apache-2.0 OR MIT)",
-  "main": "./dist/worker.mjs",
+  "main": "./dist/worker.js",
   "scripts": {
     "lt": "npm-run-all -p lt:*",
     "lt:cluster": "npx localtunnel --port 9094 --subdomain \"$(whoami)-cluster-api-web3-storage\"",

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -29,7 +29,7 @@
     "minio:reset": "web3-storage-tools minio server clean",
     "pg:start": "cd ../db && npm start",
     "pg:stop": "cd ../db && npm run stop",
-    "miniflare": "miniflare dist/worker.mjs --modules --env ../../.env $API_MINIFLARE_FLAGS --watch",
+    "miniflare": "miniflare dist/worker.js --modules --env ../../.env $API_MINIFLARE_FLAGS --watch",
     "lint": "standard --verbose",
     "lint:fix": "npm run lint -- --fix"
   },
@@ -80,7 +80,7 @@
   },
   "bundlesize": [
     {
-      "path": "./dist/worker.mjs",
+      "path": "./dist/worker.js",
       "maxSize": "1 MB"
     }
   ]

--- a/packages/api/scripts/cli.js
+++ b/packages/api/scripts/cli.js
@@ -29,7 +29,7 @@ prog
       entryPoints: [path.join(__dirname, '..', 'src', 'index.js')],
       bundle: true,
       format: 'esm',
-      outfile: path.join(__dirname, '..', 'dist', 'worker.mjs'),
+      outfile: path.join(__dirname, '..', 'dist', 'worker.js'),
       legalComments: 'external',
       inject: [path.join(__dirname, 'node-globals.js')],
       plugins: [{
@@ -76,7 +76,7 @@ prog
       await cli.releases.uploadSourceMaps(sentryRelease, {
         // validate: true,
         include: [path.join(__dirname, '..', 'dist')],
-        ext: ['map', 'mjs']
+        ext: ['map', 'js']
       })
       await cli.releases.finalize(sentryRelease)
       await cli.releases.newDeploy(sentryRelease, { env: opts.env })

--- a/packages/api/src/env.js
+++ b/packages/api/src/env.js
@@ -79,8 +79,8 @@ export function envAll (req, env, ctx) {
     allowedSearchParams: /(.*)/,
     debug: env.DEBUG === 'true',
     rewriteFrames: {
-      // strip . from start of the filename ./worker.mjs as set by cloudflare, to make absolute path `/worker.mjs`
-      iteratee: (frame) => ({ ...frame, filename: frame.filename?.substring(1) })
+      // sourcemaps only work if stack filepath are absolute like `/worker.js`
+      root: '/'
     },
     environment: env.ENV,
     release: env.SENTRY_RELEASE,

--- a/packages/api/test/hooks.js
+++ b/packages/api/test/hooks.js
@@ -37,7 +37,7 @@ export const mochaHooks = () => {
       srv = await new Miniflare({
         // Autoload configuration from `.env`, `package.json` and `wrangler.toml`
         envPath: true,
-        scriptPath: 'dist/worker.mjs',
+        scriptPath: 'dist/worker.js',
         packagePath: true,
         wranglerConfigPath: true,
         wranglerConfigEnv: 'test',

--- a/packages/api/wrangler.toml
+++ b/packages/api/wrangler.toml
@@ -1,6 +1,6 @@
 # web3.storage wrangler config.
 name = "web3-storage"
-main = "./dist/worker.mjs"
+main = "./dist/worker.js"
 compatibility_date = "2022-06-14"
 no_bundle = true
 


### PR DESCRIPTION
the errors are now showing up in sentry with `abs_path: "orker.js"` which looks like we are trimming a w from `worker.js`.
that also suggests the file is now renamed worker.js by wrangler v2 on upload, so we rename ours in this PR.

- `worker.mjs` -> `worker.js` to match what we see in sentry error.
- stop stripping first char on paths in stack traces in sentry client config.
- set `rewriteFrames.root: '/'` to get toucan to prepend `/` to make it `/worker.js`

see: https://github.com/web3-storage/web3.storage/pull/1033
needs: https://github.com/web3-storage/web3.storage/pull/1731
replaces: https://github.com/web3-storage/web3.storage/pull/1593

License: MIT
Signed-off-by: Oli Evans <oli@protocol.ai>