### PR TITLE
fix: update toucan-js and move to deps

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4988,16 +4988,14 @@
       }
     },
     "node_modules/@sentry/core": {
-      "version": "6.11.0",
-      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-6.11.0.tgz",
-      "integrity": "sha512-09TB+f3pqEq8LFahFWHO6I/4DxHo+NcS52OkbWMDqEi6oNZRD7PhPn3i14LfjsYVv3u3AESU8oxSEGbFrr2UjQ==",
-      "dev": true,
-      "license": "BSD-3-Clause",
+      "version": "6.19.6",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-6.19.6.tgz",
+      "integrity": "sha512-biEotGRr44/vBCOegkTfC9rwqaqRKIpFljKGyYU6/NtzMRooktqOhjmjmItNCMRknArdeaQwA8lk2jcZDXX3Og==",
       "dependencies": {
-        "@sentry/hub": "6.11.0",
-        "@sentry/minimal": "6.11.0",
-        "@sentry/types": "6.11.0",
-        "@sentry/utils": "6.11.0",
+        "@sentry/hub": "6.19.6",
+        "@sentry/minimal": "6.19.6",
+        "@sentry/types": "6.19.6",
+        "@sentry/utils": "6.19.6",
         "tslib": "^1.9.3"
       },
       "engines": {
@@ -5007,19 +5005,15 @@
     "node_modules/@sentry/core/node_modules/tslib": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-      "dev": true,
-      "license": "0BSD"
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "node_modules/@sentry/hub": {
-      "version": "6.11.0",
-      "resolved": "https://registry.npmjs.org/@sentry/hub/-/hub-6.11.0.tgz",
-      "integrity": "sha512-pT9hf+ZJfVFpoZopoC+yJmFNclr4NPqPcl2cgguqCHb69DklD1NxgBNWK8D6X05qjnNFDF991U6t1mxP9HrGuw==",
-      "dev": true,
-      "license": "BSD-3-Clause",
+      "version": "6.19.6",
+      "resolved": "https://registry.npmjs.org/@sentry/hub/-/hub-6.19.6.tgz",
+      "integrity": "sha512-PuEOBZxvx3bjxcXmWWZfWXG+orojQiWzv9LQXjIgroVMKM/GG4QtZbnWl1hOckUj7WtKNl4hEGO2g/6PyCV/vA==",
       "dependencies": {
-        "@sentry/types": "6.11.0",
-        "@sentry/utils": "6.11.0",
+        "@sentry/types": "6.19.6",
+        "@sentry/utils": "6.19.6",
         "tslib": "^1.9.3"
       },
       "engines": {
@@ -5029,19 +5023,15 @@
     "node_modules/@sentry/hub/node_modules/tslib": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-      "dev": true,
-      "license": "0BSD"
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "node_modules/@sentry/minimal": {
-      "version": "6.11.0",
-      "resolved": "https://registry.npmjs.org/@sentry/minimal/-/minimal-6.11.0.tgz",
-      "integrity": "sha512-XkZ7qrdlGp4IM/gjGxf1Q575yIbl5RvPbg+WFeekpo16Ufvzx37Mr8c2xsZaWosISVyE6eyFpooORjUlzy8EDw==",
-      "dev": true,
-      "license": "BSD-3-Clause",
+      "version": "6.19.6",
+      "resolved": "https://registry.npmjs.org/@sentry/minimal/-/minimal-6.19.6.tgz",
+      "integrity": "sha512-T1NKcv+HTlmd8EbzUgnGPl4ySQGHWMCyZ8a8kXVMZOPDzphN3fVIzkYzWmSftCWp0rpabXPt9aRF2mfBKU+mAQ==",
       "dependencies": {
-        "@sentry/hub": "6.11.0",
-        "@sentry/types": "6.11.0",
+        "@sentry/hub": "6.19.6",
+        "@sentry/types": "6.19.6",
         "tslib": "^1.9.3"
       },
       "engines": {
@@ -5051,28 +5041,22 @@
     "node_modules/@sentry/minimal/node_modules/tslib": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-      "dev": true,
-      "license": "0BSD"
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "node_modules/@sentry/types": {
-      "version": "6.11.0",
-      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-6.11.0.tgz",
-      "integrity": "sha512-gm5H9eZhL6bsIy/h3T+/Fzzz2vINhHhqd92CjHle3w7uXdTdFV98i2pDpErBGNTSNzbntqOMifYEB5ENtZAvcg==",
-      "dev": true,
-      "license": "BSD-3-Clause",
+      "version": "6.19.6",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-6.19.6.tgz",
+      "integrity": "sha512-QH34LMJidEUPZK78l+Frt3AaVFJhEmIi05Zf8WHd9/iTt+OqvCHBgq49DDr1FWFqyYWm/QgW/3bIoikFpfsXyQ==",
       "engines": {
         "node": ">=6"
       }
     },
     "node_modules/@sentry/utils": {
-      "version": "6.11.0",
-      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-6.11.0.tgz",
-      "integrity": "sha512-IOvyFHcnbRQxa++jO+ZUzRvFHEJ1cZjrBIQaNVc0IYF0twUOB5PTP6joTcix38ldaLeapaPZ9LGfudbvYvxkdg==",
-      "dev": true,
-      "license": "BSD-3-Clause",
+      "version": "6.19.6",
+      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-6.19.6.tgz",
+      "integrity": "sha512-fAMWcsguL0632eWrROp/vhPgI7sBj/JROWVPzpabwVkm9z3m1rQm6iLFn4qfkZL8Ozy6NVZPXOQ7EXmeU24byg==",
       "dependencies": {
-        "@sentry/types": "6.11.0",
+        "@sentry/types": "6.19.6",
         "tslib": "^1.9.3"
       },
       "engines": {
@@ -5082,9 +5066,7 @@
     "node_modules/@sentry/utils/node_modules/tslib": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-      "dev": true,
-      "license": "0BSD"
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "node_modules/@sinonjs/commons": {
       "version": "1.8.3",
@@ -5212,11 +5194,9 @@
       }
     },
     "node_modules/@types/cookie": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.4.1.tgz",
-      "integrity": "sha512-XW/Aa8APYr6jSVVA1y/DEIZX0/GMKLEVekNG727R8cs56ahETkRAy/3DR7+fJyh7oUgGwNQaRfXCun0+KbWY7Q==",
-      "dev": true,
-      "license": "MIT"
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.5.0.tgz",
+      "integrity": "sha512-CJWHVHHupxBYfIlMM+qzXx4dRKIV1VzOm0cP3Wpqten8MDx1tK+y92YDXUshN1ONAfwodvKxDNkw35/pNs+izg=="
     },
     "node_modules/@types/debug": {
       "version": "4.1.7",
@@ -5501,13 +5481,6 @@
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.6.tgz",
       "integrity": "sha512-PBjIUxZHOuj0R15/xuwJYjFi+KZdNFrehocChv4g5hu6aFroHue8m0lBP0POdK2nKzbw0cgV1mws8+V/JAcEkQ==",
-      "license": "MIT"
-    },
-    "node_modules/@types/uuid": {
-      "version": "8.3.1",
-      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-8.3.1.tgz",
-      "integrity": "sha512-Y2mHTRAbqfFkpjldbkHGY8JIzRN6XqYRliG8/24FcHm2D2PwW24fl5xMRTVGdrb7iMrwCaIEbLWerGIkXuFWVg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/ws": {
@@ -6386,99 +6359,6 @@
     "node_modules/@web3-storage/tools": {
       "resolved": "packages/tools",
       "link": true
-    },
-    "node_modules/@web3-storage/toucan-js": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/@web3-storage/toucan-js/-/toucan-js-2.7.1.tgz",
-      "integrity": "sha512-vLY985tJtc/jJvx43Xe+G6j0jpmO9W4rlsaa+etFLF9XWyqphXQ3hh6PyxFSsNtPrzyfRyIjGQRJN//xhUamew==",
-      "dependencies": {
-        "@sentry/core": "6.19.6",
-        "@sentry/hub": "6.19.6",
-        "@sentry/types": "6.19.6",
-        "@sentry/utils": "6.19.6",
-        "@types/cookie": "0.5.0",
-        "cookie": "0.5.0",
-        "stacktrace-js": "2.0.2"
-      }
-    },
-    "node_modules/@web3-storage/toucan-js/node_modules/@sentry/core": {
-      "version": "6.19.6",
-      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-6.19.6.tgz",
-      "integrity": "sha512-biEotGRr44/vBCOegkTfC9rwqaqRKIpFljKGyYU6/NtzMRooktqOhjmjmItNCMRknArdeaQwA8lk2jcZDXX3Og==",
-      "dependencies": {
-        "@sentry/hub": "6.19.6",
-        "@sentry/minimal": "6.19.6",
-        "@sentry/types": "6.19.6",
-        "@sentry/utils": "6.19.6",
-        "tslib": "^1.9.3"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/@web3-storage/toucan-js/node_modules/@sentry/hub": {
-      "version": "6.19.6",
-      "resolved": "https://registry.npmjs.org/@sentry/hub/-/hub-6.19.6.tgz",
-      "integrity": "sha512-PuEOBZxvx3bjxcXmWWZfWXG+orojQiWzv9LQXjIgroVMKM/GG4QtZbnWl1hOckUj7WtKNl4hEGO2g/6PyCV/vA==",
-      "dependencies": {
-        "@sentry/types": "6.19.6",
-        "@sentry/utils": "6.19.6",
-        "tslib": "^1.9.3"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/@web3-storage/toucan-js/node_modules/@sentry/minimal": {
-      "version": "6.19.6",
-      "resolved": "https://registry.npmjs.org/@sentry/minimal/-/minimal-6.19.6.tgz",
-      "integrity": "sha512-T1NKcv+HTlmd8EbzUgnGPl4ySQGHWMCyZ8a8kXVMZOPDzphN3fVIzkYzWmSftCWp0rpabXPt9aRF2mfBKU+mAQ==",
-      "dependencies": {
-        "@sentry/hub": "6.19.6",
-        "@sentry/types": "6.19.6",
-        "tslib": "^1.9.3"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/@web3-storage/toucan-js/node_modules/@sentry/types": {
-      "version": "6.19.6",
-      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-6.19.6.tgz",
-      "integrity": "sha512-QH34LMJidEUPZK78l+Frt3AaVFJhEmIi05Zf8WHd9/iTt+OqvCHBgq49DDr1FWFqyYWm/QgW/3bIoikFpfsXyQ==",
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/@web3-storage/toucan-js/node_modules/@sentry/utils": {
-      "version": "6.19.6",
-      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-6.19.6.tgz",
-      "integrity": "sha512-fAMWcsguL0632eWrROp/vhPgI7sBj/JROWVPzpabwVkm9z3m1rQm6iLFn4qfkZL8Ozy6NVZPXOQ7EXmeU24byg==",
-      "dependencies": {
-        "@sentry/types": "6.19.6",
-        "tslib": "^1.9.3"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/@web3-storage/toucan-js/node_modules/@types/cookie": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.5.0.tgz",
-      "integrity": "sha512-CJWHVHHupxBYfIlMM+qzXx4dRKIV1VzOm0cP3Wpqten8MDx1tK+y92YDXUshN1ONAfwodvKxDNkw35/pNs+izg=="
-    },
-    "node_modules/@web3-storage/toucan-js/node_modules/cookie": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.5.0.tgz",
-      "integrity": "sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw==",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/@web3-storage/toucan-js/node_modules/tslib": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "node_modules/@web3-storage/w3": {
       "resolved": "packages/w3",
@@ -26119,29 +25999,23 @@
       }
     },
     "node_modules/toucan-js": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/toucan-js/-/toucan-js-2.5.0.tgz",
-      "integrity": "sha512-kGC4aBI5ou0L6jIe+CqYxWjobknU7CTsgQOfHMFadSm8KLh/8f2oKgtqcmRB5Iysvai2/4vJDrFXqX/3K4iAjQ==",
-      "dev": true,
-      "license": "MIT",
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/toucan-js/-/toucan-js-2.7.0.tgz",
+      "integrity": "sha512-vbvRbFfMLN2Jf9lOkwL1KwIwuCcS/ko0MVACZTYTnbdVlVjsIviwCU0inH0CRcMXCvFAS+uL8z/gSV3y7FpZUQ==",
       "dependencies": {
-        "@sentry/core": "6.11.0",
-        "@sentry/hub": "6.11.0",
-        "@sentry/types": "6.11.0",
-        "@sentry/utils": "6.11.0",
-        "@types/cookie": "0.4.1",
-        "@types/uuid": "8.3.1",
-        "cookie": "0.4.1",
-        "stacktrace-js": "2.0.2",
-        "uuid": "8.3.2"
+        "@sentry/core": "6.19.6",
+        "@sentry/hub": "6.19.6",
+        "@sentry/types": "6.19.6",
+        "@sentry/utils": "6.19.6",
+        "@types/cookie": "0.5.0",
+        "cookie": "0.5.0",
+        "stacktrace-js": "2.0.2"
       }
     },
     "node_modules/toucan-js/node_modules/cookie": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.1.tgz",
-      "integrity": "sha512-ZwrFkGJxUR3EIoXtO+yVE69Eb7KlixbaeAWfBQB9vVsNn/o+Yw69gBWSSDK825hQNdN+wF8zELf3dFNl/kxkUA==",
-      "dev": true,
-      "license": "MIT",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.5.0.tgz",
+      "integrity": "sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw==",
       "engines": {
         "node": ">= 0.6"
       }
@@ -28335,7 +28209,7 @@
     },
     "packages/api": {
       "name": "@web3-storage/api",
-      "version": "7.8.3",
+      "version": "7.9.0",
       "license": "(Apache-2.0 OR MIT)",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.53.1",
@@ -28348,7 +28222,6 @@
         "@nftstorage/ipfs-cluster": "^5.0.1",
         "@web3-storage/db": "^4.0.0",
         "@web3-storage/multipart-parser": "^1.0.0",
-        "@web3-storage/toucan-js": "^2.7.1",
         "cardex": "^1.0.0",
         "cborg": "^1.6.0",
         "ipfs-car": "^0.7.0",
@@ -28359,6 +28232,7 @@
         "p-retry": "^5.1.1",
         "protobufjs": "^6.11.2",
         "stripe": "^10.7.0",
+        "toucan-js": "^2.7.0",
         "tweetnacl": "^1.0.3",
         "uint8arrays": "^3.0.0"
       },
@@ -28385,7 +28259,6 @@
         "sade": "^1.8.1",
         "stream": "^0.0.2",
         "stream-browserify": "^3.0.0",
-        "toucan-js": "^2.4.1",
         "websocket": "^1.0.34"
       }
     },
@@ -31394,7 +31267,7 @@
     },
     "packages/website": {
       "name": "@web3-storage/website",
-      "version": "2.26.0",
+      "version": "2.27.0",
       "dependencies": {
         "@docsearch/react": "^3.0.0",
         "@fortawesome/free-brands-svg-icons": "^6.1.2",
@@ -41939,85 +41812,76 @@
       }
     },
     "@sentry/core": {
-      "version": "6.11.0",
-      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-6.11.0.tgz",
-      "integrity": "sha512-09TB+f3pqEq8LFahFWHO6I/4DxHo+NcS52OkbWMDqEi6oNZRD7PhPn3i14LfjsYVv3u3AESU8oxSEGbFrr2UjQ==",
-      "dev": true,
+      "version": "6.19.6",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-6.19.6.tgz",
+      "integrity": "sha512-biEotGRr44/vBCOegkTfC9rwqaqRKIpFljKGyYU6/NtzMRooktqOhjmjmItNCMRknArdeaQwA8lk2jcZDXX3Og==",
       "requires": {
-        "@sentry/hub": "6.11.0",
-        "@sentry/minimal": "6.11.0",
-        "@sentry/types": "6.11.0",
-        "@sentry/utils": "6.11.0",
+        "@sentry/hub": "6.19.6",
+        "@sentry/minimal": "6.19.6",
+        "@sentry/types": "6.19.6",
+        "@sentry/utils": "6.19.6",
         "tslib": "^1.9.3"
       },
       "dependencies": {
         "tslib": {
           "version": "1.14.1",
           "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-          "dev": true
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
         }
       }
     },
     "@sentry/hub": {
-      "version": "6.11.0",
-      "resolved": "https://registry.npmjs.org/@sentry/hub/-/hub-6.11.0.tgz",
-      "integrity": "sha512-pT9hf+ZJfVFpoZopoC+yJmFNclr4NPqPcl2cgguqCHb69DklD1NxgBNWK8D6X05qjnNFDF991U6t1mxP9HrGuw==",
-      "dev": true,
+      "version": "6.19.6",
+      "resolved": "https://registry.npmjs.org/@sentry/hub/-/hub-6.19.6.tgz",
+      "integrity": "sha512-PuEOBZxvx3bjxcXmWWZfWXG+orojQiWzv9LQXjIgroVMKM/GG4QtZbnWl1hOckUj7WtKNl4hEGO2g/6PyCV/vA==",
       "requires": {
-        "@sentry/types": "6.11.0",
-        "@sentry/utils": "6.11.0",
+        "@sentry/types": "6.19.6",
+        "@sentry/utils": "6.19.6",
         "tslib": "^1.9.3"
       },
       "dependencies": {
         "tslib": {
           "version": "1.14.1",
           "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-          "dev": true
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
         }
       }
     },
     "@sentry/minimal": {
-      "version": "6.11.0",
-      "resolved": "https://registry.npmjs.org/@sentry/minimal/-/minimal-6.11.0.tgz",
-      "integrity": "sha512-XkZ7qrdlGp4IM/gjGxf1Q575yIbl5RvPbg+WFeekpo16Ufvzx37Mr8c2xsZaWosISVyE6eyFpooORjUlzy8EDw==",
-      "dev": true,
+      "version": "6.19.6",
+      "resolved": "https://registry.npmjs.org/@sentry/minimal/-/minimal-6.19.6.tgz",
+      "integrity": "sha512-T1NKcv+HTlmd8EbzUgnGPl4ySQGHWMCyZ8a8kXVMZOPDzphN3fVIzkYzWmSftCWp0rpabXPt9aRF2mfBKU+mAQ==",
       "requires": {
-        "@sentry/hub": "6.11.0",
-        "@sentry/types": "6.11.0",
+        "@sentry/hub": "6.19.6",
+        "@sentry/types": "6.19.6",
         "tslib": "^1.9.3"
       },
       "dependencies": {
         "tslib": {
           "version": "1.14.1",
           "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-          "dev": true
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
         }
       }
     },
     "@sentry/types": {
-      "version": "6.11.0",
-      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-6.11.0.tgz",
-      "integrity": "sha512-gm5H9eZhL6bsIy/h3T+/Fzzz2vINhHhqd92CjHle3w7uXdTdFV98i2pDpErBGNTSNzbntqOMifYEB5ENtZAvcg==",
-      "dev": true
+      "version": "6.19.6",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-6.19.6.tgz",
+      "integrity": "sha512-QH34LMJidEUPZK78l+Frt3AaVFJhEmIi05Zf8WHd9/iTt+OqvCHBgq49DDr1FWFqyYWm/QgW/3bIoikFpfsXyQ=="
     },
     "@sentry/utils": {
-      "version": "6.11.0",
-      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-6.11.0.tgz",
-      "integrity": "sha512-IOvyFHcnbRQxa++jO+ZUzRvFHEJ1cZjrBIQaNVc0IYF0twUOB5PTP6joTcix38ldaLeapaPZ9LGfudbvYvxkdg==",
-      "dev": true,
+      "version": "6.19.6",
+      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-6.19.6.tgz",
+      "integrity": "sha512-fAMWcsguL0632eWrROp/vhPgI7sBj/JROWVPzpabwVkm9z3m1rQm6iLFn4qfkZL8Ozy6NVZPXOQ7EXmeU24byg==",
       "requires": {
-        "@sentry/types": "6.11.0",
+        "@sentry/types": "6.19.6",
         "tslib": "^1.9.3"
       },
       "dependencies": {
         "tslib": {
           "version": "1.14.1",
           "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-          "dev": true
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
         }
       }
     },
@@ -42124,10 +41988,9 @@
       }
     },
     "@types/cookie": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.4.1.tgz",
-      "integrity": "sha512-XW/Aa8APYr6jSVVA1y/DEIZX0/GMKLEVekNG727R8cs56ahETkRAy/3DR7+fJyh7oUgGwNQaRfXCun0+KbWY7Q==",
-      "dev": true
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.5.0.tgz",
+      "integrity": "sha512-CJWHVHHupxBYfIlMM+qzXx4dRKIV1VzOm0cP3Wpqten8MDx1tK+y92YDXUshN1ONAfwodvKxDNkw35/pNs+izg=="
     },
     "@types/debug": {
       "version": "4.1.7",
@@ -42377,12 +42240,6 @@
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.6.tgz",
       "integrity": "sha512-PBjIUxZHOuj0R15/xuwJYjFi+KZdNFrehocChv4g5hu6aFroHue8m0lBP0POdK2nKzbw0cgV1mws8+V/JAcEkQ=="
-    },
-    "@types/uuid": {
-      "version": "8.3.1",
-      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-8.3.1.tgz",
-      "integrity": "sha512-Y2mHTRAbqfFkpjldbkHGY8JIzRN6XqYRliG8/24FcHm2D2PwW24fl5xMRTVGdrb7iMrwCaIEbLWerGIkXuFWVg==",
-      "dev": true
     },
     "@types/ws": {
       "version": "8.5.2",
@@ -42898,10 +42755,9 @@
         "@web3-storage/db": "^4.0.0",
         "@web3-storage/multipart-parser": "^1.0.0",
         "@web3-storage/tools": "^1.0.0",
-        "@web3-storage/toucan-js": "^2.7.1",
         "assert": "^2.0.0",
         "buffer": "^6.0.3",
-        "cardex": "*",
+        "cardex": "^1.0.0",
         "cborg": "^1.6.0",
         "delay": "^5.0.0",
         "dotenv": "^10.0.0",
@@ -42923,7 +42779,7 @@
         "stream": "^0.0.2",
         "stream-browserify": "^3.0.0",
         "stripe": "^10.7.0",
-        "toucan-js": "^2.4.1",
+        "toucan-js": "^2.7.0",
         "tweetnacl": "^1.0.3",
         "uint8arrays": "^3.0.0",
         "websocket": "^1.0.34"
@@ -43961,83 +43817,6 @@
               "dev": true
             }
           }
-        }
-      }
-    },
-    "@web3-storage/toucan-js": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/@web3-storage/toucan-js/-/toucan-js-2.7.1.tgz",
-      "integrity": "sha512-vLY985tJtc/jJvx43Xe+G6j0jpmO9W4rlsaa+etFLF9XWyqphXQ3hh6PyxFSsNtPrzyfRyIjGQRJN//xhUamew==",
-      "requires": {
-        "@sentry/core": "6.19.6",
-        "@sentry/hub": "6.19.6",
-        "@sentry/types": "6.19.6",
-        "@sentry/utils": "6.19.6",
-        "@types/cookie": "0.5.0",
-        "cookie": "0.5.0",
-        "stacktrace-js": "2.0.2"
-      },
-      "dependencies": {
-        "@sentry/core": {
-          "version": "6.19.6",
-          "resolved": "https://registry.npmjs.org/@sentry/core/-/core-6.19.6.tgz",
-          "integrity": "sha512-biEotGRr44/vBCOegkTfC9rwqaqRKIpFljKGyYU6/NtzMRooktqOhjmjmItNCMRknArdeaQwA8lk2jcZDXX3Og==",
-          "requires": {
-            "@sentry/hub": "6.19.6",
-            "@sentry/minimal": "6.19.6",
-            "@sentry/types": "6.19.6",
-            "@sentry/utils": "6.19.6",
-            "tslib": "^1.9.3"
-          }
-        },
-        "@sentry/hub": {
-          "version": "6.19.6",
-          "resolved": "https://registry.npmjs.org/@sentry/hub/-/hub-6.19.6.tgz",
-          "integrity": "sha512-PuEOBZxvx3bjxcXmWWZfWXG+orojQiWzv9LQXjIgroVMKM/GG4QtZbnWl1hOckUj7WtKNl4hEGO2g/6PyCV/vA==",
-          "requires": {
-            "@sentry/types": "6.19.6",
-            "@sentry/utils": "6.19.6",
-            "tslib": "^1.9.3"
-          }
-        },
-        "@sentry/minimal": {
-          "version": "6.19.6",
-          "resolved": "https://registry.npmjs.org/@sentry/minimal/-/minimal-6.19.6.tgz",
-          "integrity": "sha512-T1NKcv+HTlmd8EbzUgnGPl4ySQGHWMCyZ8a8kXVMZOPDzphN3fVIzkYzWmSftCWp0rpabXPt9aRF2mfBKU+mAQ==",
-          "requires": {
-            "@sentry/hub": "6.19.6",
-            "@sentry/types": "6.19.6",
-            "tslib": "^1.9.3"
-          }
-        },
-        "@sentry/types": {
-          "version": "6.19.6",
-          "resolved": "https://registry.npmjs.org/@sentry/types/-/types-6.19.6.tgz",
-          "integrity": "sha512-QH34LMJidEUPZK78l+Frt3AaVFJhEmIi05Zf8WHd9/iTt+OqvCHBgq49DDr1FWFqyYWm/QgW/3bIoikFpfsXyQ=="
-        },
-        "@sentry/utils": {
-          "version": "6.19.6",
-          "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-6.19.6.tgz",
-          "integrity": "sha512-fAMWcsguL0632eWrROp/vhPgI7sBj/JROWVPzpabwVkm9z3m1rQm6iLFn4qfkZL8Ozy6NVZPXOQ7EXmeU24byg==",
-          "requires": {
-            "@sentry/types": "6.19.6",
-            "tslib": "^1.9.3"
-          }
-        },
-        "@types/cookie": {
-          "version": "0.5.0",
-          "resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.5.0.tgz",
-          "integrity": "sha512-CJWHVHHupxBYfIlMM+qzXx4dRKIV1VzOm0cP3Wpqten8MDx1tK+y92YDXUshN1ONAfwodvKxDNkw35/pNs+izg=="
-        },
-        "cookie": {
-          "version": "0.5.0",
-          "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.5.0.tgz",
-          "integrity": "sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw=="
-        },
-        "tslib": {
-          "version": "1.14.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
         }
       }
     },
@@ -63464,27 +63243,23 @@
       "dev": true
     },
     "toucan-js": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/toucan-js/-/toucan-js-2.5.0.tgz",
-      "integrity": "sha512-kGC4aBI5ou0L6jIe+CqYxWjobknU7CTsgQOfHMFadSm8KLh/8f2oKgtqcmRB5Iysvai2/4vJDrFXqX/3K4iAjQ==",
-      "dev": true,
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/toucan-js/-/toucan-js-2.7.0.tgz",
+      "integrity": "sha512-vbvRbFfMLN2Jf9lOkwL1KwIwuCcS/ko0MVACZTYTnbdVlVjsIviwCU0inH0CRcMXCvFAS+uL8z/gSV3y7FpZUQ==",
       "requires": {
-        "@sentry/core": "6.11.0",
-        "@sentry/hub": "6.11.0",
-        "@sentry/types": "6.11.0",
-        "@sentry/utils": "6.11.0",
-        "@types/cookie": "0.4.1",
-        "@types/uuid": "8.3.1",
-        "cookie": "0.4.1",
-        "stacktrace-js": "2.0.2",
-        "uuid": "8.3.2"
+        "@sentry/core": "6.19.6",
+        "@sentry/hub": "6.19.6",
+        "@sentry/types": "6.19.6",
+        "@sentry/utils": "6.19.6",
+        "@types/cookie": "0.5.0",
+        "cookie": "0.5.0",
+        "stacktrace-js": "2.0.2"
       },
       "dependencies": {
         "cookie": {
-          "version": "0.4.1",
-          "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.1.tgz",
-          "integrity": "sha512-ZwrFkGJxUR3EIoXtO+yVE69Eb7KlixbaeAWfBQB9vVsNn/o+Yw69gBWSSDK825hQNdN+wF8zELf3dFNl/kxkUA==",
-          "dev": true
+          "version": "0.5.0",
+          "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.5.0.tgz",
+          "integrity": "sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw=="
         }
       }
     },

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -57,7 +57,6 @@
     "sade": "^1.8.1",
     "stream": "^0.0.2",
     "stream-browserify": "^3.0.0",
-    "toucan-js": "^2.4.1",
     "websocket": "^1.0.34"
   },
   "dependencies": {
@@ -71,7 +70,6 @@
     "@nftstorage/ipfs-cluster": "^5.0.1",
     "@web3-storage/db": "^4.0.0",
     "@web3-storage/multipart-parser": "^1.0.0",
-    "@web3-storage/toucan-js": "^2.7.1",
     "cardex": "^1.0.0",
     "cborg": "^1.6.0",
     "ipfs-car": "^0.7.0",
@@ -82,6 +80,7 @@
     "p-retry": "^5.1.1",
     "protobufjs": "^6.11.2",
     "stripe": "^10.7.0",
+    "toucan-js": "^2.7.0",
     "tweetnacl": "^1.0.3",
     "uint8arrays": "^3.0.0"
   },


### PR DESCRIPTION
The code was importing the old, unpatched version of `toucan-js`. The patch was in `@web3-storage/toucan-js`.

In the meantime, the original `toucan-js` project as adopted the fix to report error.cause, so we switch back and update our `toucan-js` dep here.

see: https://github.com/robertcepa/toucan-js/releases/tag/v2.7.0

License: MIT
Signed-off-by: Oli Evans <oli@protocol.ai>