### PR TITLE
feat: use sha256 checksum for r2.put

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23920,7 +23920,6 @@
       "license": "(Apache-2.0 OR MIT)",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.53.1",
-        "@aws-sdk/md5-js": "^3.171.0",
         "@cfworker/json-schema": "^1.8.3",
         "@google-cloud/precise-date": "^2.0.4",
         "@ipld/car": "^3.1.4",
@@ -23967,68 +23966,6 @@
         "stream-browserify": "^3.0.0",
         "toucan-js": "^2.4.1",
         "websocket": "^1.0.34"
-      }
-    },
-    "packages/api/node_modules/@aws-sdk/is-array-buffer": {
-      "version": "3.170.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.170.0.tgz",
-      "integrity": "sha512-yYXqgp8rilBckIvNRs22yAXHKcXb86/g+F+hsTZl38OJintTsLQB//O5v6EQTYhSW7T3wMe1NHDrjZ+hFjAy4Q==",
-      "dependencies": {
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">= 12.0.0"
-      }
-    },
-    "packages/api/node_modules/@aws-sdk/md5-js": {
-      "version": "3.171.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/md5-js/-/md5-js-3.171.0.tgz",
-      "integrity": "sha512-ZHuK7NvRY44WasjRjHnTNTGfdWuZTND4CCRC78Fmf3tk+zeCEnDZ81cVVtMqVn1wIf02U35Bwbunfx8i89VoSg==",
-      "dependencies": {
-        "@aws-sdk/types": "3.171.0",
-        "@aws-sdk/util-utf8-browser": "3.170.0",
-        "@aws-sdk/util-utf8-node": "3.170.0",
-        "tslib": "^2.3.1"
-      }
-    },
-    "packages/api/node_modules/@aws-sdk/types": {
-      "version": "3.171.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.171.0.tgz",
-      "integrity": "sha512-Yv5Wn/pbjMBST2jPHWPczmVbOLq8yFQVRyy1zGfsg1ETn25nGPvGBwqOkWcuz229KAcdUvFdRV9xaQCN3Lbo+Q==",
-      "engines": {
-        "node": ">= 12.0.0"
-      }
-    },
-    "packages/api/node_modules/@aws-sdk/util-buffer-from": {
-      "version": "3.170.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-buffer-from/-/util-buffer-from-3.170.0.tgz",
-      "integrity": "sha512-3ClE3wgN/Zw0ahfVAY5KQ/y3K2c+SYHwVUQaGSuVQlPOCDInGYjE/XEFwCeGJzncRPHIKDRPEsHCpm1uwgwEqQ==",
-      "dependencies": {
-        "@aws-sdk/is-array-buffer": "3.170.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">= 12.0.0"
-      }
-    },
-    "packages/api/node_modules/@aws-sdk/util-utf8-browser": {
-      "version": "3.170.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.170.0.tgz",
-      "integrity": "sha512-tJby9krepSwDsBK+KQF5ACacZQ4LH1Aheh5Dy0pghxsN/9IRw7kMWTumuRCnSntLFFphDD7GM494/Dvnl1UCLA==",
-      "dependencies": {
-        "tslib": "^2.3.1"
-      }
-    },
-    "packages/api/node_modules/@aws-sdk/util-utf8-node": {
-      "version": "3.170.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-node/-/util-utf8-node-3.170.0.tgz",
-      "integrity": "sha512-52QWGNoNQoyT2CuoQz6LjBKxHQtN/ceMFLW+9J1E0I1ni8XTuTYP52BlMe5484KkmZKsHOm+EWe4xuwwVetTxg==",
-      "dependencies": {
-        "@aws-sdk/util-buffer-from": "3.170.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">= 12.0.0"
       }
     },
     "packages/api/node_modules/@magic-ext/oauth": {
@@ -25011,7 +24948,7 @@
     },
     "packages/cron": {
       "name": "@web3-storage/cron",
-      "version": "1.6.0",
+      "version": "1.6.1",
       "license": "(Apache-2.0 OR MIT)",
       "dependencies": {
         "@nftstorage/ipfs-cluster": "^5.0.1",
@@ -25693,7 +25630,7 @@
     },
     "packages/w3": {
       "name": "@web3-storage/w3",
-      "version": "2.6.1",
+      "version": "2.7.0",
       "license": "(Apache-2.0 OR MIT)",
       "dependencies": {
         "@ipld/car": "^3.1.16",
@@ -36289,7 +36226,6 @@
       "version": "file:packages/api",
       "requires": {
         "@aws-sdk/client-s3": "^3.53.1",
-        "@aws-sdk/md5-js": "*",
         "@cfworker/json-schema": "^1.8.3",
         "@cloudflare/workers-types": "^3.16.0",
         "@esbuild-plugins/node-modules-polyfill": "^0.1.4",
@@ -36336,56 +36272,6 @@
         "websocket": "^1.0.34"
       },
       "dependencies": {
-        "@aws-sdk/is-array-buffer": {
-          "version": "3.170.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.170.0.tgz",
-          "integrity": "sha512-yYXqgp8rilBckIvNRs22yAXHKcXb86/g+F+hsTZl38OJintTsLQB//O5v6EQTYhSW7T3wMe1NHDrjZ+hFjAy4Q==",
-          "requires": {
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/md5-js": {
-          "version": "3.171.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/md5-js/-/md5-js-3.171.0.tgz",
-          "integrity": "sha512-ZHuK7NvRY44WasjRjHnTNTGfdWuZTND4CCRC78Fmf3tk+zeCEnDZ81cVVtMqVn1wIf02U35Bwbunfx8i89VoSg==",
-          "requires": {
-            "@aws-sdk/types": "3.171.0",
-            "@aws-sdk/util-utf8-browser": "3.170.0",
-            "@aws-sdk/util-utf8-node": "3.170.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/types": {
-          "version": "3.171.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.171.0.tgz",
-          "integrity": "sha512-Yv5Wn/pbjMBST2jPHWPczmVbOLq8yFQVRyy1zGfsg1ETn25nGPvGBwqOkWcuz229KAcdUvFdRV9xaQCN3Lbo+Q=="
-        },
-        "@aws-sdk/util-buffer-from": {
-          "version": "3.170.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/util-buffer-from/-/util-buffer-from-3.170.0.tgz",
-          "integrity": "sha512-3ClE3wgN/Zw0ahfVAY5KQ/y3K2c+SYHwVUQaGSuVQlPOCDInGYjE/XEFwCeGJzncRPHIKDRPEsHCpm1uwgwEqQ==",
-          "requires": {
-            "@aws-sdk/is-array-buffer": "3.170.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/util-utf8-browser": {
-          "version": "3.170.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.170.0.tgz",
-          "integrity": "sha512-tJby9krepSwDsBK+KQF5ACacZQ4LH1Aheh5Dy0pghxsN/9IRw7kMWTumuRCnSntLFFphDD7GM494/Dvnl1UCLA==",
-          "requires": {
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/util-utf8-node": {
-          "version": "3.170.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-node/-/util-utf8-node-3.170.0.tgz",
-          "integrity": "sha512-52QWGNoNQoyT2CuoQz6LjBKxHQtN/ceMFLW+9J1E0I1ni8XTuTYP52BlMe5484KkmZKsHOm+EWe4xuwwVetTxg==",
-          "requires": {
-            "@aws-sdk/util-buffer-from": "3.170.0",
-            "tslib": "^2.3.1"
-          }
-        },
         "@magic-ext/oauth": {
           "version": "0.8.0",
           "requires": {

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -61,7 +61,6 @@
   },
   "dependencies": {
     "@aws-sdk/client-s3": "^3.53.1",
-    "@aws-sdk/md5-js": "^3.171.0",
     "@cfworker/json-schema": "^1.8.3",
     "@google-cloud/precise-date": "^2.0.4",
     "@ipld/car": "^3.1.4",

--- a/packages/api/src/car.js
+++ b/packages/api/src/car.js
@@ -6,7 +6,6 @@ import { toString, equals } from 'uint8arrays'
 import { LinkIndexer } from 'linkdex'
 import { maybeDecode } from 'linkdex/decode'
 import { CID } from 'multiformats/cid'
-import { Md5 } from '@aws-sdk/md5-js'
 import { sha256 } from 'multiformats/hashes/sha2'
 import * as raw from 'multiformats/codecs/raw'
 import * as pb from '@ipld/dag-pb'
@@ -122,8 +121,8 @@ export async function handleCarUpload (request, env, ctx, car, uploadType = 'Car
   const r2Key = `${carCid}/${carCid}.car`
 
   await Promise.all([
-    putToS3(env.s3Client, env.s3BucketName, s3Key, carBytes, carCid, structure),
-    putToR2(env.CARPARK, r2Key, carBytes, sourceCid, structure)
+    putToS3(env, s3Key, carBytes, carCid, sourceCid, structure),
+    putToR2(env, r2Key, carBytes, carCid, sourceCid, structure)
   ])
 
   const xName = headers.get('x-name')
@@ -274,14 +273,14 @@ async function pinToCluster (cid, env) {
 /**
  * Upload given CAR file to S3
  *
- * @param {import('@aws-sdk/client-s3').S3Client} s3
- * @param {string} bucket
+ * @param {import('./env').Env} env
  * @param {string} key
  * @param {Uint8Array} carBytes
  * @param {CID} carCid
+ * @param {string} rootCid
  * @param {import('linkdex').DagStructure} structure The known structural completeness of a given DAG.
  */
-async function putToS3 (s3, bucket, key, carBytes, carCid, structure = 'Unknown') {
+async function putToS3 (env, key, carBytes, carCid, rootCid, structure = 'Unknown') {
   // aws doesn't understand multihashes yet, so we given them the unprefixed sha256 digest.
   // aws will compute the sha256 of the bytes they receive, and the put fails if they don't match.
   // see: https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutObject.html#AmazonS3-PutObject-request-header-ChecksumSHA256
@@ -289,14 +288,18 @@ async function putToS3 (s3, bucket, key, carBytes, carCid, structure = 'Unknown'
 
   /** @type import('@aws-sdk/client-s3').PutObjectCommandInput */
   const cmdParams = {
-    Bucket: bucket,
+    Bucket: env.S3_BUCKET_NAME,
     Key: key,
     Body: carBytes,
-    Metadata: { structure },
+    Metadata: { 
+      structure,
+      rootCid,
+      carCid: carCid.toString()
+    },
     ChecksumSHA256: carSha256
   }
   try {
-    return await pRetry(() => s3.send(new PutObjectCommand(cmdParams)), { retries: 3 })
+    return await pRetry(() => env.s3Client.send(new PutObjectCommand(cmdParams)), { retries: 3 })
   } catch (cause) {
     throw new Error('Failed to upload CAR to S3', { cause })
   }
@@ -309,26 +312,26 @@ async function putToS3 (s3, bucket, key, carBytes, carCid, structure = 'Unknown'
  *
  * see: https://developers.cloudflare.com/r2/platform/s3-compatibility/api/#implemented-object-level-operations
  *
- * @param {R2Bucket} bucket
+ * @param {import('./env').Env} env
  * @param {string} key
  * @param {Uint8Array} carBytes
+ * @param {CID} carCid
  * @param {string} rootCid
  * @param {import('linkdex').DagStructure} structure
  */
-export async function putToR2 (bucket, key, carBytes, rootCid, structure = 'Unknown') {
-  const md5 = toString(await md5Digest(carBytes), 'base16')
+export async function putToR2 (env, key, carBytes, carCid, rootCid, structure = 'Unknown') {
   /** @type R2PutOptions */
   const opts = {
-    md5, // put fails if not match
+    sha256: toString(carCid.multihash.digest, 'base64pad'), // put fails if not match
     customMetadata: {
       structure,
       rootCid,
-      md5 // stash on metadata as well so we can find the value used to verify this CAR in the future
+      carCid: carCid.toString()
     }
   }
   try {
     // assuming mostly unique cars, but could check for existence here before writing.
-    return await pRetry(async () => bucket.put(key, carBytes, opts), { retries: 3 })
+    return await pRetry(async () => env.CARPARK.put(key, carBytes, opts), { retries: 3 })
   } catch (cause) {
     throw new Error('Failed to upload CAR to R2', { cause })
   }


### PR DESCRIPTION
it's hot off the press but _some nice folks in a discord_ **assure** me that `sha256` checksum verification is available for `r2.put`

<img width="729" alt="Screenshot 2022-09-20 at 16 07 42" src="https://user-images.githubusercontent.com/58871/191298942-d039d036-1bb0-443f-8fbf-4c6c0a8f7cbd.png">


- remove md5 dep and use sha256 from carCid as we do for putToS3.
- tweak method signatures to take the env, so they can be pleasingly symetrical.
- capture the `rootCid` and `carCid` in the metadata so when we want to make object keys the same across s3&r2 at least we'll have both hashes in the meta, regardless of the key structure. 

see: https://community.cloudflare.com/t/2022-9-16-workers-runtime-release-notes/420496 see: https://discord.com/channels/595317990191398933/940663374377783388/1021788854388281477

License: MIT
Signed-off-by: Oli Evans <oli@protocol.ai>