### PR TITLE
ci: website.yml release step requires needs.changelog.outputs.pr (not…

### DIFF
--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -257,7 +257,7 @@ jobs:
           changelog-types: '[{"type":"feat","section":"Features","hidden":false},{"type":"fix","section":"Bug Fixes","hidden":false},{"type":"chore","section":"Other Changes","hidden":false}]'
 
   release:
-    if: (github.event_name == 'push' && github.ref == 'refs/heads/main' && needs.changelog.outputs.releases_created) || inputs.force_release
+    if: (github.event_name == 'push' && github.ref == 'refs/heads/main' && needs.changelog.outputs.pr) || inputs.force_release
     name: Release
     runs-on: ubuntu-latest
     needs:


### PR DESCRIPTION
… release_created)

this way it works when the pr already existed, so it didn't need to be created...

Motivation
* This workflow from main branch didn't deploy the website as I expected it to https://github.com/web3-storage/web3.storage/actions/runs/3100027094/jobs/5019843710

Relevant
* https://github.com/google-github-actions/release-please-action/blob/main/index.js#L65