### PR TITLE
fix: db index upload type

### DIFF
--- a/packages/db/postgres/migrations/024-add-index-upload-type.sql
+++ b/packages/db/postgres/migrations/024-add-index-upload-type.sql
@@ -1,0 +1,1 @@
+CREATE INDEX CONCURRENTLY IF NOT EXISTS upload_type_idx ON upload (type);

--- a/packages/db/postgres/tables.sql
+++ b/packages/db/postgres/tables.sql
@@ -269,6 +269,7 @@ CREATE INDEX IF NOT EXISTS upload_auth_key_id_idx ON upload (auth_key_id);
 CREATE INDEX IF NOT EXISTS upload_user_id_deleted_at_idx ON upload (user_id) WHERE deleted_at IS NULL;
 CREATE INDEX IF NOT EXISTS upload_content_cid_idx ON upload (content_cid);
 CREATE INDEX IF NOT EXISTS upload_name_idx ON upload (name);
+CREATE INDEX IF NOT EXISTS upload_type_idx ON upload (type);
 CREATE INDEX IF NOT EXISTS upload_inserted_at_idx ON upload (inserted_at);
 CREATE INDEX IF NOT EXISTS upload_updated_at_idx ON upload (updated_at);
 CREATE INDEX IF NOT EXISTS upload_source_cid_idx ON upload (source_cid);


### PR DESCRIPTION
We compute metrics in cron metrics based on upload type. As our upload table is getting bigger and bigger, this has become an issue. Adding an index for type to enable fast queries using that row