### PR TITLE
fix: trigger release to pick up fix from #1976

### DIFF
--- a/packages/api/src/user.js
+++ b/packages/api/src/user.js
@@ -152,6 +152,7 @@ async function loginOrRegister (request, env) {
     return maintenanceHandler()
   } else if (env.MODE === READ_WRITE) {
     user = await env.db.upsertUser(parsed)
+    // initialize billing, etc, but only if the user was newly inserted
     if (user.inserted) {
       await initializeNewUser(env, { ...user, id: user.id.toString() })
     }


### PR DESCRIPTION
Since #1976 didn't touch any files in the `api` package, it didn't trigger the release-please bot to open a release PR.

This just adds a kind of pointless comment so the change gets picked up.