### PR TITLE
feat: add metadata to upload error reports

### DIFF
--- a/packages/api/src/car.js
+++ b/packages/api/src/car.js
@@ -121,6 +121,7 @@ export async function handleCarUpload (request, env, ctx, car, uploadType = 'Car
   const carCid = CID.createV1(CAR_CODE, await sha256.digest(carBytes))
   const s3Key = `raw/${sourceCid}/${user._id}/${toString(carCid.multihash.bytes, 'base32')}.car`
   const r2Key = `${carCid}/${carCid}.car`
+  env.sentry?.setExtras({ sourceCid, carCid, dagSize, structure, s3Key, r2Key })
 
   await Promise.all([
     putToS3(env, s3Key, carBytes, carCid, sourceCid, structure),


### PR DESCRIPTION
add metadata to upload error reports in sentry so we can debug when we see an uptick in concurrent upload errors.

the `sentry.addExtras` function lets us set additional metadata on error reports and shows up like the screenshot below:
<img width="891" alt="Screenshot 2022-10-26 at 15 39 54" src="https://user-images.githubusercontent.com/58871/198059957-f4da68f9-26ab-4722-bf74-567dafc5a90f.png">

> setExtras: Set an object that will be merged sent as extra data with the event.
– https://github.com/robertcepa/toucan-js#features


License: MIT
Signed-off-by: Oli Evans <oli@protocol.ai>