### PR TITLE
fix: "get started" only partially clickable

### DIFF
--- a/packages/website/pages/pricing.scss
+++ b/packages/website/pages/pricing.scss
@@ -310,6 +310,7 @@ li.pricing-bullet-3 {
     flex: 0 0 auto;
     width: 260px;
     height: 260px;
+    pointer-events: none;
 
     & > span {
       top: -8rem;


### PR DESCRIPTION
https://www.notion.so/Make-get-started-on-Pricing-Page-more-easily-clickable-it-doesn-t-light-up-unless-your-cursor-hi-0f1e6f42515d46b88daca24ae1468565

The issue was the image was overlaying the button:
![image](https://user-images.githubusercontent.com/22156330/193877148-d3d52bf4-13d6-4192-a282-cf9838b4fcdb.png)

Proposed fix:
Disable `pointer-events` for the image so the browser acts like the image doesn't exist when you click where they overlap.

Post fix:
![image](https://user-images.githubusercontent.com/22156330/193878561-f3e65f0f-8567-4e1c-974f-45f1138c4382.png)
