### PR TITLE
fix: improve pins vs uploads experience on account page #2117 #1947

### DIFF
--- a/packages/website/components/account/filesManager/filesManager.scss
+++ b/packages/website/components/account/filesManager/filesManager.scss
@@ -192,7 +192,7 @@
   min-height: 23.4375rem;
 }
 
-.files-manager-upload-cta {
+.files-manager-table-message {
   @include fontWeight_Regular;
   @include fontSize_Medium;
   padding-left: 3.125rem;

--- a/packages/website/components/account/filesManager/pinRequestsTable.js
+++ b/packages/website/components/account/filesManager/pinRequestsTable.js
@@ -26,7 +26,7 @@ import GradientBackground from '../../gradientbackground/gradientbackground.js';
  * @param {PinRequestsTableProps} props
  */
 const PinRequestsTable = ({ content, hidden, onUpdatingChange, showCheckOverlay }) => {
-  const { pinRequests, pages, fetchDate, getPinRequests, isFetching, deletePinRequest } = usePinRequests();
+  const { pinRequests, pages, fetchDate, getPinRequests, isFetching, deletePinRequest, count } = usePinRequests();
   const {
     storageData: { refetch },
   } = useUser();
@@ -159,42 +159,46 @@ const PinRequestsTable = ({ content, hidden, onUpdatingChange, showCheckOverlay 
           }}
         />
       </div>
-      <PinRequestRowItem
-        onSelect={onSelectAllToggle}
-        date={fileRowLabels.date.label}
-        name={fileRowLabels.name.label}
-        cid={fileRowLabels.cid.label}
-        requestid={fileRowLabels.requestid.label}
-        status={fileRowLabels.status.label}
-        linkPrefix={linkPrefix}
-        isHeader
-        isSelected={
-          !!selectedPinRequests.length &&
-          pinRequests.every(file => selectedPinRequests.find(fileSelected => file === fileSelected)) &&
-          !!fetchDate
-        }
-      />
       <div className="files-manager-table-content">
         {isFetching || !fetchDate ? (
           <Loading className={'files-loading-spinner'} />
+        ) : !count ? (
+          <span className="files-manager-table-message">{content?.table.pins_message}</span>
         ) : (
-          pinRequests.map(item => (
+          <>
             <PinRequestRowItem
-              key={item.requestid}
-              onSelect={() => onPinRequestSelect(item)}
-              date={item.created}
-              name={item.pin.name || 'No Name'}
-              cid={item.pin.cid}
-              requestid={item.requestid}
-              status={item.status}
+              onSelect={onSelectAllToggle}
+              date={fileRowLabels.date.label}
+              name={fileRowLabels.name.label}
+              cid={fileRowLabels.cid.label}
+              requestid={fileRowLabels.requestid.label}
+              status={fileRowLabels.status.label}
               linkPrefix={linkPrefix}
-              isSelected={!!selectedPinRequests.find(fileSelected => fileSelected === item)}
-              onDelete={() => onDeleteSingle(item.requestid)}
+              isHeader
+              isSelected={
+                !!selectedPinRequests.length &&
+                pinRequests.every(file => selectedPinRequests.find(fileSelected => file === fileSelected)) &&
+                !!fetchDate
+              }
             />
-          ))
+            {pinRequests.map(item => (
+              <PinRequestRowItem
+                key={item.requestid}
+                onSelect={() => onPinRequestSelect(item)}
+                date={item.created}
+                name={item.pin.name || 'No Name'}
+                cid={item.pin.cid}
+                requestid={item.requestid}
+                status={item.status}
+                linkPrefix={linkPrefix}
+                isSelected={!!selectedPinRequests.find(fileSelected => fileSelected === item)}
+                onDelete={() => onDeleteSingle(item.requestid)}
+              />
+            ))}
+          </>
         )}
       </div>
-      {!!pinRequests.length && (
+      {!!count && (
         <div className="files-manager-footer">
           <button
             className={clsx('delete', !selectedPinRequests.length && 'disabled')}

--- a/packages/website/components/account/filesManager/uploadsTable.js
+++ b/packages/website/components/account/filesManager/uploadsTable.js
@@ -428,7 +428,7 @@ const UploadsTable = ({ content, hidden, onFileUpload, onUpdatingChange, showChe
         onSelectAll={onSelectAllToggle}
         onDelete={onDeleteSingle}
         emptyState={
-          <span className="files-manager-upload-cta">
+          <span className="files-manager-table-message">
             {content?.table.message}
             {'\u00A0'}
             <Button

--- a/packages/website/components/contexts/userContext.js
+++ b/packages/website/components/contexts/userContext.js
@@ -2,12 +2,13 @@ import React from 'react';
 import { useQuery } from 'react-query';
 
 import { getInfo, getStorage } from 'lib/api.js';
-import { useAuthorization } from './authorizationContext.js';
 import AccountBlockedModal from 'components/account/accountBlockedModal/accountBlockedModal.js';
+import { useAuthorization } from './authorizationContext.js';
 
 /**
  * @typedef Tags
  * @property {boolean} [HasAccountRestriction]
+ * @property {boolean} [HasPsaAccess]
  */
 
 /**

--- a/packages/website/content/pages/app/account.json
+++ b/packages/website/content/pages/app/account.json
@@ -110,6 +110,7 @@
           "action": "Upload File",
           "accountRestrictedText": "You are unable to upload files when your account is blocked. Please contact support@web3.storage"
         },
+        "pins_message": "You don't have any files pinned yet.",
         "file_row_labels": {
           "date": {
             "label": "Date"


### PR DESCRIPTION
Please also see https://github.com/web3-storage/web3.storage/issues/1947 for reference.

This PR: 
- avoids fetching pin requests when the user does not have PSA access enabled (see https://github.com/web3-storage/web3.storage/issues/2117)
- displays pinning table in the user account page if the user has PSA access, even though there's 0 pins currently, so that the user is aware they can access the pinning service
-  fixes bug where the table tab is selected based on the param `?table=pinned`: the previous implementation was not waiting until the pin request was done, hence removing the param and not selecting the table. This PR fixes it by checking if the user has PSA access enabled and setting the tab accordingly.