### PR TITLE
fix: add terms for w3link usage

### DIFF
--- a/packages/website/content/terms-of-service.mdx
+++ b/packages/website/content/terms-of-service.mdx
@@ -36,7 +36,7 @@ Use of the w3link Gateway (“the Gateway”) is subject to the Terms of Service
 
 When you access content via the Gateway, Protocol Labs may cache that content or the associated CID for performance reasons. Protocol Labs may also collect analytics data on use of the Gateway, including data on requests, gateway speeds, CIDs, and other performance data. Protocol Labs reserves all rights in and to any performance data and analytics collected in the course of providing the Gateway for optimizing the Gateway user experience.
 
-If you encounter content that violates the [Terms of Service of IPFS.io](https://discuss.ipfs.io/tos) (e.g., spam/phishing content or your unauthorized copyrighted content), please reach out to abuse@ipfs.io, making sure to include the relevant URL. If we determine that the content violates our Terms of Service we will remove or disable access to that content. If your complaint is copyright-related, please make sure your DMCA Notice contains the required information listed in our [DMCA Policy](https://ipfs.io/legal/).
+If you encounter content that violates the [Terms of Service of IPFS.io](https://discuss.ipfs.io/tos) (e.g., spam/phishing content or your unauthorized copyrighted content), please reach out to abuse@ipfs.io, making sure to include the relevant URL. If it is determined that the content violates our Terms of Service we will remove or disable access to that content. If your complaint is copyright-related, please make sure your DMCA Notice contains the required information listed in our [DMCA Policy](https://ipfs.io/legal/).
 
 
 #### **Paid Accounts**

--- a/packages/website/content/terms-of-service.mdx
+++ b/packages/website/content/terms-of-service.mdx
@@ -30,6 +30,15 @@ Data stored via the Services will be available and persisted via IPFS upon compl
 web3.storage will manage backup storage deals and deal renewals to ensure highly redundant storage on the Filecoin network.
 
 
+#### **[w3link](https://web3.storage/terms/#w3link)**
+
+Use of the w3link Gateway (“the Gateway”) is subject to the Terms of Service of [IPFS.io](https://discuss.ipfs.io/tos).
+
+When you access content via the Gateway, Protocol Labs may cache that content or the associated CID for performance reasons. Protocol Labs may also collect analytics data on use of the Gateway, including data on requests, gateway speeds, CIDs, and other performance data. Protocol Labs reserves all rights in and to any performance data and analytics collected in the course of providing the Gateway for optimizing the Gateway user experience.
+
+If you encounter content that violates the [Terms of Service of IPFS.io](https://discuss.ipfs.io/tos) (e.g., spam/phishing content or your unauthorized copyrighted content), please reach out to abuse@ipfs.io, making sure to include the relevant URL. If we determine that the content violates our Terms of Service we will remove or disable access to that content. If your complaint is copyright-related, please make sure your DMCA Notice contains the required information listed in our [DMCA Policy](https://ipfs.io/legal/).
+
+
 #### **Paid Accounts**
 
 <u>Billing.</u>


### PR DESCRIPTION
Adds terms for w3link per feedback on https://github.com/web3-storage/web3.storage/issues/2008

It includes same content as https://nft.storage/terms/#gateway (just swapped nft for w3link)