### PR TITLE
fix: make website e2e tests more reliable on ci

### DIFF
--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -30,6 +30,11 @@ on:
         required: true
         type: boolean
         default: true
+      force_release:
+        description: Whether to run the release job no matter what
+        required: true
+        type: boolean
+        default: false
 
 jobs:
   test:
@@ -252,7 +257,7 @@ jobs:
           changelog-types: '[{"type":"feat","section":"Features","hidden":false},{"type":"fix","section":"Bug Fixes","hidden":false},{"type":"chore","section":"Other Changes","hidden":false}]'
 
   release:
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main' && needs.changelog.outputs.releases_created
+    if: (github.event_name == 'push' && github.ref == 'refs/heads/main' && needs.changelog.outputs.releases_created) || inputs.force_release
     name: Release
     runs-on: ubuntu-latest
     needs:

--- a/packages/website/lib/countly.js
+++ b/packages/website/lib/countly.js
@@ -64,6 +64,9 @@ export function init() {
     return;
   }
 
+  // dont load on localhost
+  if (document.location.origin.match(/\/\/localhost(\W|$)/)) { return }
+
   countly.init({ app_key: config.key, url: config.url, debug: false });
 
   countly.track_sessions();

--- a/packages/website/rawJsFromFile.js
+++ b/packages/website/rawJsFromFile.js
@@ -6,6 +6,8 @@ var $buoop = {
   api: 2022.03,
 };
 function $buo_f() {
+  // dont load on localhost
+  if (document.location.origin.match(/\/\/localhost(\W|$)/)) { return }
   var e = document.createElement('script');
   e.src = '//browser-update.org/update.min.js';
   document.body.appendChild(e);

--- a/packages/website/tests/accountPayment.e2e.spec.ts
+++ b/packages/website/tests/accountPayment.e2e.spec.ts
@@ -6,7 +6,7 @@ import { E2EScreenshotPath } from './screenshots';
 const MAGIC_SUCCESS_EMAIL = 'test+success@magic.link';
 
 test.beforeEach(async ({ page }) => {
-  await page.goto('/');
+  await page.goto('/', { waitUntil: 'commit' });
 });
 
 test.describe('/account/payment', () => {


### PR DESCRIPTION
Motivation
* e2e tests often hang while the orchestrated web browser is waiting for requests to 'cdn.amplitude.com' or 'browser-update.org'. Sometimes these requests take a long time (the only reason I can think of is maybe the e2e orchestrated browser has a very fresh cache or something). I don't think we need to load those scripts when running the app on `localhost` (e.g. in tests), so this PR disables them. I think it will lead to more reliable CI at no real cost.
* I think the website ci workflow 'release' step never ran after this merge https://github.com/web3-storage/web3.storage/pull/1866
  * I think because the e2e tests timed out, so the 'release' job never ran.
  * Hopefully this PR fixes the e2e test time out. But I also added a workflow input we can use to re-trigger the release step manually