### PR TITLE
fix: make browser update versions absolute

### DIFF
--- a/packages/website/rawJsFromFile.js
+++ b/packages/website/rawJsFromFile.js
@@ -1,6 +1,10 @@
 // browser update library
+// https://browser-update.org/#install (this file's naming convention from buoop)
+
 var $buoop = {
-  required: { e: -2, f: -2, o: -2, s: -1, c: -2 },
+  // sets which version of each browser acts as the threshold for the outdated
+  // browser message to be shown (e is IE/Edge, f is Firefox, o is Opera, etc.)
+  required: { e: 11, f: 95, o: 80, s: 10, c: 96 },
   insecure: true,
   unsupported: true,
   api: 2022.03,


### PR DESCRIPTION
The [browser update library](https://browser-update.org/), which was added in #1080 to address Internet Explorer related QA issues, was set to relative browser versions (e.g., Firefox was set to _two major version ago_). 

This created an issue where browsers that were still modern but slightly out-of-date would prompt the dialog box telling the user to update their browser.

This PR adjusts to absolute versions for the browser update library instead of the relative format. The following were set as thresholds for the dialog box to appear:

- IE/Edge < 11
- Firefox < 95
- Opera < 80
- Safari < 10
- Chrome < 96