### PR TITLE
fix: do not render account blocked modal unless account restricted

### DIFF
--- a/packages/website/components/account/accountBlockedModal/accountBlockedModal.js
+++ b/packages/website/components/account/accountBlockedModal/accountBlockedModal.js
@@ -16,7 +16,7 @@ const AccountBlockedModal = ({ hasAccountRestriction }) => {
     }
   }, [hasAccountRestriction, modalState]);
 
-  return (
+  return modalState[0] ? (
     <div className="account-blocked-modal">
       <Modal
         className=""
@@ -40,7 +40,7 @@ const AccountBlockedModal = ({ hasAccountRestriction }) => {
         </div>
       </Modal>
     </div>
-  );
+  ) : null;
 };
 
 export default AccountBlockedModal;


### PR DESCRIPTION
Closes #1998 

There's a reported issue where the Account Blocked modal displays briefly when navigating the site.  I haven't yet been able to reproduce this, but currently this modal always renders (and is just hidden with CSS).  This PR is an optimization to prevent the modal from rendering at all.  It will hopefully resolve the issue, but it will also reduce the size of the prerendered HTML.