### PR TITLE
fix: properly center align the loading icon within login/logout button

### DIFF
--- a/packages/website/components/loading/loading.js
+++ b/packages/website/components/loading/loading.js
@@ -24,8 +24,7 @@ export const SpinnerColor = {
  */
 const Loading = ({ className, size, color, message }) => (
   <div
-    className={clsx({
-      className,
+    className={clsx(className, {
       [styles.loading]: true,
       [styles.message]: message,
     })}


### PR DESCRIPTION
Closes #2002 

Context: center aligns the loading icon within login/logout button