### PR TITLE
chore: report error cause to sentry

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5575,6 +5575,99 @@
       "resolved": "packages/tools",
       "link": true
     },
+    "node_modules/@web3-storage/toucan-js": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/@web3-storage/toucan-js/-/toucan-js-2.7.1.tgz",
+      "integrity": "sha512-vLY985tJtc/jJvx43Xe+G6j0jpmO9W4rlsaa+etFLF9XWyqphXQ3hh6PyxFSsNtPrzyfRyIjGQRJN//xhUamew==",
+      "dependencies": {
+        "@sentry/core": "6.19.6",
+        "@sentry/hub": "6.19.6",
+        "@sentry/types": "6.19.6",
+        "@sentry/utils": "6.19.6",
+        "@types/cookie": "0.5.0",
+        "cookie": "0.5.0",
+        "stacktrace-js": "2.0.2"
+      }
+    },
+    "node_modules/@web3-storage/toucan-js/node_modules/@sentry/core": {
+      "version": "6.19.6",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-6.19.6.tgz",
+      "integrity": "sha512-biEotGRr44/vBCOegkTfC9rwqaqRKIpFljKGyYU6/NtzMRooktqOhjmjmItNCMRknArdeaQwA8lk2jcZDXX3Og==",
+      "dependencies": {
+        "@sentry/hub": "6.19.6",
+        "@sentry/minimal": "6.19.6",
+        "@sentry/types": "6.19.6",
+        "@sentry/utils": "6.19.6",
+        "tslib": "^1.9.3"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@web3-storage/toucan-js/node_modules/@sentry/hub": {
+      "version": "6.19.6",
+      "resolved": "https://registry.npmjs.org/@sentry/hub/-/hub-6.19.6.tgz",
+      "integrity": "sha512-PuEOBZxvx3bjxcXmWWZfWXG+orojQiWzv9LQXjIgroVMKM/GG4QtZbnWl1hOckUj7WtKNl4hEGO2g/6PyCV/vA==",
+      "dependencies": {
+        "@sentry/types": "6.19.6",
+        "@sentry/utils": "6.19.6",
+        "tslib": "^1.9.3"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@web3-storage/toucan-js/node_modules/@sentry/minimal": {
+      "version": "6.19.6",
+      "resolved": "https://registry.npmjs.org/@sentry/minimal/-/minimal-6.19.6.tgz",
+      "integrity": "sha512-T1NKcv+HTlmd8EbzUgnGPl4ySQGHWMCyZ8a8kXVMZOPDzphN3fVIzkYzWmSftCWp0rpabXPt9aRF2mfBKU+mAQ==",
+      "dependencies": {
+        "@sentry/hub": "6.19.6",
+        "@sentry/types": "6.19.6",
+        "tslib": "^1.9.3"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@web3-storage/toucan-js/node_modules/@sentry/types": {
+      "version": "6.19.6",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-6.19.6.tgz",
+      "integrity": "sha512-QH34LMJidEUPZK78l+Frt3AaVFJhEmIi05Zf8WHd9/iTt+OqvCHBgq49DDr1FWFqyYWm/QgW/3bIoikFpfsXyQ==",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@web3-storage/toucan-js/node_modules/@sentry/utils": {
+      "version": "6.19.6",
+      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-6.19.6.tgz",
+      "integrity": "sha512-fAMWcsguL0632eWrROp/vhPgI7sBj/JROWVPzpabwVkm9z3m1rQm6iLFn4qfkZL8Ozy6NVZPXOQ7EXmeU24byg==",
+      "dependencies": {
+        "@sentry/types": "6.19.6",
+        "tslib": "^1.9.3"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@web3-storage/toucan-js/node_modules/@types/cookie": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.5.0.tgz",
+      "integrity": "sha512-CJWHVHHupxBYfIlMM+qzXx4dRKIV1VzOm0cP3Wpqten8MDx1tK+y92YDXUshN1ONAfwodvKxDNkw35/pNs+izg=="
+    },
+    "node_modules/@web3-storage/toucan-js/node_modules/cookie": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.5.0.tgz",
+      "integrity": "sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/@web3-storage/toucan-js/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+    },
     "node_modules/@web3-storage/w3": {
       "resolved": "packages/w3",
       "link": true
@@ -9243,7 +9336,6 @@
     },
     "node_modules/error-stack-parser": {
       "version": "2.0.6",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "stackframe": "^1.1.1"
@@ -21081,7 +21173,6 @@
     },
     "node_modules/stack-generator": {
       "version": "2.0.5",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "stackframe": "^1.1.1"
@@ -21117,12 +21208,10 @@
     },
     "node_modules/stackframe": {
       "version": "1.2.0",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/stacktrace-gps": {
       "version": "3.0.4",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "source-map": "0.5.6",
@@ -21131,7 +21220,6 @@
     },
     "node_modules/stacktrace-gps/node_modules/source-map": {
       "version": "0.5.6",
-      "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
@@ -21139,7 +21227,6 @@
     },
     "node_modules/stacktrace-js": {
       "version": "2.0.2",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "error-stack-parser": "^2.0.6",
@@ -23916,7 +24003,7 @@
     },
     "packages/api": {
       "name": "@web3-storage/api",
-      "version": "7.5.1",
+      "version": "7.6.0",
       "license": "(Apache-2.0 OR MIT)",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.53.1",
@@ -23929,6 +24016,7 @@
         "@nftstorage/ipfs-cluster": "^5.0.1",
         "@web3-storage/db": "^4.0.0",
         "@web3-storage/multipart-parser": "^1.0.0",
+        "@web3-storage/toucan-js": "^2.7.1",
         "cborg": "^1.6.0",
         "ipfs-car": "^0.7.0",
         "itty-router": "^2.4.8",
@@ -24594,7 +24682,7 @@
     },
     "packages/client": {
       "name": "web3.storage",
-      "version": "4.4.1",
+      "version": "4.5.0",
       "license": "(Apache-2.0 OR MIT)",
       "dependencies": {
         "@ipld/car": "^3.1.4",
@@ -26565,7 +26653,7 @@
     },
     "packages/website": {
       "name": "@web3-storage/website",
-      "version": "2.19.1",
+      "version": "2.20.1",
       "dependencies": {
         "@docsearch/react": "^3.0.0",
         "@fortawesome/free-brands-svg-icons": "^6.1.2",
@@ -36243,6 +36331,7 @@
         "@web3-storage/db": "^4.0.0",
         "@web3-storage/multipart-parser": "^1.0.0",
         "@web3-storage/tools": "^1.0.0",
+        "@web3-storage/toucan-js": "*",
         "assert": "^2.0.0",
         "buffer": "^6.0.3",
         "cborg": "^1.6.0",
@@ -37092,6 +37181,83 @@
               "dev": true
             }
           }
+        }
+      }
+    },
+    "@web3-storage/toucan-js": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/@web3-storage/toucan-js/-/toucan-js-2.7.1.tgz",
+      "integrity": "sha512-vLY985tJtc/jJvx43Xe+G6j0jpmO9W4rlsaa+etFLF9XWyqphXQ3hh6PyxFSsNtPrzyfRyIjGQRJN//xhUamew==",
+      "requires": {
+        "@sentry/core": "6.19.6",
+        "@sentry/hub": "6.19.6",
+        "@sentry/types": "6.19.6",
+        "@sentry/utils": "6.19.6",
+        "@types/cookie": "0.5.0",
+        "cookie": "0.5.0",
+        "stacktrace-js": "2.0.2"
+      },
+      "dependencies": {
+        "@sentry/core": {
+          "version": "6.19.6",
+          "resolved": "https://registry.npmjs.org/@sentry/core/-/core-6.19.6.tgz",
+          "integrity": "sha512-biEotGRr44/vBCOegkTfC9rwqaqRKIpFljKGyYU6/NtzMRooktqOhjmjmItNCMRknArdeaQwA8lk2jcZDXX3Og==",
+          "requires": {
+            "@sentry/hub": "6.19.6",
+            "@sentry/minimal": "6.19.6",
+            "@sentry/types": "6.19.6",
+            "@sentry/utils": "6.19.6",
+            "tslib": "^1.9.3"
+          }
+        },
+        "@sentry/hub": {
+          "version": "6.19.6",
+          "resolved": "https://registry.npmjs.org/@sentry/hub/-/hub-6.19.6.tgz",
+          "integrity": "sha512-PuEOBZxvx3bjxcXmWWZfWXG+orojQiWzv9LQXjIgroVMKM/GG4QtZbnWl1hOckUj7WtKNl4hEGO2g/6PyCV/vA==",
+          "requires": {
+            "@sentry/types": "6.19.6",
+            "@sentry/utils": "6.19.6",
+            "tslib": "^1.9.3"
+          }
+        },
+        "@sentry/minimal": {
+          "version": "6.19.6",
+          "resolved": "https://registry.npmjs.org/@sentry/minimal/-/minimal-6.19.6.tgz",
+          "integrity": "sha512-T1NKcv+HTlmd8EbzUgnGPl4ySQGHWMCyZ8a8kXVMZOPDzphN3fVIzkYzWmSftCWp0rpabXPt9aRF2mfBKU+mAQ==",
+          "requires": {
+            "@sentry/hub": "6.19.6",
+            "@sentry/types": "6.19.6",
+            "tslib": "^1.9.3"
+          }
+        },
+        "@sentry/types": {
+          "version": "6.19.6",
+          "resolved": "https://registry.npmjs.org/@sentry/types/-/types-6.19.6.tgz",
+          "integrity": "sha512-QH34LMJidEUPZK78l+Frt3AaVFJhEmIi05Zf8WHd9/iTt+OqvCHBgq49DDr1FWFqyYWm/QgW/3bIoikFpfsXyQ=="
+        },
+        "@sentry/utils": {
+          "version": "6.19.6",
+          "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-6.19.6.tgz",
+          "integrity": "sha512-fAMWcsguL0632eWrROp/vhPgI7sBj/JROWVPzpabwVkm9z3m1rQm6iLFn4qfkZL8Ozy6NVZPXOQ7EXmeU24byg==",
+          "requires": {
+            "@sentry/types": "6.19.6",
+            "tslib": "^1.9.3"
+          }
+        },
+        "@types/cookie": {
+          "version": "0.5.0",
+          "resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.5.0.tgz",
+          "integrity": "sha512-CJWHVHHupxBYfIlMM+qzXx4dRKIV1VzOm0cP3Wpqten8MDx1tK+y92YDXUshN1ONAfwodvKxDNkw35/pNs+izg=="
+        },
+        "cookie": {
+          "version": "0.5.0",
+          "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.5.0.tgz",
+          "integrity": "sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw=="
+        },
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
         }
       }
     },
@@ -44212,7 +44378,6 @@
     },
     "error-stack-parser": {
       "version": "2.0.6",
-      "dev": true,
       "requires": {
         "stackframe": "^1.1.1"
       }
@@ -51562,7 +51727,6 @@
     },
     "stack-generator": {
       "version": "2.0.5",
-      "dev": true,
       "requires": {
         "stackframe": "^1.1.1"
       }
@@ -51587,26 +51751,22 @@
       }
     },
     "stackframe": {
-      "version": "1.2.0",
-      "dev": true
+      "version": "1.2.0"
     },
     "stacktrace-gps": {
       "version": "3.0.4",
-      "dev": true,
       "requires": {
         "source-map": "0.5.6",
         "stackframe": "^1.1.1"
       },
       "dependencies": {
         "source-map": {
-          "version": "0.5.6",
-          "dev": true
+          "version": "0.5.6"
         }
       }
     },
     "stacktrace-js": {
       "version": "2.0.2",
-      "dev": true,
       "requires": {
         "error-stack-parser": "^2.0.6",
         "stack-generator": "^2.0.5",

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -70,6 +70,7 @@
     "@nftstorage/ipfs-cluster": "^5.0.1",
     "@web3-storage/db": "^4.0.0",
     "@web3-storage/multipart-parser": "^1.0.0",
+    "@web3-storage/toucan-js": "^2.7.1",
     "cborg": "^1.6.0",
     "ipfs-car": "^0.7.0",
     "itty-router": "^2.4.8",


### PR DESCRIPTION
adopt our forked toucan-js so we can start reporting error causes to sentry

i've set up a minimal fork over here with our standard release-please publishing flow: https://github.com/web3-storage/toucan-js

the original PR that i want to get deployed is here https://github.com/robertcepa/toucan-js/pull/104

and we've now got that rolled into our own npm package at https://www.npmjs.com/package/@web3-storage/toucan-js

License: MIT
Signed-off-by: Oli Evans <oli@protocol.ai>