### PR TITLE
chore: rm stripe.com:fixtures stuff from api workflow, it doesn't work

### DIFF
--- a/.github/workflows/api.yml
+++ b/.github/workflows/api.yml
@@ -58,11 +58,6 @@ jobs:
           npm run build -w packages/client
           echo "$(date --utc --iso-8601=seconds) web3.storage upload test" > ./upload-test-small
           ./packages/w3/bin.js put ./upload-test-small --api https://api-staging.web3.storage --token ${{ secrets.STAGING_WEB3_TOKEN }}
-      - name: put stripe.com fixtures
-        run: npm -w packages/api run stripe.com:fixtures
-        env:
-          STRIPE_API_KEY: ${{ secrets.TESTING_STRIPE_SECRET_KEY }}
-          DEVICE_NAME: "@web3-storage/api/.github/workflows/api.yml"
   release:
     name: Release
     runs-on: ubuntu-latest
@@ -101,9 +96,3 @@ jobs:
           apiToken: ${{ secrets.CF_TOKEN }}
           workingDirectory: 'packages/api'
           environment: 'production'
-      - name: put stripe.com fixtures
-        if: ${{ steps.tag-release.outputs.releases_created }}
-        run: npm -w packages/api run stripe.com:fixtures
-        env:
-          STRIPE_API_KEY: ${{ secrets.STRIPE_SECRET_KEY }}
-          DEVICE_NAME: "@web3-storage/api/.github/workflows/api.yml"


### PR DESCRIPTION
Motivation
* I shouldn't have moved so fast in adding this. It didn't work, and I missed that it didn't work in main, so also release-pleased to prod, and I think now the api workflow will always be broken for api releases, which is gross.
* This ci part isn't critical and I'm on a deadline, so I will improve things later by continuing ci work via [this](https://github.com/web3-storage/web3.storage/pull/1929), but not for a week or two