### PR TITLE
fix: fix bug when saving payment method while paymentSettings.storage.subscription=null

### DIFF
--- a/packages/db/index.js
+++ b/packages/db/index.js
@@ -114,12 +114,10 @@ export class DBClient {
         _github: user.github ?? '',
         _public_address: user.publicAddress
       })
-
-    const userData = data[0]
-
     if (error) {
       throw new DBError(error)
     }
+    const userData = data[0]
     return {
       id: userData.id,
       inserted: userData.inserted,

--- a/packages/website/components/contexts/plansContext.js
+++ b/packages/website/components/contexts/plansContext.js
@@ -1,6 +1,37 @@
+/**
+ * @typedef {'free'|'pro'|'lite'} StoragePrice
+ */
+
+/**
+ * @typedef {object} StorageSubscription
+ * @property {StoragePrice} price
+ */
+
+/**
+ * @typedef {null} EarlyAdopterStorageSubscription
+ * When api's /user/payment .subscription.storage is null, there is no storage subscription.
+ * And that is what we sometimes render as 'Early Adopter'
+ */
+
+/**
+ * @typedef {'earlyAdopter'} EarlyAdopterPlanId
+ */
+
+/**
+ * @typedef {object} Plan
+ * @property {StoragePrice|EarlyAdopterPlanId} id
+ * @property {string} title
+ * @property {string} description
+ * @property {string} price
+ * @property {string} baseStorage
+ * @property {string} additionalStorage
+ * @property {string} bandwidth
+ * @property {string} blockLimit
+ */
+
 export const sharedPlans = [
   {
-    id: 'lite',
+    id: /** @type {const} */ ('lite'),
     title: 'Lite',
     description: 'For those that want to take advantage of more storage',
     price: '$3/mo',
@@ -10,8 +41,7 @@ export const sharedPlans = [
     blockLimit: '10,000 / GiB',
   },
   {
-    // id: 'price_pro',
-    id: 'pro',
+    id: /** @type {const} */ ('pro'),
     title: 'Expert',
     description: 'Our lowest price per GiB stored. For those with use cases that require scale.',
     price: '$10/mo',
@@ -23,7 +53,7 @@ export const sharedPlans = [
 ];
 
 export const freePlan = {
-  id: 'free',
+  id: /** @type {const} */ ('free'),
   title: 'Free',
   description: 'You are currently on the free tier. You can use our service up to 5GiB/mo without being charged.',
   price: '$0/mo',
@@ -34,7 +64,7 @@ export const freePlan = {
 };
 
 export const earlyAdopterPlan = {
-  id: 'earlyAdopter',
+  id: /** @type {const} */ ('earlyAdopter'),
   title: 'Early Adopter',
   description:
     'As an early adopter we appreciate your support and can continue to use the storage you are already accustomed to.',
@@ -48,3 +78,16 @@ export const earlyAdopterPlan = {
 export const plans = [freePlan, ...sharedPlans];
 export const plansEarly = [earlyAdopterPlan, ...sharedPlans];
 export const plansAll = [freePlan, earlyAdopterPlan, ...sharedPlans];
+
+/**
+ * Given a plan id, return the corresponding storage subscription object
+ * that can be sent to /user/payment api (which doesn't have 'plans')
+ * @param {Plan['id']} planId
+ * @returns {StorageSubscription|EarlyAdopterStorageSubscription}
+ */
+export function planIdToStorageSubscription(planId) {
+  if (planId === 'earlyAdopter') {
+    return null;
+  }
+  return { price: planId };
+}

--- a/packages/website/hooks/use-payment.js
+++ b/packages/website/hooks/use-payment.js
@@ -3,29 +3,17 @@ import { useState, useEffect, useMemo } from 'react';
 import { userBillingSettings } from '../lib/api';
 import { earlyAdopterPlan, plans, plansEarly } from '../components/contexts/plansContext';
 
-export const usePayment = () => {
-  /**
-   * @typedef {object} storageSubscription
-   * @property {'free'|'lite'|'pro'} price
-   */
+/**
+ * @typedef {import('../components/contexts/plansContext').Plan} Plan
+ * @typedef {import('../components/contexts/plansContext').StorageSubscription} StorageSubscription
+ */
 
+export const usePayment = () => {
   /**
    * @typedef {object} PaymentSettings
    * @property {null|{id: string}} paymentMethod
    * @property {object} subscription
-   * @property {storageSubscription|null} subscription.storage
-   */
-
-  /**
-   * @typedef {Object} Plan
-   * @property {string | null} id
-   * @property {string} title
-   * @property {string} description
-   * @property {string} price
-   * @property {string} baseStorage
-   * @property {string} additionalStorage
-   * @property {string} bandwidth
-   * @property {string} blockLimit
+   * @property {StorageSubscription|null} subscription.storage
    */
 
   const [needsFetchPaymentSettings, setNeedsFetchPaymentSettings] = useState(true);
@@ -54,6 +42,7 @@ export const usePayment = () => {
   }, [needsFetchPaymentSettings]);
 
   // When storageSubscription is null, user sees a version of planList that contains 'Early Adopter' instead of 'free'
+  /** @type {Array<Plan>} */
   const planList = useMemo(() => {
     if (typeof paymentSettings === 'undefined') {
       return plans;

--- a/packages/website/lib/api.js
+++ b/packages/website/lib/api.js
@@ -300,14 +300,22 @@ export async function deletePinRequest(requestid) {
 }
 
 /**
- * Gets/Puts saved user plan and billing settings.
+ * @typedef {import('../components/contexts/plansContext').StorageSubscription} StorageSubscription
+ * @typedef {import('../components/contexts/plansContext').EarlyAdopterStorageSubscription
+ *  } EarlyAdopterStorageSubscription
  */
-export async function userBillingSettings(pm_id, currPricePlan) {
+
+/**
+ * Gets/Puts saved user plan and billing settings.
+ * @param {string} [pmId] - payment method id
+ * @param {StorageSubscription|EarlyAdopterStorageSubscription} [storageSubscription]
+ */
+export async function userBillingSettings(pmId, storageSubscription) {
   const putBody =
-    pm_id || currPricePlan
+    pmId || storageSubscription
       ? JSON.stringify({
-          paymentMethod: pm_id ? { id: pm_id } : null,
-          subscription: { storage: currPricePlan ?? null },
+          paymentMethod: pmId ? { id: pmId } : null,
+          subscription: { storage: storageSubscription },
         })
       : null;
   const method = !!putBody ? 'PUT' : 'GET';

--- a/packages/website/pages/account/payment.js
+++ b/packages/website/pages/account/payment.js
@@ -16,27 +16,17 @@ import { earlyAdopterPlan, plans, plansEarly } from '../../components/contexts/p
 import { userBillingSettings } from '../../lib/api';
 
 /**
- * @typedef {object} storageSubscription
- * @property {'free'|'lite'|'pro'} price
+ * @typedef {import('../../components/contexts/plansContext').Plan} Plan
+ * @typedef {import('../../components/contexts/plansContext').StorageSubscription} StorageSubscription
+ * @typedef {import('../../components/contexts/plansContext').StoragePrice} StoragePrice
+ * @typedef {import('../../components/contexts/plansContext').EarlyAdopterPlanId} EarlyAdopterPlanId
  */
 
 /**
  * @typedef {object} PaymentSettings
  * @property {null|{id: string}} paymentMethod
  * @property {object} subscription
- * @property {storageSubscription|null} subscription.storage
- */
-
-/**
- * @typedef {Object} Plan
- * @property {string | null} id
- * @property {string} title
- * @property {string} description
- * @property {string} price
- * @property {string} baseStorage
- * @property {string} additionalStorage
- * @property {string} bandwidth
- * @property {string} blockLimit
+ * @property {StorageSubscription} subscription.storage
  */
 
 /**
@@ -86,6 +76,7 @@ const PaymentSettingsPage = props => {
   }, [needsFetchPaymentSettings]);
 
   // When storageSubscription is null, user sees a version of planList that contains 'Early Adopter' instead of 'free'
+  /** @type {Array<Plan>} */
   const planList = useMemo(() => {
     if (typeof paymentSettings === 'undefined') {
       return plans;

--- a/packages/website/tests/accountPayment.e2e.spec.ts
+++ b/packages/website/tests/accountPayment.e2e.spec.ts
@@ -98,6 +98,7 @@ function AccountPaymentTester() {
       await stripeFrame.locator('[placeholder="Card number"]').fill('4242424242424242');
       await stripeFrame.locator('[placeholder="MM / YY"]').fill('04/30');
       await stripeFrame.locator('[placeholder="CVC"]').fill('242');
+      await stripeFrame.locator('[placeholder="ZIP"]').fill('42424');
     },
     async clickAddCardButton(page: Page) {
       await page.locator('text=Payment MethodsAdd Card >> button').click();

--- a/packages/website/tsconfig.json
+++ b/packages/website/tsconfig.json
@@ -27,7 +27,6 @@
     "incremental": true
   },
   "include": ["lib", "pages", "components", "content", "hooks", "modules", "store", "declaration.d.ts", "tests/**/*", "scripts", "playwright.config.ts"],
-  "exclude": ["node_modules", "public", ".next/", "{pages,components,content,hooks,modules}/**/*.js", "lib/countly.js"],
   "references": [
     {
       "path": "../client"


### PR DESCRIPTION
Previously, the 'earlyAdopter' plan id would be PUT to the api, but the backend doesn't allow this value as a storage subscription price. The backend doesn't explicitly model 'earlyAdopter' nor 'plans'. But the equivalent is to have a `null` storage subscription, and this commit sends that instead.

This pr also adds type hints that would have prevented this bug from being introduced, and will hopefully help in the future.