### PR TITLE
chore: add @web3-storage/website-codeowners to CODEOWNERS of /packages/website

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -7,3 +7,6 @@
 # github's syntax docs: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners#codeowners-syntax
 
 * @web3-storage/dag-house
+
+# @web3-storage/website is maintained by multiple teams
+/packages/website/  @web3-storage/dag-house @web3-storage/website-codeowners


### PR DESCRIPTION
Motivation:
* ensure tech leads for website initiative aren't blocked from merging PRs to main (e.g. to accept code into main branch or to merge release-please PRs)
* followup to #2047 
* https://www.notion.so/add-website-codeowners-team-to-web3-storage-CODEOWNERS-file-for-website-package-7b13982728364e0db4d4778ca21c5807

What:
* I created this `@web3-storage/website-codeowners` team in github: https://github.com/orgs/web3-storage/teams/website-codeowners
* I added @johnathonroach to it who is techleading the website ongoing log initiative
* This PR should make it so code changes to only the website can be approved by anyone in dag-house team or anyone in that website-codeowners team.

Potential followups
* propose/make any changes to who is in @web3-storage/website-codeowners team (I defer to @alanshaw and wider team)