### PR TITLE
feat: website link component defaults target to _blank when the href is external

### DIFF
--- a/packages/website/components/breadcrumbs/breadcrumbs.js
+++ b/packages/website/components/breadcrumbs/breadcrumbs.js
@@ -10,7 +10,7 @@ import Link from '../link/link';
  * @param {Object} props
  * @param {String} props.variant
  * @param {Object} [props.items]
- * @param {Function} props.click
+ * @param {React.MouseEventHandler<HTMLAnchorElement>} props.click
  */
 export default function Breadcrumbs({ variant, click, items }) {
   return (

--- a/packages/website/components/footer/footer.js
+++ b/packages/website/components/footer/footer.js
@@ -4,7 +4,7 @@ import { useRouter } from 'next/router';
 import clsx from 'clsx';
 
 import { trackCustomLinkClick, events } from '../../lib/countly';
-import Link from '../link/link';
+import Link, { useIsExternalHref } from '../link/link';
 import SiteLogo from '../../assets/icons/w3storage-logo.js';
 import Button from '../button/button';
 import Img from '../cloudflareImage.js';
@@ -25,6 +25,8 @@ export default function Footer({ isProductApp }) {
   const resources = GeneralPageData.footer.resources;
   const getStarted = GeneralPageData.footer.get_started;
   const copyright = GeneralPageData.footer.copyright;
+  const isExternalHref = useIsExternalHref();
+  const getLinkTarget = useCallback(href => (isExternalHref(href) ? '_blank' : undefined), [isExternalHref]);
 
   // ================================================================= Functions
   const onLinkClick = useCallback(e => {
@@ -77,7 +79,13 @@ export default function Footer({ isProductApp }) {
             <div className="footer_resources">
               <div className="label">{resources.heading}</div>
               {resources.items.map(item => (
-                <Link href={item.url} key={item.text} className="footer-link" onClick={onLinkClick}>
+                <Link
+                  href={item.url}
+                  key={item.text}
+                  className="footer-link"
+                  onClick={onLinkClick}
+                  target={getLinkTarget(item.url)}
+                >
                   {item.text}
                 </Link>
               ))}
@@ -88,7 +96,13 @@ export default function Footer({ isProductApp }) {
             <div className="footer_get-started">
               <div className="label">{getStarted.heading}</div>
               {getStarted.items.map(item => (
-                <Link className="footer-link" href={item.url} key={item.text} onClick={onLinkClick}>
+                <Link
+                  className="footer-link"
+                  href={item.url}
+                  key={item.text}
+                  onClick={onLinkClick}
+                  target={getLinkTarget(item.url)}
+                >
                   {item.text}
                 </Link>
               ))}

--- a/packages/website/components/link/link.js
+++ b/packages/website/components/link/link.js
@@ -54,16 +54,14 @@ export function useIsExternalHref() {
  * @param {React.ReactNode} [props.children]
  * @param {React.MouseEventHandler<HTMLAnchorElement>} [props.onClick] - the onClick handler for the link
  */
-const WrappedLink = ({ tabIndex = 0, href, target, ...otherProps }) => {
-  return (
-    <Link href={href} {...otherProps}>
-      {/* eslint-disable-next-line jsx-a11y/click-events-have-key-events,jsx-a11y/no-static-element-interactions */}
-      <a target={target} {...otherProps} tabIndex={tabIndex} onClick={otherProps.onClick}>
-        {otherProps.children}
-      </a>
-    </Link>
-  );
-};
+const WrappedLink = ({ tabIndex = 0, href, target, ...otherProps }) => (
+  <Link href={href} {...otherProps}>
+    {/* eslint-disable-next-line jsx-a11y/click-events-have-key-events,jsx-a11y/no-static-element-interactions */}
+    <a target={target} {...otherProps} tabIndex={tabIndex} onClick={otherProps.onClick}>
+      {otherProps.children}
+    </a>
+  </Link>
+);
 
 WrappedLink.propTypes = {
   onClick: PropTypes.func,

--- a/packages/website/components/link/link.js
+++ b/packages/website/components/link/link.js
@@ -47,11 +47,11 @@ function useHrefExternality(href) {
  */
 const WrappedLink = ({ tabIndex = 0, href, target, ...otherProps }) => {
   const isExternalHref = useHrefExternality(href);
-  const derrivedTarget = isExternalHref ? '_blank' : '_self';
+  const derivedTarget = target ?? (isExternalHref ? '_blank' : '_self');
   return (
     <Link href={href} {...otherProps}>
       {/* eslint-disable-next-line jsx-a11y/click-events-have-key-events,jsx-a11y/no-static-element-interactions */}
-      <a target={derrivedTarget} {...otherProps} tabIndex={tabIndex} onClick={otherProps.onClick}>
+      <a target={derivedTarget} {...otherProps} tabIndex={tabIndex} onClick={otherProps.onClick}>
         {otherProps.children}
       </a>
     </Link>

--- a/packages/website/components/link/link.js
+++ b/packages/website/components/link/link.js
@@ -46,7 +46,6 @@ export function useIsExternalHref() {
 
 /**
  * A generic hyperlink component.
- * * by default, links to external sites will have target=_blank if they are an external link
  * @param {object} props
  * @param {string} props.href - the href attribute for the link
  * @param {number} [props.tabIndex] - the tabIndex attribute for the link

--- a/packages/website/components/link/link.js
+++ b/packages/website/components/link/link.js
@@ -2,14 +2,61 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import Link from 'next/link';
 
-const WrappedLink = ({ tabIndex = 0, href, target = '_self', ...otherProps }) => (
-  <Link href={href} {...otherProps}>
-    {/* eslint-disable-next-line jsx-a11y/click-events-have-key-events,jsx-a11y/no-static-element-interactions */}
-    <a target={target} {...otherProps} tabIndex={tabIndex} onClick={otherProps.onClick}>
-      {otherProps.children}
-    </a>
-  </Link>
-);
+/**
+ * Return whether a url is 'external' relative to another URL.
+ * The url is considered external if it has a different hostname.
+ * @param {URL} url
+ * @param {URL} relativeTo - url to compare for externality
+ */
+function isExternalLink(url, relativeTo) {
+  return url.hostname !== relativeTo.hostname;
+}
+
+/**
+ * @param {string} href - href attribute of an <a>
+ * @returns {boolean} - whether the provided href is known to be external from the current document
+ */
+function useHrefExternality(href) {
+  const [document, setDocument] = React.useState(/** @type {Document|undefined} */ (undefined));
+  // useEffect because next ssr wont have a document
+  React.useEffect(() => {
+    if (typeof globalThis.document !== 'undefined') {
+      setDocument(globalThis.document);
+    }
+  }, []);
+  const isExternalHref = React.useMemo(() => {
+    if (!document) {
+      return false;
+    }
+    const documentURL = new URL(document.URL);
+    const isExternal = isExternalLink(new URL(href, documentURL), documentURL);
+    return isExternal;
+  }, [document, href]);
+  return isExternalHref;
+}
+
+/**
+ * A generic hyperlink component.
+ * * by default, links to external sites will have target=_blank if they are an external link
+ * @param {object} props
+ * @param {string} props.href - the href attribute for the link
+ * @param {number} [props.tabIndex] - the tabIndex attribute for the link
+ * @param {string} [props.target] - the target attribute for the link
+ * @param {React.ReactNode} [props.children]
+ * @param {React.MouseEventHandler<HTMLAnchorElement>} [props.onClick] - the onClick handler for the link
+ */
+const WrappedLink = ({ tabIndex = 0, href, target, ...otherProps }) => {
+  const isExternalHref = useHrefExternality(href);
+  const derrivedTarget = isExternalHref ? '_blank' : '_self';
+  return (
+    <Link href={href} {...otherProps}>
+      {/* eslint-disable-next-line jsx-a11y/click-events-have-key-events,jsx-a11y/no-static-element-interactions */}
+      <a target={derrivedTarget} {...otherProps} tabIndex={tabIndex} onClick={otherProps.onClick}>
+        {otherProps.children}
+      </a>
+    </Link>
+  );
+};
 
 WrappedLink.propTypes = {
   onClick: PropTypes.func,


### PR DESCRIPTION
Motivation:
* CIC - this was at top of CIC backlog for the repo
* https://github.com/web3-storage/web3.storage/issues/2006

How?
* made it so the go-to website `<Link />` component will enforce the logic @jchris requested