### PR TITLE
perf: decouple user used storage sql function

### DIFF
--- a/packages/api/test/user.spec.js
+++ b/packages/api/test/user.spec.js
@@ -33,7 +33,7 @@ describe('GET /user/account', () => {
     assert(res.ok)
     const data = await res.json()
     assert.strictEqual(data.usedStorage.uploaded, 32000)
-    assert.strictEqual(data.usedStorage.psaPinned, 10000)
+    assert.strictEqual(data.usedStorage.psaPinned, 710000)
   })
 })
 

--- a/packages/db/postgres/migrations/030-decouple-user-used-storage.sql
+++ b/packages/db/postgres/migrations/030-decouple-user-used-storage.sql
@@ -1,0 +1,81 @@
+CREATE INDEX CONCURRENTLY IF NOT EXISTS psa_pin_request_search_idx ON psa_pin_request (auth_key_id) INCLUDE (content_cid, deleted_at);
+
+DROP INDEX IF EXISTS psa_pin_request_content_cid_idx;
+DROP INDEX IF EXISTS psa_pin_request_deleted_at_idx;
+
+CREATE OR REPLACE FUNCTION user_uploaded_storage(query_user_id BIGINT)
+  RETURNS text
+  LANGUAGE plpgsql
+AS
+$$
+DECLARE
+  total         BIGINT;
+BEGIN
+  total :=
+    (
+      SELECT COALESCE((
+        SELECT SUM(dag_size)
+        FROM (
+          SELECT  c.cid,
+                  c.dag_size
+          FROM upload u
+          JOIN content c ON c.cid = u.content_cid
+          WHERE u.user_id = query_user_id::BIGINT
+          AND u.deleted_at is null
+          GROUP BY c.cid,
+                  c.dag_size
+        ) AS uploaded_content), 0)
+    );
+  return (total)::TEXT;
+END
+$$;
+
+CREATE OR REPLACE FUNCTION user_psa_storage(query_user_id BIGINT)
+  RETURNS text
+  LANGUAGE plpgsql
+AS
+$$
+DECLARE
+  total         BIGINT;
+BEGIN
+  total :=
+    (
+      SELECT COALESCE((
+        SELECT SUM(dag_size)
+        FROM (
+          SELECT  psa_pr.content_cid,
+                  c.dag_size
+          FROM psa_pin_request psa_pr
+          JOIN content c ON c.cid = psa_pr.content_cid
+          JOIN auth_key a ON a.id = psa_pr.auth_key_id
+          WHERE a.user_id = query_user_id::BIGINT
+          AND psa_pr.deleted_at is null
+          GROUP BY psa_pr.content_cid,
+                  c.dag_size
+        ) AS pinned_content), 0)
+    );
+  return (total)::TEXT;
+END
+$$;
+
+CREATE OR REPLACE FUNCTION user_used_storage(query_user_id BIGINT)
+  RETURNS stored_bytes
+  LANGUAGE plpgsql
+AS
+$$
+DECLARE
+  used_storage  stored_bytes;
+  uploaded      BIGINT := (user_uploaded_storage(query_user_id))::BIGINT;
+  psa_pinned    BIGINT := (user_psa_storage(query_user_id))::BIGINT;
+  total         BIGINT;
+BEGIN
+  total := uploaded + psa_pinned;
+
+  SELECT  uploaded::TEXT,
+          psa_pinned::TEXT,
+          total::TEXT
+  INTO    used_storage;
+
+  return used_storage;
+END
+$$;

--- a/packages/db/postgres/tables.sql
+++ b/packages/db/postgres/tables.sql
@@ -323,8 +323,7 @@ CREATE TABLE IF NOT EXISTS psa_pin_request
   updated_at      TIMESTAMP WITH TIME ZONE DEFAULT timezone('utc'::text, now()) NOT NULL
 );
 
-CREATE INDEX IF NOT EXISTS psa_pin_request_content_cid_idx ON psa_pin_request (content_cid);
-CREATE INDEX IF NOT EXISTS psa_pin_request_deleted_at_idx ON psa_pin_request (deleted_at) INCLUDE (content_cid, auth_key_id);
+CREATE INDEX IF NOT EXISTS psa_pin_request_search_idx ON psa_pin_request (auth_key_id) INCLUDE (content_cid, deleted_at);
 
 CREATE TABLE IF NOT EXISTS agreement (
   id              BIGSERIAL PRIMARY KEY,

--- a/packages/db/test/user.spec.js
+++ b/packages/db/test/user.spec.js
@@ -1,7 +1,7 @@
 /* eslint-env mocha, browser */
 import assert from 'assert'
 import { DBClient } from '../index.js'
-import { createUpload, initialPinsNotPinned, pinsError, randomCid, token } from './utils.js'
+import { createUpload, token } from './utils.js'
 
 describe('user operations', () => {
   const name = 'test-name'
@@ -182,23 +182,6 @@ describe('user operations', () => {
     await createUpload(client, user._id, authKey._id, cid2, {
       dagSize: dagSize2
     })
-
-    // Create "Failed" Upload. It should not be counted.
-    const cid3 = await randomCid()
-    const dagSize3 = 100000
-    await createUpload(client, user._id, authKey._id, cid3, {
-      dagSize: dagSize3,
-      pins: pinsError
-    })
-
-    // Create Upload not pinned yet. It should not be counted yet.
-    await createUpload(client, user._id, authKey._id, await randomCid(), {
-      dagSize: 1000000,
-      pins: initialPinsNotPinned
-    })
-
-    const usedStorageWithFailed = await client.getStorageUsed(user._id)
-    assert.strictEqual(usedStorageWithFailed.uploaded, dagSize1 + dagSize2, 'used storage should not count unpinned')
 
     const secondUsedStorage = await client.getStorageUsed(user._id)
     assert.strictEqual(secondUsedStorage.uploaded, dagSize1 + dagSize2, 'used storage with second upload')

--- a/packages/db/test/utils.js
+++ b/packages/db/test/utils.js
@@ -127,36 +127,12 @@ export async function createUserWithFiles (dbClient, options = {}) {
   const pinRequests = 3
   const dagSize = Math.ceil(((percentStorageUsed / 100) * storageQuota) / (uploads + pinRequests))
 
-  // Create a failed upload.
-  await createUpload(dbClient, Number(user._id), Number(authKey), await randomCid(), {
-    dagSize,
-    pins: pinsError
-  })
-
-  // Create a yet to be pinned upload.
-  await createUpload(dbClient, Number(user._id), Number(authKey), await randomCid(), {
-    dagSize,
-    pins: initialPinsNotPinned
-  })
-
   for (let i = 0; i < uploads; i++) {
     const cid = await randomCid()
     await createUpload(dbClient, Number(user._id), Number(authKey), cid, {
       dagSize
     })
   }
-
-  // Create a failed PinRequest.
-  await createPsaPinRequest(dbClient, authKey, await randomCid(), {
-    dagSize,
-    pins: pinsError
-  })
-
-  // Create a yet to be pinned PinRequest.
-  await createPsaPinRequest(dbClient, authKey, await randomCid(), {
-    dagSize,
-    pins: initialPinsNotPinned
-  })
 
   for (let i = 0; i < pinRequests; i++) {
     const cid = await randomCid()

--- a/packages/db/utils.js
+++ b/packages/db/utils.js
@@ -122,3 +122,13 @@ export function parseTextToNumber (numberText) {
   }
   return num
 }
+
+/**
+ * @param {Number} num
+ */
+export function safeNumber (num) {
+  if (!Number.isSafeInteger(num)) {
+    throw new Error('Invalid integer number.')
+  }
+  return num
+}


### PR DESCRIPTION
This PR aims to optimize performance for calculating user used storage. It includes:
- decouple `user_used_storage` into 2 functions, one for regular uploads and other for psa
- both regular uploads and psa now ignore Pin status. If it is not Pinned, we won't know the dag size.
  - this should be a big boost given Pin table is by far the largest table we have
  - an accepted side effect by us is that non completed uploads that get stalled will be accounted
- changes psa sql indexes so that a sequential scan is avoided
  - seq_scan on psa_pin_request is done to check the deleted_at and to join with auth_key table
  - `psa_pin_request_search_idx` should perform better and includes the 3 columns used
  - other psa indexes were only used in this flow