### PR TITLE
fix: ensure prod api deploy can only happen from main

### DIFF
--- a/.github/workflows/api.yml
+++ b/.github/workflows/api.yml
@@ -88,15 +88,6 @@ jobs:
       name: production
       url: https://web3.storage
     steps:
-      - uses: GoogleCloudPlatform/release-please-action@v3
-        id: tag-release
-        with:
-          path: packages/api
-          token: ${{ secrets.GITHUB_TOKEN }}
-          release-type: node
-          monorepo-tags: true
-          package-name: api
-          changelog-types: '[{"type":"feat","section":"Features","hidden":false},{"type":"fix","section":"Bug Fixes","hidden":false},{"type":"chore","section":"Other Changes","hidden":false}]'
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
         with:

--- a/.github/workflows/api.yml
+++ b/.github/workflows/api.yml
@@ -32,8 +32,26 @@ jobs:
           PG_REST_JWT: ${{secrets.PG_REST_JWT}}
           PG_CONNECTION: ${{secrets.PG_CONNECTION}}
 
+  changelog:
+    name: Changelog
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    needs: test
+    outputs:
+      releases_created: ${{ steps.tag-release.outputs.releases_created }}
+    steps:
+      - uses: GoogleCloudPlatform/release-please-action@v3
+        id: tag-release
+        with:
+          path: packages/api
+          token: ${{ secrets.GITHUB_TOKEN }}
+          release-type: node
+          monorepo-tags: true
+          package-name: api
+          changelog-types: '[{"type":"feat","section":"Features","hidden":false},{"type":"fix","section":"Bug Fixes","hidden":false},{"type":"chore","section":"Other Changes","hidden":false}]'
+
   deploy-staging:
-    name: Deploy Staging API
+    name: Deploy Staging
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     needs: test
@@ -58,10 +76,14 @@ jobs:
           npm run build -w packages/client
           echo "$(date --utc --iso-8601=seconds) web3.storage upload test" > ./upload-test-small
           ./packages/w3/bin.js put ./upload-test-small --api https://api-staging.web3.storage --token ${{ secrets.STAGING_WEB3_TOKEN }}
-  release:
-    name: Release
+  
+  deploy-production:
+    name: Deploy Production
+    if: (github.event_name == 'push' && github.ref == 'refs/heads/main' && needs.changelog.outputs.releases_created) || inputs.force_release
     runs-on: ubuntu-latest
-    needs: test
+    needs:
+      - test
+      - changelog
     environment:
       name: production
       url: https://web3.storage
@@ -76,17 +98,12 @@ jobs:
           package-name: api
           changelog-types: '[{"type":"feat","section":"Features","hidden":false},{"type":"fix","section":"Bug Fixes","hidden":false},{"type":"chore","section":"Other Changes","hidden":false}]'
       - uses: actions/checkout@v2
-        if: ${{ steps.tag-release.outputs.releases_created }}
       - uses: actions/setup-node@v2
-        if: ${{ steps.tag-release.outputs.releases_created }}
         with:
           node-version: '16'
           registry-url: https://registry.npmjs.org/
       - uses: bahmutov/npm-install@v1
-        if: ${{ steps.tag-release.outputs.releases_created }}
-      # --- API deploy steps -------------------------------------------------
       - name: API - Deploy to Cloudflare
-        if: ${{ steps.tag-release.outputs.releases_created }}
         uses: cloudflare/wrangler-action@2.0.0
         env:
           ENV: 'production' # inform the build process what the env is


### PR DESCRIPTION
Update the api workflow so that the prod deploy job only runs on main and if there is a release created flag from release_please

This brings the api workflow inline with the website one: https://github.com/web3-storage/web3.storage/blob/53e6da1dd62831f85735ed2b403427e731ee863d/.github/workflows/website.yml/#L242

this should prevent weird deploys happening just due to a timing error, and means we wont see a github deployment for non-main api builds... note: we will still lots of prod deploy builds as we also provide the production env to website builds, and github doesn't know about out api vs website distinction.

License: MIT
Signed-off-by: Oli Evans <oli@protocol.ai>