### PR TITLE
feat: listen for "Enter" key on login input field

### DIFF
--- a/packages/website/pages/login/index.js
+++ b/packages/website/pages/login/index.js
@@ -91,6 +91,7 @@ const Login = () => {
             className={clsx('login-email', errors.email && 'error')}
             placeholder={pageContent.form_placeholder}
             onChange={useCallback(e => setFormData({ email: e.currentTarget.value }), [])}
+            onKeyDown={e => e.key === 'Enter' && onLoginWithEmail()}
           />
           <Button
             variant={pageContent.cta.theme}


### PR DESCRIPTION
This closes #2143 by adding an `onKeyDown` handler to the email input field on the login form. If the Enter key was pressed, it calls `onLoginWithEmail` to trigger the login request.