### PR TITLE
ci: update api workflow to set production url to web3.storage not api…

### DIFF
--- a/.github/workflows/api.yml
+++ b/.github/workflows/api.yml
@@ -69,7 +69,7 @@ jobs:
     needs: test
     environment:
       name: production
-      url: https://api.web3.storage
+      url: https://web3.storage
     steps:
       - uses: GoogleCloudPlatform/release-please-action@v3
         id: tag-release


### PR DESCRIPTION
….web3.storage

Motivation:
* this is a better URL to set for the 'production' environment.