### PR TITLE
feat: send timing info to logtail. Time r2 & s3.

### DIFF
--- a/packages/api/src/car.js
+++ b/packages/api/src/car.js
@@ -292,7 +292,7 @@ async function putToS3 (env, key, carBytes, carCid, rootCid, structure = 'Unknow
     Bucket: env.S3_BUCKET_NAME,
     Key: key,
     Body: carBytes,
-    Metadata: { 
+    Metadata: {
       structure,
       rootCid,
       carCid: carCid.toString()
@@ -341,17 +341,6 @@ export async function putToR2 (env, key, carBytes, carCid, rootCid, structure = 
   } finally {
     env.log.timeEnd('putToR2')
   }
-}
-
-/**
- * Get the md5 of the bytes
- * @param {Uint8Array} bytes
- * @returns {Promise<Uint8Array>} the md5 hash of the input
- */
-export async function md5Digest (bytes) {
-  const hasher = new Md5()
-  hasher.update(bytes)
-  return hasher.digest()
 }
 
 /**

--- a/packages/api/src/car.js
+++ b/packages/api/src/car.js
@@ -281,6 +281,7 @@ async function pinToCluster (cid, env) {
  * @param {import('linkdex').DagStructure} structure The known structural completeness of a given DAG.
  */
 async function putToS3 (env, key, carBytes, carCid, rootCid, structure = 'Unknown') {
+  env.log.time('putToS3')
   // aws doesn't understand multihashes yet, so we given them the unprefixed sha256 digest.
   // aws will compute the sha256 of the bytes they receive, and the put fails if they don't match.
   // see: https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutObject.html#AmazonS3-PutObject-request-header-ChecksumSHA256
@@ -302,6 +303,8 @@ async function putToS3 (env, key, carBytes, carCid, rootCid, structure = 'Unknow
     return await pRetry(() => env.s3Client.send(new PutObjectCommand(cmdParams)), { retries: 3 })
   } catch (cause) {
     throw new Error('Failed to upload CAR to S3', { cause })
+  } finally {
+    env.log.timeEnd('putToS3')
   }
 }
 
@@ -320,6 +323,7 @@ async function putToS3 (env, key, carBytes, carCid, rootCid, structure = 'Unknow
  * @param {import('linkdex').DagStructure} structure
  */
 export async function putToR2 (env, key, carBytes, carCid, rootCid, structure = 'Unknown') {
+  env.log.time('putToR2')
   /** @type R2PutOptions */
   const opts = {
     sha256: toString(carCid.multihash.digest, 'base64pad'), // put fails if not match
@@ -334,6 +338,8 @@ export async function putToR2 (env, key, carBytes, carCid, rootCid, structure = 
     return await pRetry(async () => env.CARPARK.put(key, carBytes, opts), { retries: 3 })
   } catch (cause) {
     throw new Error('Failed to upload CAR to R2', { cause })
+  } finally {
+    env.log.timeEnd('putToR2')
   }
 }
 

--- a/packages/api/src/utils/logs.js
+++ b/packages/api/src/utils/logs.js
@@ -37,6 +37,8 @@ export class Logging {
     this.opts = opts
     this.sendToSentry = sendToSentry
     this.sendToLogtail = sendToLogtail
+    /** @typedef {{ name: string, description?: string, start: number, end?: number, duration?: number, value?: number }} Timer */
+    /** @type {Map<string, Timer>} */
     this._times = new Map()
     /**
      * @type {string[]}
@@ -179,6 +181,7 @@ export class Logging {
         level: 'info',
         metadata: {
           ...this.metadata,
+          timers: this._timersMetadata(),
           response: {
             headers: buildMetadataFromHeaders(response.headers),
             status_code: response.status,
@@ -320,6 +323,7 @@ export class Logging {
   _timersString () {
     const result = []
     for (const key of this._timesOrder) {
+      // @ts-expect-error
       const { name, duration, description } = this._times.get(key)
       result.push(
         description
@@ -329,5 +333,16 @@ export class Logging {
     }
 
     return result.join(',')
+  }
+
+  _timersMetadata () {
+    /** @type {Record<string, number>} */
+    const result = {}
+    for (const val of this._times.values()) {
+      if (val.duration !== undefined) {
+        result[val.name] = val.duration
+      }
+    }
+    return result
   }
 }


### PR DESCRIPTION
- add timers for `putToR2` and `putToS3`
- tweak logger to send the timers as metadata to logtail so we may chart it.
- fix tsc errors in log.js

This updates the final request log we send to logtail to include a `timers` property, with a key for each timer name and it's duration in `ms`.

```js
{
  message: '',
  dt: '2022-09-20T14:02:42.960Z',
  level: 'info',
  metadata: {
    user: { id: '1' },
    request: {
      url: 'http://127.0.0.1:8787/car',
      method: 'POST',
      headers: [Object],
      cf: [Object]
    },
    cloudflare_worker: {
      version: '7.5.1',
      commit: 'eae75d2366d59b0cf16143723a5af6513d891f9e',
      branch: 'main',
      worker_id: 'krXpoggAwV',
      worker_started: 1663682561602
    },
    timers: { putToR2: 237, putToS3: 464, request: 494 },
    response: { headers: [Object], status_code: 200, duration: 494 }
  }
}
```

License: MIT
Signed-off-by: Oli Evans <oli@protocol.ai>