### PR TITLE
fix: bump 'playwright' version & fix intermittent e2e test failure

### DIFF
--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -116,7 +116,7 @@ jobs:
 
       # add playwright-report to web3.storage
       - name: add playwright-report to web3.storage
-        if: inputs.add_playwright_report_to_web3_storage && steps.check_website_playwright_report.outputs.files_exists == 'true'
+        if: ${{ inputs.add_playwright_report_to_web3_storage }} && steps.check_website_playwright_report.outputs.files_exists == 'true'
         uses: web3-storage/add-to-web3@v2
         id: add_playwright_report_to_web3_storage
         with:

--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -88,7 +88,7 @@ jobs:
 
       - run: npx playwright install --with-deps ${{ matrix.browser }}
         working-directory: packages/website
-      
+
       # run e2e tests
       - id: website_test_e2e
         continue-on-error: true # when this fails, we still want to do some cleanup
@@ -116,7 +116,7 @@ jobs:
 
       # add playwright-report to web3.storage
       - name: add playwright-report to web3.storage
-        if: ${{ inputs.add_playwright_report_to_web3_storage }} && steps.check_website_playwright_report.outputs.files_exists == 'true'
+        if: inputs.add_playwright_report_to_web3_storage && steps.check_website_playwright_report.outputs.files_exists == 'true'
         uses: web3-storage/add-to-web3@v2
         id: add_playwright_report_to_web3_storage
         with:
@@ -261,7 +261,7 @@ jobs:
     if: (github.event_name == 'push' && github.ref == 'refs/heads/main' && needs.changelog.outputs.releases_created) || inputs.force_release
     name: Release
     runs-on: ubuntu-latest
-    environment: 
+    environment:
       name: production
       url: https://web3.storage
     needs:

--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -95,7 +95,7 @@ jobs:
         run: xvfb-run --auto-servernum --server-args="-screen 0 1280x960x24" -- node -r dotenv/config $(which npm) run -w @web3-storage/website test:e2e -- --project=${{ matrix.browser }} --reporter=html
         env:
           # Timeout is in milliseconds
-          PLAYWRIGHT_TIMEOUT: 360000
+          PLAYWRIGHT_TIMEOUT: 120000
           NEXT_PUBLIC_MAGIC: ${{ secrets.STAGING_MAGIC_PUBLIC_KEY }}
           MAGIC_SECRET_KEY: ${{ secrets.STAGING_MAGIC_SECRET_KEY }}
           NEXT_PUBLIC_MAGIC_TESTMODE_ENABLED: "true"

--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -94,7 +94,8 @@ jobs:
         continue-on-error: true # when this fails, we still want to do some cleanup
         run: xvfb-run --auto-servernum --server-args="-screen 0 1280x960x24" -- node -r dotenv/config $(which npm) run -w @web3-storage/website test:e2e -- --project=${{ matrix.browser }} --reporter=html
         env:
-          PLAYWRIGHT_TIMEOUT: 120000
+          # Timeout is in milliseconds
+          PLAYWRIGHT_TIMEOUT: 360000
           NEXT_PUBLIC_MAGIC: ${{ secrets.STAGING_MAGIC_PUBLIC_KEY }}
           MAGIC_SECRET_KEY: ${{ secrets.STAGING_MAGIC_SECRET_KEY }}
           NEXT_PUBLIC_MAGIC_TESTMODE_ENABLED: "true"

--- a/package-lock.json
+++ b/package-lock.json
@@ -12293,6 +12293,29 @@
         "pend": "~1.2.0"
       }
     },
+    "node_modules/fetch-blob": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
+      "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "dependencies": {
+        "node-domexception": "^1.0.0",
+        "web-streams-polyfill": "^3.0.3"
+      },
+      "engines": {
+        "node": "^12.20 || >= 14.13"
+      }
+    },
     "node_modules/file-entry-cache": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
@@ -12616,6 +12639,18 @@
       "integrity": "sha512-EFRDrsMm/kyqbTQocNvRXMLjc7Es2Vk+IQFx/YW7hkUH1eBl4J1fqiP34l74Yt0pFLCNpc06fkbVk00008mzjg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/formdata-polyfill": {
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
+      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
+      "dev": true,
+      "dependencies": {
+        "fetch-blob": "^3.1.2"
+      },
+      "engines": {
+        "node": ">=12.20.0"
+      }
     },
     "node_modules/forwarded": {
       "version": "0.2.0",
@@ -19595,6 +19630,25 @@
       "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-2.0.2.tgz",
       "integrity": "sha512-Ntyt4AIXyaLIuMHF6IOoTakB3K+RWxwtsHNRxllEoA6vPwP9o4866g6YWDLUdnucilZhmkxiHwHr11gAENw+QA==",
       "license": "MIT"
+    },
+    "node_modules/node-domexception": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "github",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "engines": {
+        "node": ">=10.5.0"
+      }
     },
     "node_modules/node-fetch": {
       "version": "2.6.7",
@@ -31522,6 +31576,7 @@
         "husky": "^8.0.0",
         "lint-staged": "^12.2.4",
         "next-sitemap": "1.6.173",
+        "node-fetch": "3.3.0",
         "prettier": "2.4.1",
         "react-query": "3.33.5",
         "sass": "1.43.4",
@@ -36427,6 +36482,33 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/postcss/"
+      }
+    },
+    "packages/website/node_modules/node-fetch": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.0.tgz",
+      "integrity": "sha512-BKwRP/O0UvoMKp7GNdwPlObhYGB5DQqwhEDQlNKuoqwVYSxkSZCSbHjnFFmUEtwSKRPU4kNK8PbDYYitwaE3QA==",
+      "dev": true,
+      "dependencies": {
+        "data-uri-to-buffer": "^4.0.0",
+        "fetch-blob": "^3.1.4",
+        "formdata-polyfill": "^4.0.10"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/node-fetch"
+      }
+    },
+    "packages/website/node_modules/node-fetch/node_modules/data-uri-to-buffer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.0.tgz",
+      "integrity": "sha512-Vr3mLBA8qWmcuschSLAOogKgQ/Jwxulv3RNE4FXnYWRGujzrRWQI4m12fQqRkwX06C0KanhLr4hK+GydchZsaA==",
+      "dev": true,
+      "engines": {
+        "node": ">= 12"
       }
     },
     "packages/website/node_modules/node-libs-browser": {
@@ -44744,6 +44826,7 @@
         "next-optimized-images": "^2.6.2",
         "next-sitemap": "1.6.173",
         "nextra": "^2.0.0-beta.5",
+        "node-fetch": "3.3.0",
         "p-map": "^5.1.0",
         "prettier": "2.4.1",
         "pretty-bytes": "^5.6.0",
@@ -48235,6 +48318,25 @@
             "@corex/deepmerge": "^2.6.34",
             "matcher": "^4.0.0",
             "minimist": "^1.2.5"
+          }
+        },
+        "node-fetch": {
+          "version": "3.3.0",
+          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.0.tgz",
+          "integrity": "sha512-BKwRP/O0UvoMKp7GNdwPlObhYGB5DQqwhEDQlNKuoqwVYSxkSZCSbHjnFFmUEtwSKRPU4kNK8PbDYYitwaE3QA==",
+          "dev": true,
+          "requires": {
+            "data-uri-to-buffer": "^4.0.0",
+            "fetch-blob": "^3.1.4",
+            "formdata-polyfill": "^4.0.10"
+          },
+          "dependencies": {
+            "data-uri-to-buffer": {
+              "version": "4.0.0",
+              "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.0.tgz",
+              "integrity": "sha512-Vr3mLBA8qWmcuschSLAOogKgQ/Jwxulv3RNE4FXnYWRGujzrRWQI4m12fQqRkwX06C0KanhLr4hK+GydchZsaA==",
+              "dev": true
+            }
           }
         },
         "node-libs-browser": {
@@ -54271,6 +54373,16 @@
         "pend": "~1.2.0"
       }
     },
+    "fetch-blob": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
+      "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
+      "dev": true,
+      "requires": {
+        "node-domexception": "^1.0.0",
+        "web-streams-polyfill": "^3.0.3"
+      }
+    },
     "file-entry-cache": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
@@ -54489,6 +54601,15 @@
       "resolved": "https://registry.npmjs.org/form-data-encoder/-/form-data-encoder-1.7.1.tgz",
       "integrity": "sha512-EFRDrsMm/kyqbTQocNvRXMLjc7Es2Vk+IQFx/YW7hkUH1eBl4J1fqiP34l74Yt0pFLCNpc06fkbVk00008mzjg==",
       "dev": true
+    },
+    "formdata-polyfill": {
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
+      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
+      "dev": true,
+      "requires": {
+        "fetch-blob": "^3.1.2"
+      }
     },
     "forwarded": {
       "version": "0.2.0",
@@ -59188,6 +59309,12 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-2.0.2.tgz",
       "integrity": "sha512-Ntyt4AIXyaLIuMHF6IOoTakB3K+RWxwtsHNRxllEoA6vPwP9o4866g6YWDLUdnucilZhmkxiHwHr11gAENw+QA=="
+    },
+    "node-domexception": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+      "dev": true
     },
     "node-fetch": {
       "version": "2.6.7",

--- a/package-lock.json
+++ b/package-lock.json
@@ -3479,6 +3479,8 @@
     },
     "node_modules/@cspotcode/source-map-support": {
       "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3571,6 +3573,8 @@
     },
     "node_modules/@fortawesome/fontawesome-common-types": {
       "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-6.1.2.tgz",
+      "integrity": "sha512-wBaAPGz1Awxg05e0PBRkDRuTsy4B3dpBm+zreTTyd9TH4uUM27cAL4xWyWR0rLJCrRwzVsQ4hF3FvM6rqydKPA==",
       "hasInstallScript": true,
       "license": "MIT",
       "engines": {
@@ -3579,6 +3583,8 @@
     },
     "node_modules/@fortawesome/fontawesome-svg-core": {
       "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-6.1.2.tgz",
+      "integrity": "sha512-853G/Htp0BOdXnPoeCPTjFrVwyrJHpe8MhjB/DYE9XjwhnNDfuBCd3aKc2YUYbEfHEcBws4UAA0kA9dymZKGjA==",
       "hasInstallScript": true,
       "license": "MIT",
       "peer": true,
@@ -3591,6 +3597,8 @@
     },
     "node_modules/@fortawesome/free-brands-svg-icons": {
       "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/@fortawesome/free-brands-svg-icons/-/free-brands-svg-icons-6.1.2.tgz",
+      "integrity": "sha512-b2eMfXQBsSxh52pcPtYchURQs6BWNh3zVTG8XH8Lv6V4kDhEg7D0kHN+K1SZniDiPb/e5tBlaygsinMUvetITA==",
       "hasInstallScript": true,
       "license": "(CC-BY-4.0 AND MIT)",
       "dependencies": {
@@ -3602,6 +3610,8 @@
     },
     "node_modules/@fortawesome/react-fontawesome": {
       "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@fortawesome/react-fontawesome/-/react-fontawesome-0.2.0.tgz",
+      "integrity": "sha512-uHg75Rb/XORTtVt7OS9WoK8uM276Ufi7gCzshVWkUJbHhh3svsUUeqXerrM96Wm7fRiDzfKRwSoahhMIkGAYHw==",
       "license": "MIT",
       "dependencies": {
         "prop-types": "^15.8.1"
@@ -3865,99 +3875,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/@jest/types": {
-      "version": "27.5.1",
-      "resolved": "https://registry.npmjs.org/@jest/types/-/types-27.5.1.tgz",
-      "integrity": "sha512-Cx46iJ9QpwQTjIdq5VJu2QTMMs3QlEjI0x1QbBP5W1+nMzyc2XmimiRR/CbX9TO0cPTeUlxWMOu8mslYsJ8DEw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/istanbul-lib-coverage": "^2.0.0",
-        "@types/istanbul-reports": "^3.0.0",
-        "@types/node": "*",
-        "@types/yargs": "^16.0.0",
-        "chalk": "^4.0.0"
-      },
-      "engines": {
-        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
-      }
-    },
-    "node_modules/@jest/types/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/@jest/types/node_modules/chalk": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "node_modules/@jest/types/node_modules/color-convert": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "color-name": "~1.1.4"
-      },
-      "engines": {
-        "node": ">=7.0.0"
-      }
-    },
-    "node_modules/@jest/types/node_modules/color-name": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@jest/types/node_modules/has-flag": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@jest/types/node_modules/supports-color": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/@jridgewell/resolve-uri": {
       "version": "3.0.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.0.5.tgz",
@@ -3975,6 +3892,8 @@
     },
     "node_modules/@jridgewell/trace-mapping": {
       "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
       "license": "MIT",
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.0.3",
@@ -4584,233 +4503,31 @@
       }
     },
     "node_modules/@playwright/test": {
-      "version": "1.21.1",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.21.1.tgz",
-      "integrity": "sha512-XkkTXl5gvEm4fciqeHvY5IuSS/OfQef0MO6RpBNmtm6EuYSdtUvP/sDVuWRKsDqyVdB3WSA0az7iSw79f2//JQ==",
+      "version": "1.28.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.28.1.tgz",
+      "integrity": "sha512-xN6spdqrNlwSn9KabIhqfZR7IWjPpFK1835tFNgjrlysaSezuX8PYUwaz38V/yI8TJLG9PkAMEXoHRXYXlpTPQ==",
       "dev": true,
-      "license": "Apache-2.0",
       "dependencies": {
-        "@babel/code-frame": "7.16.7",
-        "@babel/core": "7.16.12",
-        "@babel/helper-plugin-utils": "7.16.7",
-        "@babel/plugin-proposal-class-properties": "7.16.7",
-        "@babel/plugin-proposal-dynamic-import": "7.16.7",
-        "@babel/plugin-proposal-export-namespace-from": "7.16.7",
-        "@babel/plugin-proposal-logical-assignment-operators": "7.16.7",
-        "@babel/plugin-proposal-nullish-coalescing-operator": "7.16.7",
-        "@babel/plugin-proposal-numeric-separator": "7.16.7",
-        "@babel/plugin-proposal-optional-chaining": "7.16.7",
-        "@babel/plugin-proposal-private-methods": "7.16.11",
-        "@babel/plugin-proposal-private-property-in-object": "7.16.7",
-        "@babel/plugin-syntax-async-generators": "7.8.4",
-        "@babel/plugin-syntax-json-strings": "7.8.3",
-        "@babel/plugin-syntax-object-rest-spread": "7.8.3",
-        "@babel/plugin-syntax-optional-catch-binding": "7.8.3",
-        "@babel/plugin-transform-modules-commonjs": "7.16.8",
-        "@babel/preset-typescript": "7.16.7",
-        "colors": "1.4.0",
-        "commander": "8.3.0",
-        "debug": "4.3.3",
-        "expect": "27.2.5",
-        "jest-matcher-utils": "27.2.5",
-        "json5": "2.2.1",
-        "mime": "3.0.0",
-        "minimatch": "3.0.4",
-        "ms": "2.1.3",
-        "open": "8.4.0",
-        "pirates": "4.0.4",
-        "playwright-core": "1.21.1",
-        "rimraf": "3.0.2",
-        "source-map-support": "0.4.18",
-        "stack-utils": "2.0.5",
-        "yazl": "2.5.1"
+        "@types/node": "*",
+        "playwright-core": "1.28.1"
       },
       "bin": {
         "playwright": "cli.js"
       },
       "engines": {
-        "node": ">=12"
+        "node": ">=14"
       }
-    },
-    "node_modules/@playwright/test/node_modules/@babel/core": {
-      "version": "7.16.12",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.16.12.tgz",
-      "integrity": "sha512-dK5PtG1uiN2ikk++5OzSYsitZKny4wOCD0nrO4TqnW4BVBTQ2NGS3NgilvT/TEyxTST7LNyWV/T4tXDoD3fOgg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/code-frame": "^7.16.7",
-        "@babel/generator": "^7.16.8",
-        "@babel/helper-compilation-targets": "^7.16.7",
-        "@babel/helper-module-transforms": "^7.16.7",
-        "@babel/helpers": "^7.16.7",
-        "@babel/parser": "^7.16.12",
-        "@babel/template": "^7.16.7",
-        "@babel/traverse": "^7.16.10",
-        "@babel/types": "^7.16.8",
-        "convert-source-map": "^1.7.0",
-        "debug": "^4.1.0",
-        "gensync": "^1.0.0-beta.2",
-        "json5": "^2.1.2",
-        "semver": "^6.3.0",
-        "source-map": "^0.5.0"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/babel"
-      }
-    },
-    "node_modules/@playwright/test/node_modules/colors": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/colors/-/colors-1.4.0.tgz",
-      "integrity": "sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.1.90"
-      }
-    },
-    "node_modules/@playwright/test/node_modules/commander": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
-      "integrity": "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 12"
-      }
-    },
-    "node_modules/@playwright/test/node_modules/debug": {
-      "version": "4.3.3",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
-      "integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ms": "2.1.2"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@playwright/test/node_modules/debug/node_modules/ms": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@playwright/test/node_modules/json5": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.1.tgz",
-      "integrity": "sha512-1hqLFMSrGHRHxav9q9gNjJ5EXznIxGVO09xQRrwplcS8qs28pZ8s8hupZAmqDwZUmVZ2Qb2jnyPOWcDH8m8dlA==",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "json5": "lib/cli.js"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/@playwright/test/node_modules/ms": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/@playwright/test/node_modules/playwright-core": {
-      "version": "1.21.1",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.21.1.tgz",
-      "integrity": "sha512-SbK5dEsai9ZUKlxcinqegorBq4GnftXd4/GfW+pLsdQIQWrLCM/JNh6YQ2Rf2enVykXCejtoXW8L5vJXBBVSJQ==",
+      "version": "1.28.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.28.1.tgz",
+      "integrity": "sha512-3PixLnGPno0E8rSBJjtwqTwJe3Yw72QwBBBxNoukIj3lEeBNXwbNiKrNuB1oyQgTBw5QHUhNO3SteEtHaMK6ag==",
       "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "colors": "1.4.0",
-        "commander": "8.3.0",
-        "debug": "4.3.3",
-        "extract-zip": "2.0.1",
-        "https-proxy-agent": "5.0.0",
-        "jpeg-js": "0.4.3",
-        "mime": "3.0.0",
-        "pixelmatch": "5.2.1",
-        "pngjs": "6.0.0",
-        "progress": "2.0.3",
-        "proper-lockfile": "4.1.2",
-        "proxy-from-env": "1.1.0",
-        "rimraf": "3.0.2",
-        "socks-proxy-agent": "6.1.1",
-        "stack-utils": "2.0.5",
-        "ws": "8.4.2",
-        "yauzl": "2.10.0",
-        "yazl": "2.5.1"
-      },
       "bin": {
         "playwright": "cli.js"
       },
       "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@playwright/test/node_modules/pngjs": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-6.0.0.tgz",
-      "integrity": "sha512-TRzzuFRRmEoSW/p1KVAmiOgPco2Irlah+bGFCeNfJXxxYGwSw7YwAOAcd7X28K/m5bjBWKsC29KyoMfHbypayg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12.13.0"
-      }
-    },
-    "node_modules/@playwright/test/node_modules/semver": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      }
-    },
-    "node_modules/@playwright/test/node_modules/source-map-support": {
-      "version": "0.4.18",
-      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.18.tgz",
-      "integrity": "sha512-try0/JqxPLF9nOjvSta7tVondkP5dwgyLDjVoyMDlmjugT2lRZ1OfsrYTkCd2hkDnJTKRbO/Rl3orm8vlsUzbA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "source-map": "^0.5.6"
-      }
-    },
-    "node_modules/@playwright/test/node_modules/ws": {
-      "version": "8.4.2",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.4.2.tgz",
-      "integrity": "sha512-Kbk4Nxyq7/ZWqr/tarI9yIt/+iNNFOjBXEWgTb4ydaNHBNGgvf2QHbS9fdfsndfjFlFwEd4Al+mw83YkaD10ZA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=10.0.0"
-      },
-      "peerDependencies": {
-        "bufferutil": "^4.0.1",
-        "utf-8-validate": "^5.0.2"
-      },
-      "peerDependenciesMeta": {
-        "bufferutil": {
-          "optional": true
-        },
-        "utf-8-validate": {
-          "optional": true
-        }
+        "node": ">=14"
       }
     },
     "node_modules/@polka/url": {
@@ -5106,6 +4823,8 @@
     },
     "node_modules/@stripe/react-stripe-js": {
       "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@stripe/react-stripe-js/-/react-stripe-js-1.10.0.tgz",
+      "integrity": "sha512-vuIjJUZJ3nyiaGa5z5iyMCzZfGGsgzOOjWjqknbbhkNsewyyginfeky9EZLSz9+iSAsgC9K6MeNOTLKVGcMycQ==",
       "license": "MIT",
       "dependencies": {
         "prop-types": "^15.7.2"
@@ -5118,6 +4837,8 @@
     },
     "node_modules/@stripe/stripe-js": {
       "version": "1.35.0",
+      "resolved": "https://registry.npmjs.org/@stripe/stripe-js/-/stripe-js-1.35.0.tgz",
+      "integrity": "sha512-UIuzpbJqgXCTvJhY/aZYvBtaKdMfQgnIv6kkLlfRJ9smZcC4zoPvq3j7k9wobYI+idHAWP4BRiPnqA8lvzJCtg==",
       "license": "MIT"
     },
     "node_modules/@supabase/postgrest-js": {
@@ -5141,21 +4862,29 @@
     },
     "node_modules/@tsconfig/node10": {
       "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.9.tgz",
+      "integrity": "sha512-jNsYVVxU8v5g43Erja32laIDHXeoNvFEpX33OK4d6hljo3jDhCBDhx5dhCCTMWUojscpAagGiRkBKxpdl9fxqA==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@tsconfig/node12": {
       "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
+      "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@tsconfig/node14": {
       "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
+      "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@tsconfig/node16": {
       "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.3.tgz",
+      "integrity": "sha512-yOlFc+7UtL/89t2ZhjPvvB/DeAr3r+Dq58IgzsFkOAvVC6NMJXmCGjbptdXdR9qsX7pKcTL+s87FtYREi2dEEQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -5263,26 +4992,6 @@
       "integrity": "sha512-z/QT1XN4K4KYuslS23k62yDIDLwLFkzxOuMplDtObz0+y7VqJCaO2o+SPwHCvLFZh7xazvvoor2tA/hPz9ee7g==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/@types/istanbul-lib-report": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@types/istanbul-lib-report/-/istanbul-lib-report-3.0.0.tgz",
-      "integrity": "sha512-plGgXAPfVKFoYfa9NpYDAkseG+g6Jr294RqeqcqDixSbU34MZVJRi/P+7Y8GDpzkEwLaGZZOpKIEmeVZNtKsrg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/istanbul-lib-coverage": "*"
-      }
-    },
-    "node_modules/@types/istanbul-reports": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.1.tgz",
-      "integrity": "sha512-c3mAZEuK0lvBp8tmuL74XRKn1+y2dcwOUpH7x4WrF6gk1GIgiluDRgMYQtw2OFcBvAJWlt6ASU3tSqxp0Uu0Aw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/istanbul-lib-report": "*"
-      }
     },
     "node_modules/@types/json-buffer": {
       "version": "3.0.0",
@@ -5482,13 +5191,6 @@
       "integrity": "sha512-TgfOX+mGY/NyNxJLIbDWrO9DjGoVSW9+aB8H2yy1fy32jsvxijhmyJI9fDFgvz3YP4lvJaq9DzdR/M1bOgVc9g==",
       "dev": true
     },
-    "node_modules/@types/stack-utils": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.1.tgz",
-      "integrity": "sha512-Hl219/BT5fLAaz6NDkSuhzasy49dwQS/DSdu4MdggFB8zcXv7vflBI3xp7FEmkmdDkBUI2bPUNeMttp2knYdxw==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@types/unist": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.6.tgz",
@@ -5504,23 +5206,6 @@
       "dependencies": {
         "@types/node": "*"
       }
-    },
-    "node_modules/@types/yargs": {
-      "version": "16.0.4",
-      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-16.0.4.tgz",
-      "integrity": "sha512-T8Yc9wt/5LbJyCaLiHPReJa0kApcIgJ7Bn735GjItUfh08Z1pJvu8QZqb9s+mMvKV6WUQRV7K2R46YbjMXTTJw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/yargs-parser": "*"
-      }
-    },
-    "node_modules/@types/yargs-parser": {
-      "version": "21.0.0",
-      "resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-21.0.0.tgz",
-      "integrity": "sha512-iO9ZQHkZxHn4mSakYV0vFHAVDyEOIJQrV2uZ06HxEPcx+mt8swXoZHIbaaJ2crJYFfErySgktuTZ3BeLz+XmFA==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/@types/yauzl": {
       "version": "2.9.2",
@@ -5792,6 +5477,8 @@
     },
     "node_modules/@typescript-eslint/parser": {
       "version": "5.33.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.33.1.tgz",
+      "integrity": "sha512-IgLLtW7FOzoDlmaMoXdxG8HOCByTBXrB1V2ZQYSEV1ggMmJfAkMWTwUjjzagS6OkfpySyhKFkBw7A9jYmcHpZA==",
       "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
@@ -5836,6 +5523,8 @@
     },
     "node_modules/@typescript-eslint/scope-manager": {
       "version": "5.33.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.33.1.tgz",
+      "integrity": "sha512-8ibcZSqy4c5m69QpzJn8XQq9NnqAToC8OdH/W6IXPXv83vRyEDPYLdjAlUx8h/rbusq6MkW4YdQzURGOqsn3CA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5984,6 +5673,8 @@
     },
     "node_modules/@typescript-eslint/types": {
       "version": "5.33.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.33.1.tgz",
+      "integrity": "sha512-7K6MoQPQh6WVEkMrMW5QOA5FO+BOwzHSNd0j3+BlBwd6vtzfZceJ8xJ7Um2XDi/O3umS8/qDX6jdy2i7CijkwQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -5996,6 +5687,8 @@
     },
     "node_modules/@typescript-eslint/typescript-estree": {
       "version": "5.33.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.33.1.tgz",
+      "integrity": "sha512-JOAzJ4pJ+tHzA2pgsWQi4804XisPHOtbvwUyqsuuq8+y5B5GMZs7lI1xDWs6V2d7gE/Ez5bTGojSK12+IIPtXA==",
       "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
@@ -6222,6 +5915,8 @@
     },
     "node_modules/@typescript-eslint/visitor-keys": {
       "version": "5.33.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.33.1.tgz",
+      "integrity": "sha512-nwIxOK8Z2MPWltLKMLOEZwmfBZReqUdbEoHQXeCpa+sRVARe5twpJGHCB4dk9903Yaf0nMAlGbQfaAH92F60eg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6610,6 +6305,8 @@
     },
     "node_modules/acorn-walk": {
       "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.2.0.tgz",
+      "integrity": "sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -6938,6 +6635,8 @@
     },
     "node_modules/arg": {
       "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
+      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
       "dev": true,
       "license": "MIT"
     },
@@ -9335,6 +9034,8 @@
     },
     "node_modules/create-require": {
       "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
+      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -10162,16 +9863,6 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.3.1"
-      }
-    },
-    "node_modules/diff-sequences": {
-      "version": "27.5.1",
-      "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-27.5.1.tgz",
-      "integrity": "sha512-k1gCAXAsNgLwEL+Y8Wvl+M6oEFj5bgazfZULpS5CneoPPXRaCCW7dm+q21Ky2VEE5X+VeRDBVg1Pcvvsr4TtNQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
       }
     },
     "node_modules/diffie-hellman": {
@@ -12344,37 +12035,6 @@
       "license": "(MIT OR WTFPL)",
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/expect": {
-      "version": "27.2.5",
-      "resolved": "https://registry.npmjs.org/expect/-/expect-27.2.5.tgz",
-      "integrity": "sha512-ZrO0w7bo8BgGoP/bLz+HDCI+0Hfei9jUSZs5yI/Wyn9VkG9w8oJ7rHRgYj+MA7yqqFa0IwHA3flJzZtYugShJA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jest/types": "^27.2.5",
-        "ansi-styles": "^5.0.0",
-        "jest-get-type": "^27.0.6",
-        "jest-matcher-utils": "^27.2.5",
-        "jest-message-util": "^27.2.5",
-        "jest-regex-util": "^27.0.6"
-      },
-      "engines": {
-        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
-      }
-    },
-    "node_modules/expect/node_modules/ansi-styles": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
-      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/express": {
@@ -15751,314 +15411,6 @@
       "integrity": "sha512-VpAHeAN+/ABLqT/zEnwMomNCDh8eRrs06C8HRR8OxjVwGhXtvzoJbggjUnjAeNGxqjV4w7pp87Iu8jzEpr92fg==",
       "license": "MIT"
     },
-    "node_modules/jest-diff": {
-      "version": "27.5.1",
-      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-27.5.1.tgz",
-      "integrity": "sha512-m0NvkX55LDt9T4mctTEgnZk3fmEg3NRYutvMPWM/0iPnkFj2wIeF45O1718cMSOFO1vINkqmxqD8vE37uTEbqw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "chalk": "^4.0.0",
-        "diff-sequences": "^27.5.1",
-        "jest-get-type": "^27.5.1",
-        "pretty-format": "^27.5.1"
-      },
-      "engines": {
-        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
-      }
-    },
-    "node_modules/jest-diff/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/jest-diff/node_modules/chalk": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "node_modules/jest-diff/node_modules/color-convert": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "color-name": "~1.1.4"
-      },
-      "engines": {
-        "node": ">=7.0.0"
-      }
-    },
-    "node_modules/jest-diff/node_modules/color-name": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/jest-diff/node_modules/has-flag": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/jest-diff/node_modules/supports-color": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/jest-get-type": {
-      "version": "27.5.1",
-      "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-27.5.1.tgz",
-      "integrity": "sha512-2KY95ksYSaK7DMBWQn6dQz3kqAf3BB64y2udeG+hv4KfSOb9qwcYQstTJc1KCbsix+wLZWZYN8t7nwX3GOBLRw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
-      }
-    },
-    "node_modules/jest-matcher-utils": {
-      "version": "27.2.5",
-      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-27.2.5.tgz",
-      "integrity": "sha512-qNR/kh6bz0Dyv3m68Ck2g1fLW5KlSOUNcFQh87VXHZwWc/gY6XwnKofx76Qytz3x5LDWT09/2+yXndTkaG4aWg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "chalk": "^4.0.0",
-        "jest-diff": "^27.2.5",
-        "jest-get-type": "^27.0.6",
-        "pretty-format": "^27.2.5"
-      },
-      "engines": {
-        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
-      }
-    },
-    "node_modules/jest-matcher-utils/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/jest-matcher-utils/node_modules/chalk": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "node_modules/jest-matcher-utils/node_modules/color-convert": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "color-name": "~1.1.4"
-      },
-      "engines": {
-        "node": ">=7.0.0"
-      }
-    },
-    "node_modules/jest-matcher-utils/node_modules/color-name": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/jest-matcher-utils/node_modules/has-flag": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/jest-matcher-utils/node_modules/supports-color": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/jest-message-util": {
-      "version": "27.5.1",
-      "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-27.5.1.tgz",
-      "integrity": "sha512-rMyFe1+jnyAAf+NHwTclDz0eAaLkVDdKVHHBFWsBWHnnh5YeJMNWWsv7AbFYXfK3oTqvL7VTWkhNLu1jX24D+g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/code-frame": "^7.12.13",
-        "@jest/types": "^27.5.1",
-        "@types/stack-utils": "^2.0.0",
-        "chalk": "^4.0.0",
-        "graceful-fs": "^4.2.9",
-        "micromatch": "^4.0.4",
-        "pretty-format": "^27.5.1",
-        "slash": "^3.0.0",
-        "stack-utils": "^2.0.3"
-      },
-      "engines": {
-        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
-      }
-    },
-    "node_modules/jest-message-util/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/jest-message-util/node_modules/chalk": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "node_modules/jest-message-util/node_modules/color-convert": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "color-name": "~1.1.4"
-      },
-      "engines": {
-        "node": ">=7.0.0"
-      }
-    },
-    "node_modules/jest-message-util/node_modules/color-name": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/jest-message-util/node_modules/graceful-fs": {
-      "version": "4.2.10",
-      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.10.tgz",
-      "integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==",
-      "dev": true,
-      "license": "ISC"
-    },
-    "node_modules/jest-message-util/node_modules/has-flag": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/jest-message-util/node_modules/supports-color": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/jest-regex-util": {
-      "version": "27.5.1",
-      "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-27.5.1.tgz",
-      "integrity": "sha512-4bfKq2zie+x16okqDXjXn9ql2B0dScQu+vcwe4TvFVhkVyuWLqpZrZtXxLLWoXYgn0E87I6r6GRYHF7wFZBUvg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
-      }
-    },
     "node_modules/jest-worker": {
       "version": "27.5.1",
       "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-27.5.1.tgz",
@@ -16999,6 +16351,8 @@
     },
     "node_modules/make-error": {
       "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
+      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
       "dev": true,
       "license": "ISC"
     },
@@ -22085,39 +21439,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/pirates": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.4.tgz",
-      "integrity": "sha512-ZIrVPH+A52Dw84R0L3/VS9Op04PuQ2SEoJL6bkshmiTic/HldyW9Tf7oH5mhJZBK7NmDx27vSMrYEXPXclpDKw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/pixelmatch": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/pixelmatch/-/pixelmatch-5.2.1.tgz",
-      "integrity": "sha512-WjcAdYSnKrrdDdqTcVEY7aB7UhhwjYQKYhHiBXdJef0MOaQeYpUdQ+iVyBLa5YBKS8MPVPPMX7rpOByISLpeEQ==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "pngjs": "^4.0.1"
-      },
-      "bin": {
-        "pixelmatch": "bin/pixelmatch"
-      }
-    },
-    "node_modules/pixelmatch/node_modules/pngjs": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-4.0.1.tgz",
-      "integrity": "sha512-rf5+2/ioHeQxR6IxuYNYGFytUyG3lma/WW1nsmjeHlWwtb2aByla6dkVc8pmJ9nplzkTA0q2xx7mMWrOTqT4Gg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
     "node_modules/pkg-conf": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/pkg-conf/-/pkg-conf-3.1.0.tgz",
@@ -22775,41 +22096,6 @@
       "engines": {
         "node": ">=10.13.0"
       }
-    },
-    "node_modules/pretty-format": {
-      "version": "27.5.1",
-      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
-      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^5.0.1",
-        "ansi-styles": "^5.0.0",
-        "react-is": "^17.0.1"
-      },
-      "engines": {
-        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
-      }
-    },
-    "node_modules/pretty-format/node_modules/ansi-styles": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
-      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/pretty-format/node_modules/react-is": {
-      "version": "17.0.2",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
-      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/prettycli": {
       "version": "1.4.3",
@@ -26385,6 +25671,8 @@
     },
     "node_modules/ts-node": {
       "version": "10.9.1",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.1.tgz",
+      "integrity": "sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -26438,6 +25726,8 @@
     },
     "node_modules/ts-node/node_modules/diff": {
       "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
       "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
@@ -27565,6 +26855,8 @@
     },
     "node_modules/v8-compile-cache-lib": {
       "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
+      "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
       "dev": true,
       "license": "MIT"
     },
@@ -28755,6 +28047,8 @@
     },
     "node_modules/yn": {
       "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
+      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -32200,7 +31494,7 @@
       },
       "devDependencies": {
         "@next/eslint-plugin-next": "12.0.8",
-        "@playwright/test": "^1.20.2",
+        "@playwright/test": "^1.28.1",
         "@svgr/webpack": "^6.2.1",
         "@types/react": "17.0.36",
         "@types/react-dom": "17.0.11",
@@ -34069,6 +33363,8 @@
     },
     "packages/website/node_modules/debug": {
       "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
       "license": "MIT",
       "dependencies": {
         "ms": "2.1.2"
@@ -41629,6 +40925,8 @@
     },
     "@cspotcode/source-map-support": {
       "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
       "dev": true,
       "requires": {
         "@jridgewell/trace-mapping": "0.3.9"
@@ -41693,10 +40991,14 @@
       }
     },
     "@fortawesome/fontawesome-common-types": {
-      "version": "6.1.2"
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-6.1.2.tgz",
+      "integrity": "sha512-wBaAPGz1Awxg05e0PBRkDRuTsy4B3dpBm+zreTTyd9TH4uUM27cAL4xWyWR0rLJCrRwzVsQ4hF3FvM6rqydKPA=="
     },
     "@fortawesome/fontawesome-svg-core": {
       "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-6.1.2.tgz",
+      "integrity": "sha512-853G/Htp0BOdXnPoeCPTjFrVwyrJHpe8MhjB/DYE9XjwhnNDfuBCd3aKc2YUYbEfHEcBws4UAA0kA9dymZKGjA==",
       "peer": true,
       "requires": {
         "@fortawesome/fontawesome-common-types": "6.1.2"
@@ -41704,12 +41006,16 @@
     },
     "@fortawesome/free-brands-svg-icons": {
       "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/@fortawesome/free-brands-svg-icons/-/free-brands-svg-icons-6.1.2.tgz",
+      "integrity": "sha512-b2eMfXQBsSxh52pcPtYchURQs6BWNh3zVTG8XH8Lv6V4kDhEg7D0kHN+K1SZniDiPb/e5tBlaygsinMUvetITA==",
       "requires": {
         "@fortawesome/fontawesome-common-types": "6.1.2"
       }
     },
     "@fortawesome/react-fontawesome": {
       "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@fortawesome/react-fontawesome/-/react-fontawesome-0.2.0.tgz",
+      "integrity": "sha512-uHg75Rb/XORTtVt7OS9WoK8uM276Ufi7gCzshVWkUJbHhh3svsUUeqXerrM96Wm7fRiDzfKRwSoahhMIkGAYHw==",
       "requires": {
         "prop-types": "^15.8.1"
       }
@@ -41909,70 +41215,6 @@
       "integrity": "sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==",
       "dev": true
     },
-    "@jest/types": {
-      "version": "27.5.1",
-      "resolved": "https://registry.npmjs.org/@jest/types/-/types-27.5.1.tgz",
-      "integrity": "sha512-Cx46iJ9QpwQTjIdq5VJu2QTMMs3QlEjI0x1QbBP5W1+nMzyc2XmimiRR/CbX9TO0cPTeUlxWMOu8mslYsJ8DEw==",
-      "dev": true,
-      "requires": {
-        "@types/istanbul-lib-coverage": "^2.0.0",
-        "@types/istanbul-reports": "^3.0.0",
-        "@types/node": "*",
-        "@types/yargs": "^16.0.0",
-        "chalk": "^4.0.0"
-      },
-      "dependencies": {
-        "ansi-styles": {
-          "version": "4.3.0",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-          "dev": true,
-          "requires": {
-            "color-convert": "^2.0.1"
-          }
-        },
-        "chalk": {
-          "version": "4.1.2",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^4.1.0",
-            "supports-color": "^7.1.0"
-          }
-        },
-        "color-convert": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-          "dev": true,
-          "requires": {
-            "color-name": "~1.1.4"
-          }
-        },
-        "color-name": {
-          "version": "1.1.4",
-          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-          "dev": true
-        },
-        "has-flag": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-          "dev": true
-        },
-        "supports-color": {
-          "version": "7.2.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-          "dev": true,
-          "requires": {
-            "has-flag": "^4.0.0"
-          }
-        }
-      }
-    },
     "@jridgewell/resolve-uri": {
       "version": "3.0.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.0.5.tgz",
@@ -41985,6 +41227,8 @@
     },
     "@jridgewell/trace-mapping": {
       "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
       "requires": {
         "@jridgewell/resolve-uri": "^3.0.3",
         "@jridgewell/sourcemap-codec": "^1.4.10"
@@ -42411,164 +41655,20 @@
       }
     },
     "@playwright/test": {
-      "version": "1.21.1",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.21.1.tgz",
-      "integrity": "sha512-XkkTXl5gvEm4fciqeHvY5IuSS/OfQef0MO6RpBNmtm6EuYSdtUvP/sDVuWRKsDqyVdB3WSA0az7iSw79f2//JQ==",
+      "version": "1.28.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.28.1.tgz",
+      "integrity": "sha512-xN6spdqrNlwSn9KabIhqfZR7IWjPpFK1835tFNgjrlysaSezuX8PYUwaz38V/yI8TJLG9PkAMEXoHRXYXlpTPQ==",
       "dev": true,
       "requires": {
-        "@babel/code-frame": "7.16.7",
-        "@babel/core": "7.16.12",
-        "@babel/helper-plugin-utils": "7.16.7",
-        "@babel/plugin-proposal-class-properties": "7.16.7",
-        "@babel/plugin-proposal-dynamic-import": "7.16.7",
-        "@babel/plugin-proposal-export-namespace-from": "7.16.7",
-        "@babel/plugin-proposal-logical-assignment-operators": "7.16.7",
-        "@babel/plugin-proposal-nullish-coalescing-operator": "7.16.7",
-        "@babel/plugin-proposal-numeric-separator": "7.16.7",
-        "@babel/plugin-proposal-optional-chaining": "7.16.7",
-        "@babel/plugin-proposal-private-methods": "7.16.11",
-        "@babel/plugin-proposal-private-property-in-object": "7.16.7",
-        "@babel/plugin-syntax-async-generators": "7.8.4",
-        "@babel/plugin-syntax-json-strings": "7.8.3",
-        "@babel/plugin-syntax-object-rest-spread": "7.8.3",
-        "@babel/plugin-syntax-optional-catch-binding": "7.8.3",
-        "@babel/plugin-transform-modules-commonjs": "7.16.8",
-        "@babel/preset-typescript": "7.16.7",
-        "colors": "1.4.0",
-        "commander": "8.3.0",
-        "debug": "4.3.3",
-        "expect": "27.2.5",
-        "jest-matcher-utils": "27.2.5",
-        "json5": "2.2.1",
-        "mime": "3.0.0",
-        "minimatch": "3.0.4",
-        "ms": "2.1.3",
-        "open": "8.4.0",
-        "pirates": "4.0.4",
-        "playwright-core": "1.21.1",
-        "rimraf": "3.0.2",
-        "source-map-support": "0.4.18",
-        "stack-utils": "2.0.5",
-        "yazl": "2.5.1"
+        "@types/node": "*",
+        "playwright-core": "1.28.1"
       },
       "dependencies": {
-        "@babel/core": {
-          "version": "7.16.12",
-          "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.16.12.tgz",
-          "integrity": "sha512-dK5PtG1uiN2ikk++5OzSYsitZKny4wOCD0nrO4TqnW4BVBTQ2NGS3NgilvT/TEyxTST7LNyWV/T4tXDoD3fOgg==",
-          "dev": true,
-          "requires": {
-            "@babel/code-frame": "^7.16.7",
-            "@babel/generator": "^7.16.8",
-            "@babel/helper-compilation-targets": "^7.16.7",
-            "@babel/helper-module-transforms": "^7.16.7",
-            "@babel/helpers": "^7.16.7",
-            "@babel/parser": "^7.16.12",
-            "@babel/template": "^7.16.7",
-            "@babel/traverse": "^7.16.10",
-            "@babel/types": "^7.16.8",
-            "convert-source-map": "^1.7.0",
-            "debug": "^4.1.0",
-            "gensync": "^1.0.0-beta.2",
-            "json5": "^2.1.2",
-            "semver": "^6.3.0",
-            "source-map": "^0.5.0"
-          }
-        },
-        "colors": {
-          "version": "1.4.0",
-          "resolved": "https://registry.npmjs.org/colors/-/colors-1.4.0.tgz",
-          "integrity": "sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==",
-          "dev": true
-        },
-        "commander": {
-          "version": "8.3.0",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
-          "integrity": "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==",
-          "dev": true
-        },
-        "debug": {
-          "version": "4.3.3",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
-          "integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
-          "dev": true,
-          "requires": {
-            "ms": "2.1.2"
-          },
-          "dependencies": {
-            "ms": {
-              "version": "2.1.2",
-              "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-              "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-              "dev": true
-            }
-          }
-        },
-        "json5": {
-          "version": "2.2.1",
-          "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.1.tgz",
-          "integrity": "sha512-1hqLFMSrGHRHxav9q9gNjJ5EXznIxGVO09xQRrwplcS8qs28pZ8s8hupZAmqDwZUmVZ2Qb2jnyPOWcDH8m8dlA==",
-          "dev": true
-        },
-        "ms": {
-          "version": "2.1.3",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-          "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-          "dev": true
-        },
         "playwright-core": {
-          "version": "1.21.1",
-          "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.21.1.tgz",
-          "integrity": "sha512-SbK5dEsai9ZUKlxcinqegorBq4GnftXd4/GfW+pLsdQIQWrLCM/JNh6YQ2Rf2enVykXCejtoXW8L5vJXBBVSJQ==",
-          "dev": true,
-          "requires": {
-            "colors": "1.4.0",
-            "commander": "8.3.0",
-            "debug": "4.3.3",
-            "extract-zip": "2.0.1",
-            "https-proxy-agent": "5.0.0",
-            "jpeg-js": "0.4.3",
-            "mime": "3.0.0",
-            "pixelmatch": "5.2.1",
-            "pngjs": "6.0.0",
-            "progress": "2.0.3",
-            "proper-lockfile": "4.1.2",
-            "proxy-from-env": "1.1.0",
-            "rimraf": "3.0.2",
-            "socks-proxy-agent": "6.1.1",
-            "stack-utils": "2.0.5",
-            "ws": "8.4.2",
-            "yauzl": "2.10.0",
-            "yazl": "2.5.1"
-          }
-        },
-        "pngjs": {
-          "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-6.0.0.tgz",
-          "integrity": "sha512-TRzzuFRRmEoSW/p1KVAmiOgPco2Irlah+bGFCeNfJXxxYGwSw7YwAOAcd7X28K/m5bjBWKsC29KyoMfHbypayg==",
+          "version": "1.28.1",
+          "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.28.1.tgz",
+          "integrity": "sha512-3PixLnGPno0E8rSBJjtwqTwJe3Yw72QwBBBxNoukIj3lEeBNXwbNiKrNuB1oyQgTBw5QHUhNO3SteEtHaMK6ag==",
           "dev": true
-        },
-        "semver": {
-          "version": "6.3.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-          "dev": true
-        },
-        "source-map-support": {
-          "version": "0.4.18",
-          "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.18.tgz",
-          "integrity": "sha512-try0/JqxPLF9nOjvSta7tVondkP5dwgyLDjVoyMDlmjugT2lRZ1OfsrYTkCd2hkDnJTKRbO/Rl3orm8vlsUzbA==",
-          "dev": true,
-          "requires": {
-            "source-map": "^0.5.6"
-          }
-        },
-        "ws": {
-          "version": "8.4.2",
-          "resolved": "https://registry.npmjs.org/ws/-/ws-8.4.2.tgz",
-          "integrity": "sha512-Kbk4Nxyq7/ZWqr/tarI9yIt/+iNNFOjBXEWgTb4ydaNHBNGgvf2QHbS9fdfsndfjFlFwEd4Al+mw83YkaD10ZA==",
-          "dev": true,
-          "requires": {}
         }
       }
     },
@@ -42811,12 +41911,16 @@
     },
     "@stripe/react-stripe-js": {
       "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@stripe/react-stripe-js/-/react-stripe-js-1.10.0.tgz",
+      "integrity": "sha512-vuIjJUZJ3nyiaGa5z5iyMCzZfGGsgzOOjWjqknbbhkNsewyyginfeky9EZLSz9+iSAsgC9K6MeNOTLKVGcMycQ==",
       "requires": {
         "prop-types": "^15.7.2"
       }
     },
     "@stripe/stripe-js": {
-      "version": "1.35.0"
+      "version": "1.35.0",
+      "resolved": "https://registry.npmjs.org/@stripe/stripe-js/-/stripe-js-1.35.0.tgz",
+      "integrity": "sha512-UIuzpbJqgXCTvJhY/aZYvBtaKdMfQgnIv6kkLlfRJ9smZcC4zoPvq3j7k9wobYI+idHAWP4BRiPnqA8lvzJCtg=="
     },
     "@supabase/postgrest-js": {
       "version": "0.37.1",
@@ -42834,18 +41938,26 @@
     },
     "@tsconfig/node10": {
       "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.9.tgz",
+      "integrity": "sha512-jNsYVVxU8v5g43Erja32laIDHXeoNvFEpX33OK4d6hljo3jDhCBDhx5dhCCTMWUojscpAagGiRkBKxpdl9fxqA==",
       "dev": true
     },
     "@tsconfig/node12": {
       "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
+      "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
       "dev": true
     },
     "@tsconfig/node14": {
       "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
+      "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
       "dev": true
     },
     "@tsconfig/node16": {
       "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.3.tgz",
+      "integrity": "sha512-yOlFc+7UtL/89t2ZhjPvvB/DeAr3r+Dq58IgzsFkOAvVC6NMJXmCGjbptdXdR9qsX7pKcTL+s87FtYREi2dEEQ==",
       "dev": true
     },
     "@types/acorn": {
@@ -42941,24 +42053,6 @@
       "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.4.tgz",
       "integrity": "sha512-z/QT1XN4K4KYuslS23k62yDIDLwLFkzxOuMplDtObz0+y7VqJCaO2o+SPwHCvLFZh7xazvvoor2tA/hPz9ee7g==",
       "dev": true
-    },
-    "@types/istanbul-lib-report": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@types/istanbul-lib-report/-/istanbul-lib-report-3.0.0.tgz",
-      "integrity": "sha512-plGgXAPfVKFoYfa9NpYDAkseG+g6Jr294RqeqcqDixSbU34MZVJRi/P+7Y8GDpzkEwLaGZZOpKIEmeVZNtKsrg==",
-      "dev": true,
-      "requires": {
-        "@types/istanbul-lib-coverage": "*"
-      }
-    },
-    "@types/istanbul-reports": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.1.tgz",
-      "integrity": "sha512-c3mAZEuK0lvBp8tmuL74XRKn1+y2dcwOUpH7x4WrF6gk1GIgiluDRgMYQtw2OFcBvAJWlt6ASU3tSqxp0Uu0Aw==",
-      "dev": true,
-      "requires": {
-        "@types/istanbul-lib-report": "*"
-      }
     },
     "@types/json-buffer": {
       "version": "3.0.0",
@@ -43134,12 +42228,6 @@
       "integrity": "sha512-TgfOX+mGY/NyNxJLIbDWrO9DjGoVSW9+aB8H2yy1fy32jsvxijhmyJI9fDFgvz3YP4lvJaq9DzdR/M1bOgVc9g==",
       "dev": true
     },
-    "@types/stack-utils": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.1.tgz",
-      "integrity": "sha512-Hl219/BT5fLAaz6NDkSuhzasy49dwQS/DSdu4MdggFB8zcXv7vflBI3xp7FEmkmdDkBUI2bPUNeMttp2knYdxw==",
-      "dev": true
-    },
     "@types/unist": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.6.tgz",
@@ -43153,21 +42241,6 @@
       "requires": {
         "@types/node": "*"
       }
-    },
-    "@types/yargs": {
-      "version": "16.0.4",
-      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-16.0.4.tgz",
-      "integrity": "sha512-T8Yc9wt/5LbJyCaLiHPReJa0kApcIgJ7Bn735GjItUfh08Z1pJvu8QZqb9s+mMvKV6WUQRV7K2R46YbjMXTTJw==",
-      "dev": true,
-      "requires": {
-        "@types/yargs-parser": "*"
-      }
-    },
-    "@types/yargs-parser": {
-      "version": "21.0.0",
-      "resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-21.0.0.tgz",
-      "integrity": "sha512-iO9ZQHkZxHn4mSakYV0vFHAVDyEOIJQrV2uZ06HxEPcx+mt8swXoZHIbaaJ2crJYFfErySgktuTZ3BeLz+XmFA==",
-      "dev": true
     },
     "@types/yauzl": {
       "version": "2.9.2",
@@ -43312,6 +42385,8 @@
     },
     "@typescript-eslint/parser": {
       "version": "5.33.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.33.1.tgz",
+      "integrity": "sha512-IgLLtW7FOzoDlmaMoXdxG8HOCByTBXrB1V2ZQYSEV1ggMmJfAkMWTwUjjzagS6OkfpySyhKFkBw7A9jYmcHpZA==",
       "dev": true,
       "requires": {
         "@typescript-eslint/scope-manager": "5.33.1",
@@ -43333,6 +42408,8 @@
     },
     "@typescript-eslint/scope-manager": {
       "version": "5.33.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.33.1.tgz",
+      "integrity": "sha512-8ibcZSqy4c5m69QpzJn8XQq9NnqAToC8OdH/W6IXPXv83vRyEDPYLdjAlUx8h/rbusq6MkW4YdQzURGOqsn3CA==",
       "dev": true,
       "requires": {
         "@typescript-eslint/types": "5.33.1",
@@ -43410,10 +42487,14 @@
     },
     "@typescript-eslint/types": {
       "version": "5.33.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.33.1.tgz",
+      "integrity": "sha512-7K6MoQPQh6WVEkMrMW5QOA5FO+BOwzHSNd0j3+BlBwd6vtzfZceJ8xJ7Um2XDi/O3umS8/qDX6jdy2i7CijkwQ==",
       "dev": true
     },
     "@typescript-eslint/typescript-estree": {
       "version": "5.33.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.33.1.tgz",
+      "integrity": "sha512-JOAzJ4pJ+tHzA2pgsWQi4804XisPHOtbvwUyqsuuq8+y5B5GMZs7lI1xDWs6V2d7gE/Ez5bTGojSK12+IIPtXA==",
       "dev": true,
       "requires": {
         "@typescript-eslint/types": "5.33.1",
@@ -43539,6 +42620,8 @@
     },
     "@typescript-eslint/visitor-keys": {
       "version": "5.33.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.33.1.tgz",
+      "integrity": "sha512-nwIxOK8Z2MPWltLKMLOEZwmfBZReqUdbEoHQXeCpa+sRVARe5twpJGHCB4dk9903Yaf0nMAlGbQfaAH92F60eg==",
       "dev": true,
       "requires": {
         "@typescript-eslint/types": "5.33.1",
@@ -45619,7 +44702,7 @@
         "@magic-ext/oauth": "^0.7.0",
         "@mdx-js/react": "^2.1.1",
         "@next/eslint-plugin-next": "12.0.8",
-        "@playwright/test": "^1.20.2",
+        "@playwright/test": "^1.28.1",
         "@stripe/react-stripe-js": "^1.10.0",
         "@stripe/stripe-js": "^1.35.0",
         "@svgr/webpack": "^6.2.1",
@@ -46950,6 +46033,8 @@
         },
         "debug": {
           "version": "4.3.4",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+          "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
           "requires": {
             "ms": "2.1.2"
           }
@@ -50868,6 +49953,8 @@
     },
     "acorn-walk": {
       "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.2.0.tgz",
+      "integrity": "sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==",
       "dev": true
     },
     "agent-base": {
@@ -51112,6 +50199,8 @@
     },
     "arg": {
       "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
+      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
       "dev": true
     },
     "argparse": {
@@ -52865,6 +51954,8 @@
     },
     "create-require": {
       "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
+      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
       "dev": true
     },
     "cron-schedule": {
@@ -53445,12 +52536,6 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/diff/-/diff-5.0.0.tgz",
       "integrity": "sha512-/VTCrvm5Z0JGty/BWHljh+BAiw3IK+2j87NGMu8Nwc/f48WoDAC395uomO9ZD117ZOBaHmkX1oyLvkVM/aIT3w=="
-    },
-    "diff-sequences": {
-      "version": "27.5.1",
-      "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-27.5.1.tgz",
-      "integrity": "sha512-k1gCAXAsNgLwEL+Y8Wvl+M6oEFj5bgazfZULpS5CneoPPXRaCCW7dm+q21Ky2VEE5X+VeRDBVg1Pcvvsr4TtNQ==",
-      "dev": true
     },
     "diffie-hellman": {
       "version": "5.0.3",
@@ -54982,28 +54067,6 @@
       "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
       "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
       "dev": true
-    },
-    "expect": {
-      "version": "27.2.5",
-      "resolved": "https://registry.npmjs.org/expect/-/expect-27.2.5.tgz",
-      "integrity": "sha512-ZrO0w7bo8BgGoP/bLz+HDCI+0Hfei9jUSZs5yI/Wyn9VkG9w8oJ7rHRgYj+MA7yqqFa0IwHA3flJzZtYugShJA==",
-      "dev": true,
-      "requires": {
-        "@jest/types": "^27.2.5",
-        "ansi-styles": "^5.0.0",
-        "jest-get-type": "^27.0.6",
-        "jest-matcher-utils": "^27.2.5",
-        "jest-message-util": "^27.2.5",
-        "jest-regex-util": "^27.0.6"
-      },
-      "dependencies": {
-        "ansi-styles": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
-          "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
-          "dev": true
-        }
-      }
     },
     "express": {
       "version": "4.17.3",
@@ -57336,218 +56399,6 @@
       "resolved": "https://registry.npmjs.org/itty-router/-/itty-router-2.4.8.tgz",
       "integrity": "sha512-VpAHeAN+/ABLqT/zEnwMomNCDh8eRrs06C8HRR8OxjVwGhXtvzoJbggjUnjAeNGxqjV4w7pp87Iu8jzEpr92fg=="
     },
-    "jest-diff": {
-      "version": "27.5.1",
-      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-27.5.1.tgz",
-      "integrity": "sha512-m0NvkX55LDt9T4mctTEgnZk3fmEg3NRYutvMPWM/0iPnkFj2wIeF45O1718cMSOFO1vINkqmxqD8vE37uTEbqw==",
-      "dev": true,
-      "requires": {
-        "chalk": "^4.0.0",
-        "diff-sequences": "^27.5.1",
-        "jest-get-type": "^27.5.1",
-        "pretty-format": "^27.5.1"
-      },
-      "dependencies": {
-        "ansi-styles": {
-          "version": "4.3.0",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-          "dev": true,
-          "requires": {
-            "color-convert": "^2.0.1"
-          }
-        },
-        "chalk": {
-          "version": "4.1.2",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^4.1.0",
-            "supports-color": "^7.1.0"
-          }
-        },
-        "color-convert": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-          "dev": true,
-          "requires": {
-            "color-name": "~1.1.4"
-          }
-        },
-        "color-name": {
-          "version": "1.1.4",
-          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-          "dev": true
-        },
-        "has-flag": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-          "dev": true
-        },
-        "supports-color": {
-          "version": "7.2.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-          "dev": true,
-          "requires": {
-            "has-flag": "^4.0.0"
-          }
-        }
-      }
-    },
-    "jest-get-type": {
-      "version": "27.5.1",
-      "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-27.5.1.tgz",
-      "integrity": "sha512-2KY95ksYSaK7DMBWQn6dQz3kqAf3BB64y2udeG+hv4KfSOb9qwcYQstTJc1KCbsix+wLZWZYN8t7nwX3GOBLRw==",
-      "dev": true
-    },
-    "jest-matcher-utils": {
-      "version": "27.2.5",
-      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-27.2.5.tgz",
-      "integrity": "sha512-qNR/kh6bz0Dyv3m68Ck2g1fLW5KlSOUNcFQh87VXHZwWc/gY6XwnKofx76Qytz3x5LDWT09/2+yXndTkaG4aWg==",
-      "dev": true,
-      "requires": {
-        "chalk": "^4.0.0",
-        "jest-diff": "^27.2.5",
-        "jest-get-type": "^27.0.6",
-        "pretty-format": "^27.2.5"
-      },
-      "dependencies": {
-        "ansi-styles": {
-          "version": "4.3.0",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-          "dev": true,
-          "requires": {
-            "color-convert": "^2.0.1"
-          }
-        },
-        "chalk": {
-          "version": "4.1.2",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^4.1.0",
-            "supports-color": "^7.1.0"
-          }
-        },
-        "color-convert": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-          "dev": true,
-          "requires": {
-            "color-name": "~1.1.4"
-          }
-        },
-        "color-name": {
-          "version": "1.1.4",
-          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-          "dev": true
-        },
-        "has-flag": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-          "dev": true
-        },
-        "supports-color": {
-          "version": "7.2.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-          "dev": true,
-          "requires": {
-            "has-flag": "^4.0.0"
-          }
-        }
-      }
-    },
-    "jest-message-util": {
-      "version": "27.5.1",
-      "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-27.5.1.tgz",
-      "integrity": "sha512-rMyFe1+jnyAAf+NHwTclDz0eAaLkVDdKVHHBFWsBWHnnh5YeJMNWWsv7AbFYXfK3oTqvL7VTWkhNLu1jX24D+g==",
-      "dev": true,
-      "requires": {
-        "@babel/code-frame": "^7.12.13",
-        "@jest/types": "^27.5.1",
-        "@types/stack-utils": "^2.0.0",
-        "chalk": "^4.0.0",
-        "graceful-fs": "^4.2.9",
-        "micromatch": "^4.0.4",
-        "pretty-format": "^27.5.1",
-        "slash": "^3.0.0",
-        "stack-utils": "^2.0.3"
-      },
-      "dependencies": {
-        "ansi-styles": {
-          "version": "4.3.0",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-          "dev": true,
-          "requires": {
-            "color-convert": "^2.0.1"
-          }
-        },
-        "chalk": {
-          "version": "4.1.2",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^4.1.0",
-            "supports-color": "^7.1.0"
-          }
-        },
-        "color-convert": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-          "dev": true,
-          "requires": {
-            "color-name": "~1.1.4"
-          }
-        },
-        "color-name": {
-          "version": "1.1.4",
-          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-          "dev": true
-        },
-        "graceful-fs": {
-          "version": "4.2.10",
-          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.10.tgz",
-          "integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==",
-          "dev": true
-        },
-        "has-flag": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-          "dev": true
-        },
-        "supports-color": {
-          "version": "7.2.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-          "dev": true,
-          "requires": {
-            "has-flag": "^4.0.0"
-          }
-        }
-      }
-    },
-    "jest-regex-util": {
-      "version": "27.5.1",
-      "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-27.5.1.tgz",
-      "integrity": "sha512-4bfKq2zie+x16okqDXjXn9ql2B0dScQu+vcwe4TvFVhkVyuWLqpZrZtXxLLWoXYgn0E87I6r6GRYHF7wFZBUvg==",
-      "dev": true
-    },
     "jest-worker": {
       "version": "27.5.1",
       "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-27.5.1.tgz",
@@ -58213,6 +57064,8 @@
     },
     "make-error": {
       "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
+      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
       "dev": true
     },
     "map-obj": {
@@ -61578,29 +60431,6 @@
         "pinkie": "^2.0.0"
       }
     },
-    "pirates": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.4.tgz",
-      "integrity": "sha512-ZIrVPH+A52Dw84R0L3/VS9Op04PuQ2SEoJL6bkshmiTic/HldyW9Tf7oH5mhJZBK7NmDx27vSMrYEXPXclpDKw==",
-      "dev": true
-    },
-    "pixelmatch": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/pixelmatch/-/pixelmatch-5.2.1.tgz",
-      "integrity": "sha512-WjcAdYSnKrrdDdqTcVEY7aB7UhhwjYQKYhHiBXdJef0MOaQeYpUdQ+iVyBLa5YBKS8MPVPPMX7rpOByISLpeEQ==",
-      "dev": true,
-      "requires": {
-        "pngjs": "^4.0.1"
-      },
-      "dependencies": {
-        "pngjs": {
-          "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-4.0.1.tgz",
-          "integrity": "sha512-rf5+2/ioHeQxR6IxuYNYGFytUyG3lma/WW1nsmjeHlWwtb2aByla6dkVc8pmJ9nplzkTA0q2xx7mMWrOTqT4Gg==",
-          "dev": true
-        }
-      }
-    },
     "pkg-conf": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/pkg-conf/-/pkg-conf-3.1.0.tgz",
@@ -62022,31 +60852,6 @@
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.5.1.tgz",
       "integrity": "sha512-vBZcPRUR5MZJwoyi3ZoyQlc1rXeEck8KgeC9AwwOn+exuxLxq5toTRDTSaVrXHxelDMHy9zlicw8u66yxoSUFg==",
       "dev": true
-    },
-    "pretty-format": {
-      "version": "27.5.1",
-      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
-      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
-      "dev": true,
-      "requires": {
-        "ansi-regex": "^5.0.1",
-        "ansi-styles": "^5.0.0",
-        "react-is": "^17.0.1"
-      },
-      "dependencies": {
-        "ansi-styles": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
-          "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
-          "dev": true
-        },
-        "react-is": {
-          "version": "17.0.2",
-          "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
-          "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
-          "dev": true
-        }
-      }
     },
     "prettycli": {
       "version": "1.4.3",
@@ -64532,6 +63337,8 @@
     },
     "ts-node": {
       "version": "10.9.1",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.1.tgz",
+      "integrity": "sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==",
       "dev": true,
       "requires": {
         "@cspotcode/source-map-support": "^0.8.0",
@@ -64555,6 +63362,8 @@
         },
         "diff": {
           "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+          "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
           "dev": true
         }
       }
@@ -65283,6 +64092,8 @@
     },
     "v8-compile-cache-lib": {
       "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
+      "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
       "dev": true
     },
     "v8-to-istanbul": {
@@ -66341,6 +65152,8 @@
     },
     "yn": {
       "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
+      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
       "dev": true
     },
     "yocto-queue": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -19670,6 +19670,23 @@
         }
       }
     },
+    "node_modules/node-fetch-commonjs": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/node-fetch-commonjs/-/node-fetch-commonjs-3.2.4.tgz",
+      "integrity": "sha512-bZW7+ldcuuMPLTJk8DufhT6qHDRdljYD0jqBjmrYfcInaYcReX5kK42SQsu/jvtit/tER28yYjnk63PEEmNPtg==",
+      "dev": true,
+      "dependencies": {
+        "formdata-polyfill": "^4.0.10",
+        "web-streams-polyfill": "^3.1.1"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/node-fetch"
+      }
+    },
     "node_modules/node-forge": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.3.1.tgz",
@@ -31576,7 +31593,7 @@
         "husky": "^8.0.0",
         "lint-staged": "^12.2.4",
         "next-sitemap": "1.6.173",
-        "node-fetch": "3.3.0",
+        "node-fetch-commonjs": "3.2.4",
         "prettier": "2.4.1",
         "react-query": "3.33.5",
         "sass": "1.43.4",
@@ -36482,33 +36499,6 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/postcss/"
-      }
-    },
-    "packages/website/node_modules/node-fetch": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.0.tgz",
-      "integrity": "sha512-BKwRP/O0UvoMKp7GNdwPlObhYGB5DQqwhEDQlNKuoqwVYSxkSZCSbHjnFFmUEtwSKRPU4kNK8PbDYYitwaE3QA==",
-      "dev": true,
-      "dependencies": {
-        "data-uri-to-buffer": "^4.0.0",
-        "fetch-blob": "^3.1.4",
-        "formdata-polyfill": "^4.0.10"
-      },
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/node-fetch"
-      }
-    },
-    "packages/website/node_modules/node-fetch/node_modules/data-uri-to-buffer": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.0.tgz",
-      "integrity": "sha512-Vr3mLBA8qWmcuschSLAOogKgQ/Jwxulv3RNE4FXnYWRGujzrRWQI4m12fQqRkwX06C0KanhLr4hK+GydchZsaA==",
-      "dev": true,
-      "engines": {
-        "node": ">= 12"
       }
     },
     "packages/website/node_modules/node-libs-browser": {
@@ -44826,7 +44816,7 @@
         "next-optimized-images": "^2.6.2",
         "next-sitemap": "1.6.173",
         "nextra": "^2.0.0-beta.5",
-        "node-fetch": "3.3.0",
+        "node-fetch-commonjs": "3.2.4",
         "p-map": "^5.1.0",
         "prettier": "2.4.1",
         "pretty-bytes": "^5.6.0",
@@ -48318,25 +48308,6 @@
             "@corex/deepmerge": "^2.6.34",
             "matcher": "^4.0.0",
             "minimist": "^1.2.5"
-          }
-        },
-        "node-fetch": {
-          "version": "3.3.0",
-          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.0.tgz",
-          "integrity": "sha512-BKwRP/O0UvoMKp7GNdwPlObhYGB5DQqwhEDQlNKuoqwVYSxkSZCSbHjnFFmUEtwSKRPU4kNK8PbDYYitwaE3QA==",
-          "dev": true,
-          "requires": {
-            "data-uri-to-buffer": "^4.0.0",
-            "fetch-blob": "^3.1.4",
-            "formdata-polyfill": "^4.0.10"
-          },
-          "dependencies": {
-            "data-uri-to-buffer": {
-              "version": "4.0.0",
-              "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.0.tgz",
-              "integrity": "sha512-Vr3mLBA8qWmcuschSLAOogKgQ/Jwxulv3RNE4FXnYWRGujzrRWQI4m12fQqRkwX06C0KanhLr4hK+GydchZsaA==",
-              "dev": true
-            }
           }
         },
         "node-libs-browser": {
@@ -59322,6 +59293,16 @@
       "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
       "requires": {
         "whatwg-url": "^5.0.0"
+      }
+    },
+    "node-fetch-commonjs": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/node-fetch-commonjs/-/node-fetch-commonjs-3.2.4.tgz",
+      "integrity": "sha512-bZW7+ldcuuMPLTJk8DufhT6qHDRdljYD0jqBjmrYfcInaYcReX5kK42SQsu/jvtit/tER28yYjnk63PEEmNPtg==",
+      "dev": true,
+      "requires": {
+        "formdata-polyfill": "^4.0.10",
+        "web-streams-polyfill": "^3.1.1"
       }
     },
     "node-forge": {

--- a/packages/website/next.config.js
+++ b/packages/website/next.config.js
@@ -41,6 +41,11 @@ const nextConfig = {
       ZeroHooks: path.resolve(__dirname, 'modules/zero/hooks'),
     };
 
+    config.watchOptions.ignored = [
+      path.resolve(__dirname, 'test-results'),
+      path.resolve(__dirname, 'playwright-report')
+    ];
+
     config.module.rules.push({
       test: /\.svg$/,
       use: ['@svgr/webpack', 'url-loader'],

--- a/packages/website/next.config.js
+++ b/packages/website/next.config.js
@@ -41,11 +41,6 @@ const nextConfig = {
       ZeroHooks: path.resolve(__dirname, 'modules/zero/hooks'),
     };
 
-    config.watchOptions.ignored = [
-      path.resolve(__dirname, 'test-results'),
-      path.resolve(__dirname, 'playwright-report')
-    ];
-
     config.module.rules.push({
       test: /\.svg$/,
       use: ['@svgr/webpack', 'url-loader'],

--- a/packages/website/package.json
+++ b/packages/website/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "ci:envfile": "ts-node -O '{\"module\": \"commonjs\"}' scripts/envfile.ts ",
     "dev": "rm -rf .next && next dev -p 4000",
-    "start": "env-cmd -f ../../.env next dev -p 4000 --no-watch",
+    "start": "env-cmd -f ../../.env next dev -p 4000",
     "prebuild": "sh ./scripts/prebuild.sh",
     "build": "next build && next-sitemap && next export",
     "postbuild": "sh ./scripts/postbuild.sh",

--- a/packages/website/package.json
+++ b/packages/website/package.json
@@ -63,7 +63,7 @@
   },
   "devDependencies": {
     "@next/eslint-plugin-next": "12.0.8",
-    "@playwright/test": "^1.20.2",
+    "@playwright/test": "^1.28.1",
     "@svgr/webpack": "^6.2.1",
     "@types/react": "17.0.36",
     "@types/react-dom": "17.0.11",

--- a/packages/website/package.json
+++ b/packages/website/package.json
@@ -91,6 +91,7 @@
     "husky": "^8.0.0",
     "lint-staged": "^12.2.4",
     "next-sitemap": "1.6.173",
+    "node-fetch": "3.3.0",
     "prettier": "2.4.1",
     "react-query": "3.33.5",
     "sass": "1.43.4",

--- a/packages/website/package.json
+++ b/packages/website/package.json
@@ -91,7 +91,7 @@
     "husky": "^8.0.0",
     "lint-staged": "^12.2.4",
     "next-sitemap": "1.6.173",
-    "node-fetch": "3.3.0",
+    "node-fetch-commonjs": "3.2.4",
     "prettier": "2.4.1",
     "react-query": "3.33.5",
     "sass": "1.43.4",

--- a/packages/website/package.json
+++ b/packages/website/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "ci:envfile": "ts-node -O '{\"module\": \"commonjs\"}' scripts/envfile.ts ",
     "dev": "rm -rf .next && next dev -p 4000",
-    "start": "env-cmd -f ../../.env next dev -p 4000",
+    "start": "env-cmd -f ../../.env next dev -p 4000 --no-watch",
     "prebuild": "sh ./scripts/prebuild.sh",
     "build": "next build && next-sitemap && next export",
     "postbuild": "sh ./scripts/postbuild.sh",

--- a/packages/website/tests/accountPayment.e2e.spec.ts
+++ b/packages/website/tests/accountPayment.e2e.spec.ts
@@ -11,7 +11,6 @@ test.beforeEach(async ({ page }) => {
 
 test.describe('/account/payment', () => {
   test('redirects through login and back when not initially authenticated', async ({ page }, testInfo) => {
-    test.slow()
     const accountPaymentPathname = '/account/payment/';
     const accountQuery = '?plan=lite'
     const accountUrl = `${accountPaymentPathname}${accountQuery}`;

--- a/packages/website/tests/accountPayment.e2e.spec.ts
+++ b/packages/website/tests/accountPayment.e2e.spec.ts
@@ -6,7 +6,7 @@ import { E2EScreenshotPath } from './screenshots';
 const MAGIC_SUCCESS_EMAIL = 'test+success@magic.link';
 
 test.beforeEach(async ({ page }) => {
-  await page.goto('/', { waitUntil: 'commit' });
+  await page.goto('/');
 });
 
 test.describe('/account/payment', () => {

--- a/packages/website/tests/accountPayment.e2e.spec.ts
+++ b/packages/website/tests/accountPayment.e2e.spec.ts
@@ -6,8 +6,7 @@ import { E2EScreenshotPath } from './screenshots';
 const MAGIC_SUCCESS_EMAIL = 'test+success@magic.link';
 
 test.beforeEach(async ({ page }, testInfo) => {
-  console.log(`Running ${testInfo.title}`);
-  await page.goto('/');
+  console.log(`Running test: ${testInfo.title}`);
 });
 
 test.describe('/account/payment', () => {
@@ -39,7 +38,6 @@ test.describe('/account/payment', () => {
       fullPage: true,
       path: await E2EScreenshotPath(testInfo, `accountPayment-noauth`),
     });
-    await page.goto('/#1');
   });
   test('can access when authenticated', async ({ page }, testInfo) => {
     page.on('pageerror', err => {
@@ -63,7 +61,6 @@ test.describe('/account/payment', () => {
       fullPage: true,
       path: await E2EScreenshotPath(testInfo, `accountPayment`),
     });
-    await page.goto('/#2');
   });
   test('can enter credit card details', async ({ page }) => {
     const tester = LoginTester();
@@ -72,7 +69,6 @@ test.describe('/account/payment', () => {
     await page.goto(AccountPaymentTester().url);
     await AccountPaymentTester().fillCreditCardDetails(page);
     await AccountPaymentTester().clickAddCardButton(page);
-    await page.goto('/#3');
   });
 });
 

--- a/packages/website/tests/accountPayment.e2e.spec.ts
+++ b/packages/website/tests/accountPayment.e2e.spec.ts
@@ -38,6 +38,7 @@ test.describe('/account/payment', () => {
       fullPage: true,
       path: await E2EScreenshotPath(testInfo, `accountPayment-noauth`),
     });
+    await page.goto('/#1');
   });
   test('can access when authenticated', async ({ page }, testInfo) => {
     page.on('pageerror', err => {
@@ -61,6 +62,7 @@ test.describe('/account/payment', () => {
       fullPage: true,
       path: await E2EScreenshotPath(testInfo, `accountPayment`),
     });
+    await page.goto('/#2');
   });
   test('can enter credit card details', async ({ page }) => {
     const tester = LoginTester();
@@ -69,6 +71,7 @@ test.describe('/account/payment', () => {
     await page.goto(AccountPaymentTester().url);
     await AccountPaymentTester().fillCreditCardDetails(page);
     await AccountPaymentTester().clickAddCardButton(page);
+    await page.goto('/#3');
   });
 });
 

--- a/packages/website/tests/accountPayment.e2e.spec.ts
+++ b/packages/website/tests/accountPayment.e2e.spec.ts
@@ -6,7 +6,7 @@ import { E2EScreenshotPath } from './screenshots';
 const MAGIC_SUCCESS_EMAIL = 'test+success@magic.link';
 
 test.beforeEach(async ({ page }) => {
-  await page.goto('/');
+  await page.goto('/', { waitUntil: 'commit' });
 });
 
 test.describe('/account/payment', () => {
@@ -84,7 +84,7 @@ function LoginTester({
   async function submitLoginForm(page: Page) {
     const loginButton = page.locator('.login-content .section-email button');
     await loginButton.isVisible();
-    await loginButton.click();
+    await Promise.all([page.waitForNavigation({ waitUntil: 'networkidle' }), loginButton.click()]);
   }
   async function login(
     page: Page,

--- a/packages/website/tests/accountPayment.e2e.spec.ts
+++ b/packages/website/tests/accountPayment.e2e.spec.ts
@@ -11,6 +11,7 @@ test.beforeEach(async ({ page }) => {
 
 test.describe('/account/payment', () => {
   test('redirects through login and back when not initially authenticated', async ({ page }, testInfo) => {
+    test.slow()
     const accountPaymentPathname = '/account/payment/';
     const accountQuery = '?plan=lite'
     const accountUrl = `${accountPaymentPathname}${accountQuery}`;

--- a/packages/website/tests/accountPayment.e2e.spec.ts
+++ b/packages/website/tests/accountPayment.e2e.spec.ts
@@ -5,7 +5,8 @@ import { E2EScreenshotPath } from './screenshots';
 // https://magic.link/docs/auth/introduction/test-mode#usage
 const MAGIC_SUCCESS_EMAIL = 'test+success@magic.link';
 
-test.beforeEach(async ({ page }) => {
+test.beforeEach(async ({ page }, testInfo) => {
+  console.log(`Running ${testInfo.title}`);
   await page.goto('/');
 });
 

--- a/packages/website/tests/accountPayment.e2e.spec.ts
+++ b/packages/website/tests/accountPayment.e2e.spec.ts
@@ -84,7 +84,7 @@ function LoginTester({
   async function submitLoginForm(page: Page) {
     const loginButton = page.locator('.login-content .section-email button');
     await loginButton.isVisible();
-    await Promise.all([page.waitForNavigation({ waitUntil: 'networkidle' }), loginButton.click()]);
+    await loginButton.click();
   }
   async function login(
     page: Page,

--- a/packages/website/tests/homepage.e2e.spec.ts
+++ b/packages/website/tests/homepage.e2e.spec.ts
@@ -12,5 +12,6 @@ test.describe('homepage', () => {
       fullPage: true,
       path: await E2EScreenshotPath(testInfo, `homepage`),
     });
+    await page.goto('/#4');
   });
 });

--- a/packages/website/tests/homepage.e2e.spec.ts
+++ b/packages/website/tests/homepage.e2e.spec.ts
@@ -2,7 +2,8 @@ import { test } from '@playwright/test';
 
 import { E2EScreenshotPath } from './screenshots.js';
 
-test.beforeEach(async ({ page }) => {
+test.beforeEach(async ({ page }, testInfo) => {
+  console.log(`Running ${testInfo.title}`);
   await page.goto('/');
 });
 

--- a/packages/website/tests/homepage.e2e.spec.ts
+++ b/packages/website/tests/homepage.e2e.spec.ts
@@ -3,16 +3,15 @@ import { test } from '@playwright/test';
 import { E2EScreenshotPath } from './screenshots.js';
 
 test.beforeEach(async ({ page }, testInfo) => {
-  console.log(`Running ${testInfo.title}`);
-  await page.goto('/');
+  console.log(`Running test: ${testInfo.title}`);
 });
 
 test.describe('homepage', () => {
   test('should be screenshottable', async ({ page }, testInfo) => {
+    await page.goto('/');
     await page.screenshot({
       fullPage: true,
       path: await E2EScreenshotPath(testInfo, `homepage`),
     });
-    await page.goto('/#4');
   });
 });

--- a/packages/website/tests/playwright/globalSetup.ts
+++ b/packages/website/tests/playwright/globalSetup.ts
@@ -14,8 +14,8 @@ export default async function main(config) {
     });
   }
   w3storageProcess.on('exit', code => {
+    console.log(`w3 storage process stopped (code: ${code}).`);
     process.exit(code ?? undefined);
-    console.log('Stopped w3 storage process.');
   });
 
   // Wait for the dev server to get up and running before attempting to start the tests,
@@ -26,17 +26,12 @@ export default async function main(config) {
   await waitForServer(apiURL, 'API');
 }
 
-if (process.env.RUN) {
-  console.log('What is this for?')
-  // main();
-}
-
 function prepender(prefix) {
   return suffix => `${prefix}${suffix}`;
 }
 
 async function waitForServer (url, name) {
-  const maxAttempts = 50;
+  const maxAttempts = 30;
   let attempt = 0;
   while (attempt < maxAttempts) {
     attempt ++
@@ -51,10 +46,10 @@ async function waitForServer (url, name) {
     } catch (error) {
       console.log(`Failed to connect to ${name} server (attempt ${attempt} of ${maxAttempts}`)
     }
-    // Wait *at least* 5 seconds per iteration.
+    // Wait *at least* 2 seconds per iteration.
     const end = Date.now()
     const timeTaken = end - start
-    await delay(Math.max(5000 - timeTaken, 0))
+    await delay(Math.max(2000 - timeTaken, 0))
   }
   throw Error(`Could not connected to ${name} server (${url}) after ${attempt} attempts.`)
 }

--- a/packages/website/tests/playwright/globalSetup.ts
+++ b/packages/website/tests/playwright/globalSetup.ts
@@ -7,15 +7,6 @@ export default async function main(config) {
   const w3storageProcess = spawn('npm', ['start'], {
     cwd: path.join(__dirname, '../../../../'),
   });
-
-  // Wait for the dev server to get up and running before attempting to start the tests,
-  // otherwise the first test will fail just trying to connect.
-  const { baseURL } = config.projects[0].use;
-  const apiURL = process.env.NEXT_PUBLIC_API;
-
-  await waitForServer(baseURL, 'web');
-  await waitForServer(apiURL, 'API');
-
   for (const fd of ['stdout', 'stderr']) {
     const prefix = process.env.PLAYWRIGHT_PREFIX_FD ? `[${fd}]: ` : '';
     w3storageProcess[fd].on('data', log => {
@@ -26,6 +17,13 @@ export default async function main(config) {
     process.exit(code ?? undefined);
     console.log('Stopped w3 storage process.');
   });
+
+  // Wait for the dev server to get up and running before attempting to start the tests,
+  // otherwise the first test will fail just trying to connect.
+  const { baseURL } = config.projects[0].use;
+  const apiURL = process.env.NEXT_PUBLIC_API;
+  await waitForServer(baseURL, 'web');
+  await waitForServer(apiURL, 'API');
 }
 
 if (process.env.RUN) {
@@ -44,9 +42,10 @@ async function waitForServer (url, name) {
     attempt ++
     const start = Date.now()
     try {
-      console.log('Seeing if the dev server is ready...')
+      console.log(`Checking if the ${name} server is ready (attempt ${attempt})...`)
       const response = await fetch(url);
       if (response.ok) {
+        console.log(`Successfully connected to ${name} server at ${url}. Ready.`)
         return
       }
     } catch (error) {

--- a/packages/website/tests/playwright/globalSetup.ts
+++ b/packages/website/tests/playwright/globalSetup.ts
@@ -2,6 +2,7 @@ import { spawn } from 'child_process';
 import * as path from 'path';
 
 export default async function main() {
+  console.log('Starting w3 storage process for tests...');
   const w3storageProcess = spawn('npm', ['start'], {
     cwd: path.join(__dirname, '../../../../'),
   });
@@ -13,6 +14,7 @@ export default async function main() {
   }
   w3storageProcess.on('exit', code => {
     process.exit(code ?? undefined);
+    console.log('Stopped w3 storage process.');
   });
 }
 

--- a/packages/website/tests/playwright/globalSetup.ts
+++ b/packages/website/tests/playwright/globalSetup.ts
@@ -1,11 +1,21 @@
 import { spawn } from 'child_process';
+import fetch from 'node-fetch';
 import * as path from 'path';
 
-export default async function main() {
+export default async function main(config) {
   console.log('Starting w3 storage process for tests...');
   const w3storageProcess = spawn('npm', ['start'], {
     cwd: path.join(__dirname, '../../../../'),
   });
+
+  // Wait for the dev server to get up and running before attempting to start the tests,
+  // otherwise the first test will fail just trying to connect.
+  const { baseURL } = config.projects[0].use;
+  const apiURL = process.env.NEXT_PUBLIC_API;
+
+  await waitForServer(baseURL, 'web');
+  await waitForServer(apiURL, 'API');
+
   for (const fd of ['stdout', 'stderr']) {
     const prefix = process.env.PLAYWRIGHT_PREFIX_FD ? `[${fd}]: ` : '';
     w3storageProcess[fd].on('data', log => {
@@ -19,9 +29,26 @@ export default async function main() {
 }
 
 if (process.env.RUN) {
-  main();
+  console.log('What is this for?')
+  // main();
 }
 
 function prepender(prefix) {
   return suffix => `${prefix}${suffix}`;
+}
+
+async function waitForServer (url, name) {
+  let connected = false;
+  const maxAttempts = 5;
+  let attempt = 0;
+  while (attempt < maxAttempts && !connected) {
+    attempt++;
+    try {
+      console.log('Seeing if the dev server is ready...')
+      const response = await fetch(url);
+      connected = response.ok
+    } catch (error) {
+      console.log(`Failed to connect to ${name} server (attempt ${attempt} of ${maxAttempts}`)
+    }
+  }
 }

--- a/packages/website/tests/playwright/globalSetup.ts
+++ b/packages/website/tests/playwright/globalSetup.ts
@@ -38,17 +38,30 @@ function prepender(prefix) {
 }
 
 async function waitForServer (url, name) {
-  let connected = false;
-  const maxAttempts = 5;
+  const maxAttempts = 50;
   let attempt = 0;
-  while (attempt < maxAttempts && !connected) {
-    attempt++;
+  while (attempt < maxAttempts) {
+    attempt ++
+    const start = Date.now()
     try {
       console.log('Seeing if the dev server is ready...')
       const response = await fetch(url);
-      connected = response.ok
+      if (response.ok) {
+        return
+      }
     } catch (error) {
       console.log(`Failed to connect to ${name} server (attempt ${attempt} of ${maxAttempts}`)
     }
+    // Wait *at least* 5 seconds per iteration.
+    const end = Date.now()
+    const timeTaken = end - start
+    await delay(Math.max(5000 - timeTaken, 0))
   }
+  throw Error(`Could not connected to ${name} server (${url}) after ${attempt} attempts.`)
+}
+
+async function delay (ms) {
+  return new Promise((resolve) => {
+    setTimeout(resolve, ms)
+  })
 }


### PR DESCRIPTION
A story in two parts…

### Part 1 - Playwright installation was failing

This PR was started to fix an error with `playwright install-deps` which is showing up here: https://github.com/web3-storage/web3.storage/actions/runs/3620217854/jobs/6124601471

It seems that the dependencies which are required by the version of Playwright that we were using are no longer available on `ubuntu-latest` because `ubuntu-latest` is now a newer version. When that changed, this broke (is my educated guess). There are vague clues pointing at this being the case in this issue: https://github.com/microsoft/playwright/issues/19234

Bumping the playwright version seems to fix it. So that's the first part of this PR.

But fixing that made the Playwright tests run again. Which then uncovered another problem…

### Part 2 - The Playwright tests were failing

The `test-e2e` step in `.github/workflows/website.yml` was failing for the Firefox value of the matrix with this error:

```
page.goto: NS_ERROR_ABORT
    =========================== logs ===========================
    navigating to "http://localhost:4000/", waiting until "load"
    ============================================================

       7 |
       8 | test.beforeEach(async ({ page }) => {
    >  9 |   await page.goto('/');
         |              ^
      10 | });
      11 |
      12 | test.describe('/account/payment', () => {
```

[Example CI run](https://github.com/web3-storage/web3.storage/actions/runs/3630975522/jobs/6140045696).

After much confusion (why did it only fail for Firefox and not Chrome? why did it only fail for the first test? how come you can see many successful requests being made to the server before that error occurs?), the painfully simple answer is:

After running `npm start` we weren't waiting for the servers (web or API) to be ready before we ran the browser tests.

So when the `beforeEach` hook ran on the first test, it got that error. The test would be retried (including retrying the failed `beforeEach` hook), the retries would also fail (because the server still wasn't ready), then the other tests would run and pass (server now ready), then only after all the tests had run did you see the output of the one that failed. In Chrome, the test was marked as flakey (i.e. it passed after one or more retries). Presumably Chrome was taking longer to start up, giving the server more time to be ready, and hence it passed on the retry.

### Happily ever after

This PR fixes both of the above issues. Yay! It also adds some improved logging so that you can see a lot more about what's happening when the e2e tests are being run, which should make debugging of this stuff much easier in future.