### PR TITLE
fix: (wip) add custom upsert_user function to distinguish new vs updated

### DIFF
--- a/packages/db/db-client-types.ts
+++ b/packages/db/db-client-types.ts
@@ -16,6 +16,7 @@ export type UpsertUserOutput = {
   id: number
   // whether the upsert inserted a new record (if falsy, it was updated)
   inserted: boolean
+  inserted_at: string
   issuer: string
 }
 

--- a/packages/db/index.js
+++ b/packages/db/index.js
@@ -106,32 +106,24 @@ export class DBClient {
   async upsertUser (user) {
     /** @type {{ data: definitions['user'], error: PostgrestError }} */
     const { data, error } = await this._client
-      .from('user')
-      .upsert(
-        {
-          name: user.name,
-          picture: user.picture,
-          email: user.email,
-          issuer: user.issuer,
-          github: user.github,
-          public_address: user.publicAddress
-        },
-        {
-          onConflict: 'issuer',
-          returning: 'representation'
-        }
-      )
-      .select('id,xmax,issuer')
-      .single()
+      .rpc('upsert_user', {
+        _name: user.name,
+        _picture: user.picture ?? '',
+        _email: user.email,
+        _issuer: user.issuer,
+        _github: user.github ?? '',
+        _public_address: user.publicAddress
+      })
+
+    const userData = data[0]
 
     if (error) {
       throw new DBError(error)
     }
-    const inserted = Boolean(data.xmax === '0')
     return {
-      id: data.id,
-      inserted,
-      issuer: data.issuer
+      id: userData.id,
+      inserted: userData.inserted,
+      issuer: userData.issuer
     }
   }
 

--- a/packages/db/postgres/functions.sql
+++ b/packages/db/postgres/functions.sql
@@ -415,3 +415,37 @@ FROM cargo.aggregate_entries ae
 WHERE ae.cid_v1 = ANY (cids)
 ORDER BY de.entry_last_updated
 $$;
+
+
+-- a custom UPSERT operation for user account, so that we can distinguish between
+-- newly inserted users and updated ones.
+CREATE OR REPLACE FUNCTION upsert_user(_name TEXT, _picture TEXT, _email TEXT, _issuer TEXT, _github TEXT, _public_address TEXT)
+RETURNS TABLE (
+  "id" BIGINT,
+  "issuer" TEXT,
+  "inserted" BOOLEAN
+)
+LANGUAGE plpgsql
+AS
+$$
+#variable_conflict use_column
+DECLARE
+  inserted BOOLEAN;
+
+BEGIN
+  SELECT (COUNT(id) = 0) into inserted FROM public.user WHERE issuer = _issuer;
+
+  RETURN QUERY
+  INSERT INTO public.user AS u (name, picture, email, issuer, github, public_address) 
+  VALUES (_name, _picture, _email, _issuer, _github, _public_address)
+  ON CONFLICT (issuer) DO UPDATE
+  SET 
+    name = EXCLUDED.name,
+    picture = EXCLUDED.picture,
+    email = EXCLUDED.email,
+    github = EXCLUDED.github,
+    public_address = EXCLUDED.public_address
+  RETURNING u.id, u.issuer, inserted;
+
+END
+$$;


### PR DESCRIPTION
This is a start at fixing the issue with the new `inserted` field returned by `upsertUser`.

The current implementation uses `xmax == 0` to mean the row was newly inserted, but this doesn't seem to work in production - all newly created users have a non-zero `xmax` in the DB.

This adds an `upsert_user` PGSQL function that does a `SELECT (COUNT(id) = 0) into inserted FROM public.user WHERE issuer = _issuer;` before doing the `INSERT`, which should set `inserted` to true only if there's no existing row with that `issuer`.

I haven't done extensive testing yet, but it seems to pass the existing `userLoginPost` test that checks whether new users get the free tier.

TODO:
- [ ] add migration sql file
- [ ] explicitly test the `upsert_user` function
