### PR TITLE
chore: encode sha256 hash as hex for r2 put

### DIFF
--- a/packages/api/src/car.js
+++ b/packages/api/src/car.js
@@ -322,7 +322,7 @@ async function putToS3 (env, key, carBytes, carCid, rootCid, structure = 'Unknow
 export async function putToR2 (env, key, carBytes, carCid, rootCid, structure = 'Unknown') {
   /** @type R2PutOptions */
   const opts = {
-    sha256: toString(carCid.multihash.digest, 'base64pad'), // put fails if not match
+    sha256: toString(carCid.multihash.digest, 'base16'), // put fails if hash not match
     customMetadata: {
       structure,
       rootCid,


### PR DESCRIPTION
The `sha256` string we pass to `r2.put` should be hex.

tested on staging. it work.

License: MIT
Signed-off-by: Oli Evans <oli@protocol.ai>