### PR TITLE
fix: migrate upsert_user function to return id text instead of id bigint

### DIFF
--- a/packages/api/src/user.js
+++ b/packages/api/src/user.js
@@ -154,7 +154,7 @@ async function loginOrRegister (request, env) {
     user = await env.db.upsertUser(parsed)
     // initialize billing, etc, but only if the user was newly inserted
     if (user.inserted) {
-      await initializeNewUser(env, { ...user, id: user.id.toString() })
+      await initializeNewUser(env, { ...user, id: user.id })
     }
   } else if (env.MODE === READ_ONLY) {
     user = await env.db.getUser(parsed.issuer, {})

--- a/packages/db/db-client-types.ts
+++ b/packages/db/db-client-types.ts
@@ -13,7 +13,7 @@ export type UpsertUserInput = {
 }
 
 export type UpsertUserOutput = {
-  id: number
+  id: string
   // whether the upsert inserted a new record (if falsy, it was updated)
   inserted: boolean
   issuer: string

--- a/packages/db/index.js
+++ b/packages/db/index.js
@@ -114,12 +114,10 @@ export class DBClient {
         _github: user.github ?? '',
         _public_address: user.publicAddress
       })
-
-    const userData = data[0]
-
     if (error) {
       throw new DBError(error)
     }
+    const userData = data[0]
     return {
       id: userData.id,
       inserted: userData.inserted,

--- a/packages/db/postgres/functions.sql
+++ b/packages/db/postgres/functions.sql
@@ -422,7 +422,7 @@ $$;
 -- newly inserted users and updated ones.
 CREATE OR REPLACE FUNCTION upsert_user(_name TEXT, _picture TEXT, _email TEXT, _issuer TEXT, _github TEXT, _public_address TEXT)
 RETURNS TABLE (
-  "id" BIGINT,
+  "id" TEXT,
   "issuer" TEXT,
   "inserted" BOOLEAN
 )
@@ -446,7 +446,7 @@ BEGIN
     email = EXCLUDED.email,
     github = EXCLUDED.github,
     public_address = EXCLUDED.public_address
-  RETURNING u.id, u.issuer, inserted;
+  RETURNING u.id::TEXT, u.issuer, inserted;
 
 END
 $$;

--- a/packages/db/postgres/migrations/027-change-upsert-user-return-type.sql
+++ b/packages/db/postgres/migrations/027-change-upsert-user-return-type.sql
@@ -1,0 +1,33 @@
+-- This replaces the previous upsert_user function, which returned "id" BIGINT not text
+-- the bigints were cast to Numbers by our js lib and overflowed Number.MAX_SAFE_INTEGER
+DROP FUNCTION IF EXISTS upsert_user(text,text,text,text,text,text);
+CREATE OR REPLACE FUNCTION upsert_user(_name TEXT, _picture TEXT, _email TEXT, _issuer TEXT, _github TEXT, _public_address TEXT)
+RETURNS TABLE (
+  "id" TEXT,
+  "issuer" TEXT,
+  "inserted" BOOLEAN
+)
+LANGUAGE plpgsql
+AS
+$$
+#variable_conflict use_column
+DECLARE
+  inserted BOOLEAN;
+
+BEGIN
+  SELECT (COUNT(id) = 0) into inserted FROM public.user WHERE issuer = _issuer;
+
+  RETURN QUERY
+  INSERT INTO public.user AS u (name, picture, email, issuer, github, public_address) 
+  VALUES (_name, _picture, _email, _issuer, _github, _public_address)
+  ON CONFLICT (issuer) DO UPDATE
+  SET 
+    name = EXCLUDED.name,
+    picture = EXCLUDED.picture,
+    email = EXCLUDED.email,
+    github = EXCLUDED.github,
+    public_address = EXCLUDED.public_address
+  RETURNING u.id::TEXT, u.issuer, inserted;
+
+END
+$$;


### PR DESCRIPTION
Motivation:
* originally I typed [UpsertUserOutput.id as a number](https://github.com/web3-storage/web3.storage/pull/1945/files#diff-3f447b347f942bfd2bcfa962fec4f2320ea8ef5e7c759367d7071da5af108d0aR16), but in the db these ids are bigints which will overflow js Number.MAX_SAFE_INTEGER