### PR TITLE
feat: `w3 open <cid>` to open cid on w3s.link in browser

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8475,7 +8475,6 @@
     },
     "node_modules/define-lazy-prop": {
       "version": "2.0.0",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -12342,7 +12341,6 @@
     },
     "node_modules/is-docker": {
       "version": "2.2.1",
-      "dev": true,
       "license": "MIT",
       "bin": {
         "is-docker": "cli.js"
@@ -12705,7 +12703,6 @@
     },
     "node_modules/is-wsl": {
       "version": "2.2.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-docker": "^2.0.0"
@@ -17355,8 +17352,8 @@
     },
     "node_modules/open": {
       "version": "8.4.0",
-      "dev": true,
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/open/-/open-8.4.0.tgz",
+      "integrity": "sha512-XgFPPM+B28FtCCgSb9I+s9szOC1vZRSwgWsRUA5ylIxRTgKozqjOCrVOqGsYABPYK5qnfqClxZTFBa8PKt2v6Q==",
       "dependencies": {
         "define-lazy-prop": "^2.0.0",
         "is-docker": "^2.1.1",
@@ -23807,7 +23804,7 @@
     },
     "packages/api": {
       "name": "@web3-storage/api",
-      "version": "7.4.1",
+      "version": "7.5.1",
       "license": "(Apache-2.0 OR MIT)",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.53.1",
@@ -24846,7 +24843,7 @@
     },
     "packages/cron": {
       "name": "@web3-storage/cron",
-      "version": "1.5.7",
+      "version": "1.6.0",
       "license": "(Apache-2.0 OR MIT)",
       "dependencies": {
         "@nftstorage/ipfs-cluster": "^5.0.1",
@@ -25536,6 +25533,7 @@
         "enquirer": "^2.3.6",
         "hard-rejection": "^2.1.0",
         "ipfs-car": "^0.7.0",
+        "open": "^8.4.0",
         "ora": "^5.4.1",
         "sade": "^1.7.4",
         "uint8arrays": "^3.0.0",
@@ -26462,7 +26460,7 @@
     },
     "packages/website": {
       "name": "@web3-storage/website",
-      "version": "2.17.1",
+      "version": "2.19.1",
       "dependencies": {
         "@docsearch/react": "^3.0.0",
         "@fortawesome/free-brands-svg-icons": "^6.1.2",
@@ -36913,6 +36911,7 @@
         "hard-rejection": "^2.1.0",
         "ipfs-car": "^0.7.0",
         "mocha": "^8.3.2",
+        "open": "*",
         "ora": "^5.4.1",
         "sade": "^1.7.4",
         "uint8arrays": "^3.0.0",
@@ -43545,8 +43544,7 @@
       }
     },
     "define-lazy-prop": {
-      "version": "2.0.0",
-      "dev": true
+      "version": "2.0.0"
     },
     "define-properties": {
       "version": "1.1.3",
@@ -46070,8 +46068,7 @@
       "dev": true
     },
     "is-docker": {
-      "version": "2.2.1",
-      "dev": true
+      "version": "2.2.1"
     },
     "is-electron": {
       "version": "2.2.1"
@@ -46251,7 +46248,6 @@
     },
     "is-wsl": {
       "version": "2.2.0",
-      "dev": true,
       "requires": {
         "is-docker": "^2.0.0"
       }
@@ -49097,7 +49093,8 @@
     },
     "open": {
       "version": "8.4.0",
-      "dev": true,
+      "resolved": "https://registry.npmjs.org/open/-/open-8.4.0.tgz",
+      "integrity": "sha512-XgFPPM+B28FtCCgSb9I+s9szOC1vZRSwgWsRUA5ylIxRTgKozqjOCrVOqGsYABPYK5qnfqClxZTFBa8PKt2v6Q==",
       "requires": {
         "define-lazy-prop": "^2.0.0",
         "is-docker": "^2.1.1",

--- a/packages/w3/README.md
+++ b/packages/w3/README.md
@@ -36,6 +36,18 @@ Upload a [CAR](https://ipld.io/specs/transport/car/carv1/) file to web3.storage.
 - `-n, --name` Name to identify the upload
 - `--no-retry` Don't try the upload again if it fails
 
+### `w3 open <cid>`
+
+Open a CID on https://w3s.link in your browser. You can also pass a CID and a path.
+
+```bash
+# opens a browser to https://w3s.link/ipfs/bafybeidluj5ub7okodgg5v6l4x3nytpivvcouuxgzuioa6vodg3xt2uqle
+w3 open bafybeidluj5ub7okodgg5v6l4x3nytpivvcouuxgzuioa6vodg3xt2uqle
+
+# opens a browser to https://w3s.link/ipfs/bafybeidluj5ub7okodgg5v6l4x3nytpivvcouuxgzuioa6vodg3xt2uqle/olizilla.png
+w3 open bafybeidluj5ub7okodgg5v6l4x3nytpivvcouuxgzuioa6vodg3xt2uqle/olizilla.png
+```
+
 ### `w3 get <cid>`
 
 Fetch files by CID. They are verified on your machine to ensure you got the eact bytes for the given CID.

--- a/packages/w3/bin.js
+++ b/packages/w3/bin.js
@@ -2,6 +2,7 @@
 
 import 'hard-rejection/register.js' // throw on unhandled promise rejection in node 14.
 import sade from 'sade'
+import open from 'open'
 import { get, list, put, putCar, status, token } from './index.js'
 import * as Name from './name.js'
 import { getPkg } from './lib.js'
@@ -39,6 +40,10 @@ cli.command('list')
   .option('--cid', 'Only print the root CID per upload')
   .alias(['ls'])
   .action(list)
+
+cli.command('open <cid>')
+  .describe('open CID on https://w3s.link')
+  .action(cid => open(`https://w3s.link/ipfs/${cid}`))
 
 cli.command('get <cid>')
   .describe('Fetch and verify files from web3.storage')

--- a/packages/w3/package.json
+++ b/packages/w3/package.json
@@ -28,6 +28,7 @@
     "enquirer": "^2.3.6",
     "hard-rejection": "^2.1.0",
     "ipfs-car": "^0.7.0",
+    "open": "^8.4.0",
     "ora": "^5.4.1",
     "sade": "^1.7.4",
     "uint8arrays": "^3.0.0",


### PR DESCRIPTION
I find myself having to add the https://w3s.link/ipfs prefix a lot. I want a command to do it for me.

```bash
# view <cid> in default browser
w3 open bafybeidluj5ub7okodgg5v6l4x3nytpivvcouuxgzuioa6vodg3xt2uqle

# works with paths too
w3 open bafybeidluj5ub7okodgg5v6l4x3nytpivvcouuxgzuioa6vodg3xt2uqle/olizilla.png
```

License: MIT
Signed-off-by: Oli Evans <oli@protocol.ai>