### PR TITLE
fix: rm staging url in PSA docs

### DIFF
--- a/packages/website/pages/docs/how-tos/pinning-services-api.md
+++ b/packages/website/pages/docs/how-tos/pinning-services-api.md
@@ -43,7 +43,7 @@ curl -X GET 'https://api.web3.storage/pins' \
 ### Delete a pin
 
 ```bash
-curl -X DELETE 'https://api-staging.web3.storage/pins/<REQUEST_ID>' \
+curl -X DELETE 'https://api.web3.storage/pins/<REQUEST_ID>' \
   --header 'Accept: */*' \
   --header 'Authorization: Bearer <YOUR_AUTH_KEY_JWT>'
 ```


### PR DESCRIPTION
closes #2024 by changing the API endpoint from `api-staging` to `api`.