### PR TITLE
fix: remove web apps footer link

### DIFF
--- a/packages/website/content/pages/general.json
+++ b/packages/website/content/pages/general.json
@@ -222,10 +222,6 @@
         {
           "text": "HTTP API",
           "url": "/docs/reference/http-api/"
-        },
-        {
-          "text": "Web Apps",
-          "url": "/terms"
         }
       ]
     },


### PR DESCRIPTION
'web apps' in footer linked to terms, needed removal.