### PR TITLE
fix: /account/payment tiny bugs - use env var on website, fix uncaught error when no default_payment_method in StripeBillingService

### DIFF
--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -185,7 +185,7 @@ jobs:
           NEXT_PUBLIC_MAGIC: ${{ secrets.STAGING_MAGIC_PUBLIC_KEY }}
           NEXT_PUBLIC_COUNTLY_URL: ${{ secrets.COUNTLY_URL }}
           NEXT_PUBLIC_COUNTLY_KEY: ${{ secrets.COUNTLY_KEY }}
-          NEXT_PUBLIC_STRIPE_TEST_PK: ${{ secrets.TESTING_STRIPE_TEST_PK}}
+          NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY: ${{ secrets.TESTING_STRIPE_PUBLISHABLE_KEY }}
       - name: Add to web3.storage
         uses: web3-storage/add-to-web3@v2
         id: ipfs
@@ -275,6 +275,7 @@ jobs:
           NEXT_PUBLIC_MAGIC: ${{ secrets.PROD_MAGIC_PUBLIC_KEY }}
           NEXT_PUBLIC_COUNTLY_URL: ${{ secrets.COUNTLY_URL }}
           NEXT_PUBLIC_COUNTLY_KEY: ${{ secrets.COUNTLY_KEY }}
+          NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY: ${{ secrets.TESTING_STRIPE_PUBLISHABLE_KEY }}
       - name: Add to web3.storage
         uses: web3-storage/add-to-web3@v2
         id: ipfs

--- a/packages/api/src/utils/stripe.js
+++ b/packages/api/src/utils/stripe.js
@@ -8,6 +8,7 @@ import { CustomerNotFound, randomString } from './billing.js'
 
 /**
  * @typedef {import("./billing-types").BillingService} BillingService
+ * @typedef {import("./billing-types").PaymentMethod} PaymentMethod
  */
 
 /**
@@ -39,7 +40,8 @@ export class StripeBillingService {
   }
 
   /**
-   * @returns {Promise<import('./billing-types').CustomerNotFound|import('./billing-types').PaymentMethod>}
+   * @param {string} customerId
+   * @returns {Promise<null | CustomerNotFound | PaymentMethod>}
    */
   async getPaymentMethod (customerId) {
     const response = await this.stripe.customers.retrieve(customerId, {
@@ -52,7 +54,7 @@ export class StripeBillingService {
     const defaultPaymentMethodObject = (typeof defaultPaymentMethod === 'string') ? { id: defaultPaymentMethod } : defaultPaymentMethod ?? {}
     const defaultPaymentMethodId = (typeof defaultPaymentMethod === 'string') ? defaultPaymentMethod : defaultPaymentMethod?.id
     if (!defaultPaymentMethodId) {
-      throw new Error('unable to determine defaultPaymentMethodId for customer')
+      return null
     }
     /** @type {import('./billing-types').PaymentMethod} */
     const paymentMethod = ('card' in defaultPaymentMethodObject)

--- a/packages/api/test/stripe.spec.js
+++ b/packages/api/test/stripe.spec.js
@@ -30,7 +30,7 @@ describe('StripeBillingService', async function () {
     const billing = StripeBillingService.create(mockStripe)
     const gotPaymentMethod = await billing.getPaymentMethod(customerId)
     assert.ok(!(gotPaymentMethod instanceof Error), 'gotPaymentMethod did not return an error')
-    assert.equal(gotPaymentMethod.id, mockPaymentMethodId)
+    assert.equal(gotPaymentMethod?.id, mockPaymentMethodId)
   })
   it('getPaymentMethod results in CustomerNotFound error if customer is deleted', async function () {
     const customerId = `customer-${Math.random().toString().slice(2)}`
@@ -62,7 +62,8 @@ describe('StripeCustomersService + StripeBillingService', () => {
     await billing.savePaymentMethod(customer.id, desiredPaymentMethodId)
     const gotPaymentMethod = await billing.getPaymentMethod(customer.id)
     assert.ok(!(gotPaymentMethod instanceof Error), 'getPaymentMethod did not return an error')
-    assert.ok(gotPaymentMethod.id.startsWith('pm_'), 'payment method id starts with pm_')
+    assert.ok(gotPaymentMethod, 'paymentMethod is truthy')
+    assert.ok(gotPaymentMethod?.id.startsWith('pm_'), 'payment method id starts with pm_')
     // it will have a 'card' property same as stripe
     assert.ok('card' in gotPaymentMethod, 'payment method has card property')
     const card = gotPaymentMethod.card


### PR DESCRIPTION
Motivation:
* small errors in /account/payment in staging/prod

Why wasn't this caught by testing?
* missing env var - I should have tested the website preview link
* uncaught error - this is tricky. We mock this service in all our tests, so tests wouldn't have caught it. Maybe test code coverage metric could have helped.  We can also later consider running e2e tests against a stripe account in testMode (instead of mocks)