### PR TITLE
fix: empty payload is client error

### DIFF
--- a/packages/api/src/upload.js
+++ b/packages/api/src/upload.js
@@ -35,7 +35,7 @@ export async function uploadPost (request, env, ctx) {
   } else {
     const blob = await request.blob()
     if (blob.size === 0) {
-      throw new Error('Empty payload')
+      throw new HTTPError('Empty payload', 400)
     }
     input = [blob]
   }


### PR DESCRIPTION
This is currently raising alerts for on call folks but is a client error.