### PR TITLE
fix: report carCid as string to sentry

### DIFF
--- a/packages/api/src/car.js
+++ b/packages/api/src/car.js
@@ -121,7 +121,7 @@ export async function handleCarUpload (request, env, ctx, car, uploadType = 'Car
   const carCid = CID.createV1(CAR_CODE, await sha256.digest(carBytes))
   const s3Key = `raw/${sourceCid}/${user._id}/${toString(carCid.multihash.bytes, 'base32')}.car`
   const r2Key = `${carCid}/${carCid}.car`
-  env.sentry?.setExtras({ sourceCid, carCid, dagSize, structure, s3Key, r2Key })
+  env.sentry?.setExtras({ sourceCid, carCid: carCid.toString(), dagSize, structure, s3Key, r2Key })
 
   await Promise.all([
     putToS3(env, s3Key, carBytes, carCid, sourceCid, structure),


### PR DESCRIPTION
dont report it as a CID object, as they look whack. e.g.

<img width="879" alt="Screenshot 2022-10-27 at 11 32 06" src="https://user-images.githubusercontent.com/58871/198262007-0b1c5480-2f4e-4c37-ad53-d3ec46bec051.png">


License: MIT
Signed-off-by: Oli Evans <oli@protocol.ai>