### PR TITLE
fix: fix social media preview image URLs

### DIFF
--- a/packages/website/components/general/metadata.js
+++ b/packages/website/components/general/metadata.js
@@ -19,14 +19,13 @@ const Metadata = ({
   <Head>
     <title>{title}</title>
     <meta name="description" content={description} />
-    <meta property="image" content="/social-card-web3storage.jpg" />
     <meta property="og:title" content={title} />
     <meta property="og:description" content={description} />
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://web3.storage" />
-    <meta property="og:image" content="/social-card-web3storage.jpg" />
+    <meta property="og:image" content="https://web3.storage/social-card-web3storage.jpg" />
     <meta name="twitter:card" content="summary_large_image" />
-    <meta name="twitter:image" content="/social-card-web3storage.jpg" />
+    <meta name="twitter:image" content="https://web3.storage/social-card-web3storage.jpg" />
     <meta name="twitter:site" content="@protocollabs" />
     <meta name="twitter:creator" content="@protocollabs" />
   </Head>


### PR DESCRIPTION
Closes #1984 

I'm not familiar with `<meta property="image" content="/social-card-web3storage.jpg" />` and googling gave me nothing, so I'm just yanking it out.  Let me know if this one rings a bell for anyone.