### PR TITLE
feat: allow displaying of custom stripe prices

### DIFF
--- a/packages/api/src/utils/billing-types.ts
+++ b/packages/api/src/utils/billing-types.ts
@@ -66,7 +66,8 @@ export interface PriceTier {
 
 export interface CustomStoragePrice {
   id: string;
-  bandwidth?: string;
+  // Monthly bandwidth in GiB
+  bandwidth?: number;
   label: string;
   // True if price is prioritized.  It could be used to disable selection of alternative prices.
   isPreferred: boolean;

--- a/packages/api/src/utils/billing-types.ts
+++ b/packages/api/src/utils/billing-types.ts
@@ -59,7 +59,22 @@ export interface CustomersService {
 
 export type StoragePriceName = 'free' | 'lite' | 'pro'
 
-export type StoragePrice = StoragePriceName | Pick<Stripe.Response<Stripe.Price>, 'id'|'metadata'|'tiers'>
+export interface PriceTier {
+  flatAmount: number | null;
+  unitAmount: number | null;
+  upTo: number | null;
+}
+
+export interface CustomStoragePrice {
+  id: string;
+  bandwidth?: string;
+  label: string;
+  isPreferred: boolean;
+  description?: string;
+  tiers: Array<PriceTier> | null;
+}
+
+export type StoragePrice = StoragePriceName | CustomStoragePrice;
 
 /**
  * A subscription to the web3.storage platform.

--- a/packages/api/src/utils/billing-types.ts
+++ b/packages/api/src/utils/billing-types.ts
@@ -68,6 +68,7 @@ export interface CustomStoragePrice {
   id: string;
   bandwidth?: string;
   label: string;
+  // True if price is prioritized.  It could be used to disable selection of alternative prices.
   isPreferred: boolean;
   description?: string;
   tiers: Array<PriceTier> | null;

--- a/packages/api/src/utils/billing-types.ts
+++ b/packages/api/src/utils/billing-types.ts
@@ -1,4 +1,5 @@
 import { StripePriceId } from "./stripe";
+import Stripe from 'stripe';
 
 export type StripePaymentMethodId = string;
 export type CustomerId = string;
@@ -58,6 +59,8 @@ export interface CustomersService {
 
 export type StoragePriceName = 'free' | 'lite' | 'pro'
 
+export type StoragePrice = StoragePriceName | Pick<Stripe.Response<Stripe.Price>, 'id'|'metadata'|'tiers'>
+
 /**
  * A subscription to the web3.storage platform.
  * This may be a composition of several product-specific subscriptions.
@@ -66,12 +69,12 @@ export interface W3PlatformSubscription {
   // details of subscription to storage functionality
   storage: null | {
     // the price that should be used to determine the subscription's periodic invoice/credit.
-    price: StoragePriceName
+    price: StoragePrice
   }
 }
 
 export type NamedStripePrices = {
-  priceToName: (priceId: StripePriceId) => undefined | StoragePriceName
+  priceToName: (priceId: string) => undefined | StoragePriceName
   nameToPrice: (name: StoragePriceName) => undefined | StripePriceId
 }
 

--- a/packages/api/src/utils/billing-types.ts
+++ b/packages/api/src/utils/billing-types.ts
@@ -1,5 +1,4 @@
 import { StripePriceId } from "./stripe";
-import Stripe from 'stripe';
 
 export type StripePaymentMethodId = string;
 export type CustomerId = string;

--- a/packages/api/src/utils/number.js
+++ b/packages/api/src/utils/number.js
@@ -1,0 +1,13 @@
+/**
+ * Converts a string to a number.
+ *
+ * @param {string} s
+ * @returns {number|undefined}
+ */
+export const stringToNumber = (s) => {
+  const n = parseFloat(s)
+  if (isNaN(n)) {
+    return undefined
+  }
+  return n
+}

--- a/packages/api/src/utils/stripe.js
+++ b/packages/api/src/utils/stripe.js
@@ -20,6 +20,7 @@ import { CustomerNotFound, hasOwnProperty, isStoragePriceName, randomString, sto
  * @property {Pick<StripeInterface['paymentMethods'], 'attach'>} paymentMethods
  * @property {Pick<StripeInterface['setupIntents'], 'create'>} setupIntents
  * @property {Pick<StripeInterface['customers'], 'retrieve'|'update'>} customers
+ * @property {Pick<StripeInterface['prices'], 'retrieve'>} prices
  */
 
 /**
@@ -349,12 +350,29 @@ export function createMockStripeForCustomersService () {
 /**
  * @param {object} [options]
  * @param {(id: string) => Promise<undefined|Stripe.Customer|Stripe.DeletedCustomer>} [options.retrieveCustomer]
+ * @param {(id: string) => Promise<undefined|Stripe.Price>} [options.retrievePrice]
  * @param {() => void} [options.onCreateSetupintent]
  * @returns {StripeComForBillingService}
  */
 export function createMockStripeForBilling (options = {}) {
   const retrieveCustomer = options.retrieveCustomer || async function (id) {
     throw new Error(`no customer found with id=${id}`)
+  }
+  const retrievePrice = options.retrievePrice || async function (id) {
+    throw new Error(`no price found with id=${id}`)
+  }
+  /** @type {StripeComForBillingService['prices']} */
+  const prices = {
+    async retrieve (id, params) {
+      const price = await retrievePrice(id)
+      /** @type {Stripe.Response<Stripe.Price>} */
+      const response = {
+        ...price,
+        // @ts-ignore
+        lastResponse: undefined
+      }
+      return response
+    }
   }
   const paymentMethods = {
     /**
@@ -421,7 +439,7 @@ export function createMockStripeForBilling (options = {}) {
       return response
     }
   }
-  return { paymentMethods, customers, setupIntents }
+  return { paymentMethods, customers, prices, setupIntents }
 }
 
 /**
@@ -556,7 +574,7 @@ export class NamedStripePrices {
   }
 
   /**
-   * @param {StripePriceId} priceId
+   * @param {string} priceId
    * @returns {StoragePriceName|undefined}
    */
   priceToName (priceId) {
@@ -585,6 +603,7 @@ export const stagingStripePrices = new NamedStripePrices({
  * @property {Pick<Stripe['subscriptions'], 'cancel'|'create'>} subscriptions
  * @property {Pick<Stripe['subscriptionItems'], 'update'|'del'>} subscriptionItems
  * @property {Pick<Stripe['customers'], 'retrieve'>} customers
+ * @property {Pick<Stripe['prices'], 'retrieve'>} prices
  */
 
 /**
@@ -709,11 +728,54 @@ export class StripeSubscriptionsService {
   async getSubscription (customerId) {
     const storageStripeSubscription = await this.getStorageStripeSubscription(customerId)
     if (storageStripeSubscription instanceof CustomerNotFound) { return storageStripeSubscription }
-    /** @returns {import('./billing-types').W3PlatformSubscription} */
-    const subscription = {
-      storage: createW3StorageSubscription(storageStripeSubscription, this.priceNamer)
+
+    if (!storageStripeSubscription) {
+      return {
+        storage: null
+      }
     }
-    return subscription
+
+    if (storageStripeSubscription.items.data.length > 1) {
+      throw new Error(
+        `subscription ${storageStripeSubscription.id} has ${storageStripeSubscription.items.data?.length} items, but we only expect to ever see one.`
+      )
+    }
+
+    // @todo - be more clever in ensuring this came from correct subscription item
+    // or consider throwing if there is more than one subscription item
+    const stripePrice = /** @type {Stripe.Response<Stripe.Price>} */ (
+      storageStripeSubscription.items.data[0].price
+    )
+
+    const storagePriceName = this.priceNamer.priceToName(stripePrice.id)
+
+    if (storagePriceName) {
+      /** @type {import('./billing-types').W3PlatformSubscription['storage']} */
+      return {
+        storage: {
+          price: storagePriceName
+        }
+      }
+    }
+
+    const expandedStripePriceResponse = await this.getStripePrice(stripePrice.id)
+
+    if (!expandedStripePriceResponse) {
+      throw new Error(`there was an error fetching price for price id ${stripePrice.id}}`)
+    }
+
+    const expandedStripePrice = {
+      id: expandedStripePriceResponse.id,
+      metadata: expandedStripePriceResponse.metadata,
+      tiers: expandedStripePriceResponse.tiers
+    }
+
+    /** @type {import('./billing-types').W3PlatformSubscription['storage']} */
+    return {
+      storage: {
+        price: expandedStripePrice
+      }
+    }
   }
 
   async getStorageStripeSubscription (customerId) {
@@ -730,6 +792,18 @@ export class StripeSubscriptionsService {
     }
     const storageStripeSubscription = selectStorageStripeSubscription(customerId, stripeSubscriptions)
     return storageStripeSubscription
+  }
+
+  async getStripePrice (priceId) {
+    const price = await this.stripe.prices.retrieve(priceId, {
+      expand: ['tiers']
+    })
+
+    if (!price.active) {
+      throw new Error(`price with id ${priceId} is not active`)
+    }
+
+    return price
   }
 
   /**
@@ -759,7 +833,7 @@ export class StripeSubscriptionsService {
       return null
     }
     const priceName = storageSubscription.price
-    const desiredPriceId = this.priceNamer.nameToPrice(priceName)
+    const desiredPriceId = typeof priceName === 'string' ? this.priceNamer.nameToPrice(priceName) : null
     if (!desiredPriceId) {
       throw new Error(`invalid price name: ${priceName}`)
     }
@@ -826,32 +900,6 @@ function selectStorageStripeSubscriptionItem (stripeSubscription) {
   }
   const item = items.data[0]
   return item
-}
-
-/**
- * @param {null|Stripe.Subscription} stripeSubscription
- * @param {import('./billing-types').NamedStripePrices} priceNamer
- * @returns {import('./billing-types').W3PlatformSubscription['storage']}
- */
-function createW3StorageSubscription (stripeSubscription, priceNamer) {
-  if (!stripeSubscription) {
-    return null
-  }
-  if (stripeSubscription.items.data.length > 1) {
-    throw new Error(`subscription ${stripeSubscription.id} has ${stripeSubscription.items.data?.length} items, but we only expect to ever see one.`)
-  }
-  // @todo - be more clever in ensuring this came from correct subscription item
-  // or consider throwing if there is more than one subscription item
-  const storagePrice = /** @type {StripePriceId} */ (stripeSubscription.items.data[0].price.id)
-  const storagePriceName = priceNamer.priceToName(storagePrice)
-  if (!storagePriceName) {
-    throw new Error(`unable to determien price name for stripe price ${storagePrice}`)
-  }
-  /** @type {import('./billing-types').W3PlatformSubscription['storage']} */
-  const storageSubscription = {
-    price: storagePriceName
-  }
-  return storageSubscription
 }
 
 /**

--- a/packages/api/src/utils/stripe.js
+++ b/packages/api/src/utils/stripe.js
@@ -1,6 +1,7 @@
 /* eslint-disable no-void */
 import Stripe from 'stripe'
 import { CustomerNotFound, hasOwnProperty, isStoragePriceName, randomString, storagePriceNames } from './billing.js'
+import { stringToNumber } from './number.js'
 
 /**
  * @typedef {import('./billing-types').StoragePriceName} StoragePriceName
@@ -807,7 +808,7 @@ export class StripeSubscriptionsService {
       id: price.id,
       label: price.metadata['UI Label'] ?? 'Custom',
       description: price.metadata?.Description,
-      bandwidth: price.metadata?.Bandwidth,
+      bandwidth: stringToNumber(price.metadata?.Bandwidth),
       isPreferred: price.metadata?.Preferred === 'true',
       tiers: price.tiers?.map((tier) => ({
         flatAmount: tier.flat_amount,

--- a/packages/website/components/account/currentBillingPlanCard/currentBillingPlanCard.js
+++ b/packages/website/components/account/currentBillingPlanCard/currentBillingPlanCard.js
@@ -1,27 +1,30 @@
+import { formatAsStorageAmount, formatCurrency } from '../../../lib/utils';
+
 const CurrentBillingPlanCard = ({ plan }) => {
   return (
     <div className="billing-card card-transparent">
       {plan !== undefined && (
         <div key={plan.title} className="billing-plan">
           <div className="billing-plan-overview">
-            <h4 className="billing-plan-title">{plan.title}</h4>
-            <div className="billing-plan-amount">{plan.price}</div>
+            <h4 className="billing-plan-title">{plan.metadata['UI Label']}</h4>
+            <div className="billing-plan-amount">{formatCurrency(plan.tiers[0]?.flat_amount / 100, true)}/mo</div>
           </div>
 
-          <p className="billing-plan-desc">{plan.description}</p>
+          <p className="billing-plan-desc">{plan.metadata['Description']}</p>
           <p className="billing-plan-limit">
             {plan.id !== 'free' && (
               <span>
-                <span>Base Storage Capacity:</span> <strong>{plan.baseStorage}</strong> for{' '}
-                <strong>{plan.price}</strong>
+                <span>Base Storage Capacity:</span> <strong>{formatAsStorageAmount(plan.tiers[0]?.up_to)}</strong> for{' '}
+                <strong>{formatCurrency(plan.tiers[0]?.flat_amount / 100, true)}/mo</strong>
               </span>
             )}
             <span>
-              <span>Additional Storage:</span> <strong>{plan.additionalStorage.split(' ')[0]} per GiB</strong> after{' '}
-              {plan.baseStorage.split(' ')[0]}
+              <span>Additional Storage:</span>{' '}
+              <strong>{formatCurrency(plan.tiers[1]?.unit_amount / 100)} per GiB</strong> after{' '}
+              {formatAsStorageAmount(plan.tiers[0]?.up_to)}
             </span>
             <span>
-              <span>Bandwidth:</span> <strong>{plan.bandwidth}</strong>
+              <span>Bandwidth:</span> <strong>{formatAsStorageAmount(plan.metadata['Bandwidth'])} / month</strong>
             </span>
           </p>
         </div>

--- a/packages/website/components/account/currentBillingPlanCard/currentBillingPlanCard.js
+++ b/packages/website/components/account/currentBillingPlanCard/currentBillingPlanCard.js
@@ -6,25 +6,25 @@ const CurrentBillingPlanCard = ({ plan }) => {
       {plan !== undefined && (
         <div key={plan.title} className="billing-plan">
           <div className="billing-plan-overview">
-            <h4 className="billing-plan-title">{plan.metadata['UI Label']}</h4>
-            <div className="billing-plan-amount">{formatCurrency(plan.tiers[0]?.flat_amount / 100, true)}/mo</div>
+            <h4 className="billing-plan-title">{plan.label}</h4>
+            <div className="billing-plan-amount">{formatCurrency(plan.tiers[0]?.flatAmount / 100, true)}/mo</div>
           </div>
 
-          <p className="billing-plan-desc">{plan.metadata['Description']}</p>
+          <p className="billing-plan-desc">{plan.description}</p>
           <p className="billing-plan-limit">
             {plan.id !== 'free' && (
               <span>
-                <span>Base Storage Capacity:</span> <strong>{formatAsStorageAmount(plan.tiers[0]?.up_to)}</strong> for{' '}
-                <strong>{formatCurrency(plan.tiers[0]?.flat_amount / 100, true)}/mo</strong>
+                <span>Base Storage Capacity:</span> <strong>{formatAsStorageAmount(plan.tiers[0]?.upTo)}</strong> for{' '}
+                <strong>{formatCurrency(plan.tiers[0]?.flatAmount / 100, true)}/mo</strong>
               </span>
             )}
             <span>
               <span>Additional Storage:</span>{' '}
-              <strong>{formatCurrency(plan.tiers[1]?.unit_amount / 100)} per GiB</strong> after{' '}
-              {formatAsStorageAmount(plan.tiers[0]?.up_to)}
+              <strong>{formatCurrency(plan.tiers[1]?.unitAmount / 100)} per GiB</strong> after{' '}
+              {formatAsStorageAmount(plan.tiers[0]?.upTo)}
             </span>
             <span>
-              <span>Bandwidth:</span> <strong>{formatAsStorageAmount(plan.metadata['Bandwidth'])} / month</strong>
+              <span>Bandwidth:</span> <strong>{formatAsStorageAmount(plan.bandwidth)} / month</strong>
             </span>
           </p>
         </div>

--- a/packages/website/components/account/paymentTable.js/paymentTable.js
+++ b/packages/website/components/account/paymentTable.js/paymentTable.js
@@ -52,7 +52,7 @@ const PaymentTable = ({ plans: plansProp, currentPlan, setPlanSelection, setIsPa
             {plans.map(plan => (
               <div
                 key={plan.id}
-                className={`billing-card card-transparent ${currentPlan?.id === plan?.id ? 'current' : ''}`}
+                className={`billing-card card-transparent ${currentPlan?.id === plan.id ? 'current' : ''}`}
               >
                 <div className="billing-plan">
                   <h4 className="billing-plan-title">{plan.label}</h4>
@@ -74,7 +74,7 @@ const PaymentTable = ({ plans: plansProp, currentPlan, setPlanSelection, setIsPa
                     </div>
                   )}
 
-                  {currentPlan?.id !== plan?.id && (
+                  {currentPlan?.id !== plan.id && (
                     <Button
                       variant="light"
                       disabled={currentPlan?.isPreferred}
@@ -88,7 +88,7 @@ const PaymentTable = ({ plans: plansProp, currentPlan, setPlanSelection, setIsPa
                     </Button>
                   )}
 
-                  {currentPlan.id === plan.id && (
+                  {currentPlan?.id === plan.id && (
                     <Button variant="light" disabled={true} className="">
                       Current Plan
                     </Button>

--- a/packages/website/components/account/paymentTable.js/paymentTable.js
+++ b/packages/website/components/account/paymentTable.js/paymentTable.js
@@ -1,14 +1,32 @@
+import { useMemo } from 'react';
+
 import Tooltip from '../../../modules/zero/components/tooltip/tooltip.js';
 import InfoIcon from '../../../assets/icons/info';
 import Button from '../../button/button.js';
+import { formatAsStorageAmount, formatCurrency } from '../../../lib/utils.js';
 
-const PaymentTable = ({ plans, currentPlan, setPlanSelection, setIsPaymentPlanModalOpen }) => {
+const getAdditionalStoragePrice = price => (typeof price === 'number' ? `${formatCurrency(price / 100)} / GiB` : 'N/A');
+
+const PaymentTable = ({ plans: plansProp, currentPlan, setPlanSelection, setIsPaymentPlanModalOpen }) => {
+  const plans = useMemo(() => {
+    const isCurrentPlanStandard = ['free', 'lite', 'pro'].includes(currentPlan?.id);
+
+    if (!isCurrentPlanStandard) {
+      return [currentPlan, ...plansProp.slice(1)];
+    }
+
+    return plansProp;
+  }, [plansProp, currentPlan]);
+
   return (
     <>
       {currentPlan && (
         <p className="billing-content-intro" data-testid="currentPlanIndicator">
           <span>
-            Your current plan is: <strong data-testid="currentPlan.title">{currentPlan.title}</strong>
+            Your current plan is:{' '}
+            <strong data-testid="currentPlan.metadata['UI Label']">
+              {currentPlan?.metadata['UI Label'] ?? 'Custom'}
+            </strong>
           </span>
         </p>
       )}
@@ -32,16 +50,18 @@ const PaymentTable = ({ plans, currentPlan, setPlanSelection, setIsPaymentPlanMo
             </div>
             {plans.map(plan => (
               <div
-                key={plan.title}
-                className={`billing-card card-transparent ${currentPlan?.id === plan.id ? 'current' : ''}`}
+                key={plan.metadata['UI Label']}
+                className={`billing-card card-transparent ${currentPlan?.id === plan?.id ? 'current' : ''}`}
               >
-                <div key={plan.title} className="billing-plan">
-                  <h4 className="billing-plan-title">{plan.title}</h4>
+                <div key={plan.metadata['UI Label']} className="billing-plan">
+                  <h4 className="billing-plan-title">{plan.metadata['UI Label']}</h4>
                   <div>
-                    <div className="billing-plan-amount">{plan.price}</div>
+                    <div className="billing-plan-amount">
+                      {formatCurrency((plan?.tiers?.[0]?.flat_amount ?? 0) / 100, true)}/mo
+                    </div>
                   </div>
 
-                  {currentPlan?.id === 'earlyAdopter' && plan.id === 'earlyAdopter' ? (
+                  {currentPlan.id === 'earlyAdopter' && plan.id === 'earlyAdopter' ? (
                     <div className="billing-plan-details">
                       <p className="early-adopter-desc">
                         As an Early Adopter, you already get our lowest storage rate.
@@ -49,13 +69,17 @@ const PaymentTable = ({ plans, currentPlan, setPlanSelection, setIsPaymentPlanMo
                     </div>
                   ) : (
                     <div className="billing-plan-details">
-                      <p>{plan.baseStorage}</p>
-                      <p>{plan.additionalStorage}</p>
-                      <p>{plan.bandwidth}</p>
+                      <p>{formatAsStorageAmount(plan.tiers?.[0]?.up_to)}</p>
+                      <p>{getAdditionalStoragePrice(plan.tiers?.[1]?.unit_amount)}</p>
+                      <p>
+                        {plan.metadata['Bandwidth']
+                          ? `${formatAsStorageAmount(plan.metadata['Bandwidth'])} / month`
+                          : 'N/A'}
+                      </p>
                     </div>
                   )}
 
-                  {currentPlan?.id !== plan.id && plan.id !== 'earlyAdopter' && (
+                  {currentPlan?.id !== plan?.id && plan?.id !== 'earlyAdopter' && (
                     <Button
                       variant="light"
                       disabled={currentPlan?.id === 'earlyAdopter'}
@@ -69,8 +93,8 @@ const PaymentTable = ({ plans, currentPlan, setPlanSelection, setIsPaymentPlanMo
                     </Button>
                   )}
 
-                  {(currentPlan?.id === plan.id ||
-                    (currentPlan?.id === 'earlyAdopter' && plan.id === 'earlyAdopter')) && (
+                  {(currentPlan.id === plan.id ||
+                    (currentPlan.id === 'earlyAdopter' && plan.id === 'earlyAdopter')) && (
                     <Button variant="light" disabled={true} className="">
                       Current Plan
                     </Button>

--- a/packages/website/components/account/paymentTable.js/paymentTable.js
+++ b/packages/website/components/account/paymentTable.js/paymentTable.js
@@ -23,17 +23,18 @@ const PaymentTable = ({ plans: plansProp, currentPlan, setPlanSelection, setIsPa
       {currentPlan && (
         <p className="billing-content-intro" data-testid="currentPlanIndicator">
           <span>
-            Your current plan is:{' '}
-            <strong data-testid="currentPlan.metadata['UI Label']">
-              {currentPlan?.metadata['UI Label'] ?? 'Custom'}
-            </strong>
+            Your current plan is: <strong data-testid="currentPlan.label">{currentPlan?.label ?? 'Custom'}</strong>
           </span>
         </p>
       )}
 
       <div>
         <div>
-          <div className={`billing-plans-table ${currentPlan?.id === 'earlyAdopter' && 'early-adopter'}`}>
+          <div
+            className={`billing-plans-table ${currentPlan?.isPreferred && 'preferred'} ${
+              !currentPlan?.tiers?.length ? 'no-tiers' : ''
+            }`}
+          >
             <div className="billing-play-key">
               <div></div>
               <div></div>
@@ -50,39 +51,33 @@ const PaymentTable = ({ plans: plansProp, currentPlan, setPlanSelection, setIsPa
             </div>
             {plans.map(plan => (
               <div
-                key={plan.metadata['UI Label']}
+                key={plan.id}
                 className={`billing-card card-transparent ${currentPlan?.id === plan?.id ? 'current' : ''}`}
               >
-                <div key={plan.metadata['UI Label']} className="billing-plan">
-                  <h4 className="billing-plan-title">{plan.metadata['UI Label']}</h4>
+                <div className="billing-plan">
+                  <h4 className="billing-plan-title">{plan.label}</h4>
                   <div>
                     <div className="billing-plan-amount">
-                      {formatCurrency((plan?.tiers?.[0]?.flat_amount ?? 0) / 100, true)}/mo
+                      {formatCurrency((plan?.tiers?.[0]?.flatAmount ?? 0) / 100, true)}/mo
                     </div>
                   </div>
 
-                  {currentPlan.id === 'earlyAdopter' && plan.id === 'earlyAdopter' ? (
+                  {!currentPlan?.tiers?.length && plan.id === currentPlan.id ? (
                     <div className="billing-plan-details">
-                      <p className="early-adopter-desc">
-                        As an Early Adopter, you already get our lowest storage rate.
-                      </p>
+                      <p className="preferred-desc">{currentPlan.description}</p>
                     </div>
                   ) : (
                     <div className="billing-plan-details">
-                      <p>{formatAsStorageAmount(plan.tiers?.[0]?.up_to)}</p>
-                      <p>{getAdditionalStoragePrice(plan.tiers?.[1]?.unit_amount)}</p>
-                      <p>
-                        {plan.metadata['Bandwidth']
-                          ? `${formatAsStorageAmount(plan.metadata['Bandwidth'])} / month`
-                          : 'N/A'}
-                      </p>
+                      <p>{formatAsStorageAmount(plan.tiers?.[0]?.upTo)}</p>
+                      <p>{getAdditionalStoragePrice(plan.tiers?.[1]?.unitAmount)}</p>
+                      <p>{plan.bandwidth ? `${formatAsStorageAmount(plan.bandwidth)} / month` : 'N/A'}</p>
                     </div>
                   )}
 
-                  {currentPlan?.id !== plan?.id && plan?.id !== 'earlyAdopter' && (
+                  {currentPlan?.id !== plan?.id && (
                     <Button
                       variant="light"
-                      disabled={currentPlan?.id === 'earlyAdopter'}
+                      disabled={currentPlan?.isPreferred}
                       className=""
                       onClick={() => {
                         setPlanSelection(plans.find(p => p.id === plan.id));
@@ -93,8 +88,7 @@ const PaymentTable = ({ plans: plansProp, currentPlan, setPlanSelection, setIsPa
                     </Button>
                   )}
 
-                  {(currentPlan.id === plan.id ||
-                    (currentPlan.id === 'earlyAdopter' && plan.id === 'earlyAdopter')) && (
+                  {currentPlan.id === plan.id && (
                     <Button variant="light" disabled={true} className="">
                       Current Plan
                     </Button>
@@ -102,7 +96,7 @@ const PaymentTable = ({ plans: plansProp, currentPlan, setPlanSelection, setIsPa
                 </div>
               </div>
             ))}
-            {currentPlan?.id === 'earlyAdopter' && <p className="early-adopter-ui-block"></p>}
+            {currentPlan?.isPreferred && <p className="preferred-ui-block"></p>}
           </div>
         </div>
       </div>

--- a/packages/website/components/account/paymentTable.js/paymentTable.js
+++ b/packages/website/components/account/paymentTable.js/paymentTable.js
@@ -23,7 +23,7 @@ const PaymentTable = ({ plans: plansProp, currentPlan, setPlanSelection, setIsPa
       {currentPlan && (
         <p className="billing-content-intro" data-testid="currentPlanIndicator">
           <span>
-            Your current plan is: <strong data-testid="currentPlan.label">{currentPlan?.label ?? 'Custom'}</strong>
+            Your current plan is: <strong data-testid="currentPlan.label">{currentPlan.label}</strong>
           </span>
         </p>
       )}

--- a/packages/website/components/account/storageManager/storageManager.js
+++ b/packages/website/components/account/storageManager/storageManager.js
@@ -36,9 +36,7 @@ const StorageManager = ({ className = '', content }) => {
     if (currentPlan?.id === 'earlyAdopter') {
       return data?.storageLimitBytes || defaultStorageLimit;
     } else {
-      const byteConversion = currentPlan?.tiers?.[0].up_to
-        ? gibibyte * currentPlan.tiers[0].up_to
-        : defaultStorageLimit;
+      const byteConversion = currentPlan?.tiers?.[0].upTo ? gibibyte * currentPlan.tiers[0].upTo : defaultStorageLimit;
       return byteConversion;
     }
   }, [data, currentPlan]);
@@ -103,7 +101,7 @@ const StorageManager = ({ className = '', content }) => {
           Want more storage? Upgrade your plan here!
         </a>
       </Link>
-      <h6>Your Plan: {currentPlan?.metadata['UI Label']}</h6>
+      <h6>Your Plan: {currentPlan?.label}</h6>
       <div className="storage-manager-space">
         <div className="storage-manager-used">
           {isLoading ? (
@@ -126,7 +124,7 @@ const StorageManager = ({ className = '', content }) => {
                 <>
                   &nbsp;of{' '}
                   <span className="storage-number">
-                    {currentPlan?.tiers?.[0].up_to ? formatAsStorageAmount(currentPlan?.tiers?.[0].up_to) : ''}
+                    {currentPlan?.tiers?.[0].upTo ? formatAsStorageAmount(currentPlan?.tiers?.[0].upTo) : ''}
                   </span>{' '}
                   used
                 </>

--- a/packages/website/components/account/storageManager/storageManager.js
+++ b/packages/website/components/account/storageManager/storageManager.js
@@ -4,7 +4,7 @@ import { useMemo, useEffect, useState, useRef } from 'react';
 import Link from 'next/link';
 
 import { useUser } from 'components/contexts/userContext';
-import { elementIsInViewport } from 'lib/utils';
+import { elementIsInViewport, formatAsStorageAmount } from 'lib/utils';
 import { usePayment } from '../../../hooks/use-payment';
 import Tooltip from 'ZeroComponents/tooltip/tooltip';
 import InfoIcon from 'assets/icons/info';
@@ -36,7 +36,9 @@ const StorageManager = ({ className = '', content }) => {
     if (currentPlan?.id === 'earlyAdopter') {
       return data?.storageLimitBytes || defaultStorageLimit;
     } else {
-      const byteConversion = currentPlan ? gibibyte * parseInt(currentPlan.baseStorage) : defaultStorageLimit;
+      const byteConversion = currentPlan?.tiers?.[0].up_to
+        ? gibibyte * currentPlan.tiers[0].up_to
+        : defaultStorageLimit;
       return byteConversion;
     }
   }, [data, currentPlan]);
@@ -101,7 +103,7 @@ const StorageManager = ({ className = '', content }) => {
           Want more storage? Upgrade your plan here!
         </a>
       </Link>
-      <h6>Your Plan: {currentPlan?.title}</h6>
+      <h6>Your Plan: {currentPlan?.metadata['UI Label']}</h6>
       <div className="storage-manager-space">
         <div className="storage-manager-used">
           {isLoading ? (
@@ -122,7 +124,11 @@ const StorageManager = ({ className = '', content }) => {
                 </>
               ) : (
                 <>
-                  &nbsp;of <span className="storage-number">{currentPlan?.baseStorage}</span> used
+                  &nbsp;of{' '}
+                  <span className="storage-number">
+                    {currentPlan?.tiers?.[0].up_to ? formatAsStorageAmount(currentPlan?.tiers?.[0].up_to) : ''}
+                  </span>{' '}
+                  used
                 </>
               )}
               <Tooltip content={content.tooltip_total}>

--- a/packages/website/components/account/storageManager/storageManager.js
+++ b/packages/website/components/account/storageManager/storageManager.js
@@ -98,7 +98,7 @@ const StorageManager = ({ className = '', content }) => {
     <div ref={storageManagerRef} className={clsx('section storage-manager-container', className)}>
       <Link href={'account/payment'} passHref>
         <a href={'account/payment'} className="storage-manager-payment-link">
-          Want more storage? Upgrade your plan here!
+          {currentPlan?.isPreferred ? 'View your plan details here.' : 'Want more storage? Upgrade your plan here!'}
         </a>
       </Link>
       <h6>Your Plan: {currentPlan?.label}</h6>

--- a/packages/website/components/accountPlansModal/accountPlansModal.js
+++ b/packages/website/components/accountPlansModal/accountPlansModal.js
@@ -124,7 +124,12 @@ const AccountPlansModal = ({
               if (currentPlan.id === 'earlyAdopter') {
                 throw new Error('Change plan modal form submitted with early adopter plan, but it must be a paid plan');
               }
-              await userBillingSettings(consentedTosAgreement, savedPaymentMethod.id, { price: currentPlan.id });
+              if (currentPlan.id !== 'free' && currentPlan.id !== 'pro' && currentPlan.id !== 'lite') {
+                throw new Error('Unrecognized plan');
+              }
+              await userBillingSettings(consentedTosAgreement, savedPaymentMethod.id, {
+                price: currentPlan.id,
+              });
               await setCurrentPlan(currentPlan);
               setIsCreatingSub(false);
               onClose();

--- a/packages/website/components/contexts/plansContext.js
+++ b/packages/website/components/contexts/plansContext.js
@@ -28,6 +28,7 @@
  * @typedef {object} Plan
  * @property {string} id
  * @property {string} label
+ * @property {boolean} isPreferred
  * @property {string|null} description
  * @property {string|null} bandwidth
  * @property {StripeTier[]} [tiers]
@@ -39,6 +40,7 @@ export const sharedPlans = [
     description: 'For those that want to take advantage of more storage',
     label: 'Lite',
     bandwidth: '60',
+    isPreferred: false,
     tiers: [
       {
         flatAmount: 300,
@@ -57,6 +59,7 @@ export const sharedPlans = [
     description: 'Our lowest price per GiB stored. For those with use cases that require scale.',
     label: 'Expert',
     bandwidth: '24',
+    isPreferred: false,
     tiers: [
       {
         flatAmount: 1000,
@@ -77,6 +80,7 @@ export const freePlan = {
   description: 'You are currently on the free tier. You can use our service up to 5GiB/mo without being charged.',
   label: 'Free',
   bandwidth: '10',
+  isPreferred: false,
   tiers: [
     {
       flatAmount: 0,
@@ -94,6 +98,7 @@ export const freePlan = {
 export const earlyAdopterPlan = {
   id: /** @type {const} */ ('earlyAdopter'),
   isPreferred: true,
+  bandwidth: null,
   description:
     'As an early adopter we appreciate your support and can continue to use the storage you are already accustomed to.',
   label: 'Early Adopter',

--- a/packages/website/components/contexts/plansContext.js
+++ b/packages/website/components/contexts/plansContext.js
@@ -19,56 +19,54 @@
 
 /**
  * @typedef {object} StripeTier
- * @property {number|null} flat_amount
- * @property {number|null} unit_amount
- * @property {number|null} up_to
+ * @property {number|null} flatAmount
+ * @property {number|null} unitAmount
+ * @property {number|null} upTo
  */
 
 /**
  * @typedef {object} Plan
  * @property {string} id
- * @property {import("@stripe/stripe-js").Metadata} metadata
+ * @property {string} label
+ * @property {string|null} description
+ * @property {string|null} bandwidth
  * @property {StripeTier[]} [tiers]
  */
 
 export const sharedPlans = [
   {
     id: /** @type {const} */ ('lite'),
-    metadata: {
-      Description: 'For those that want to take advantage of more storage',
-      'UI Label': 'Lite',
-      Bandwidth: '60',
-    },
+    description: 'For those that want to take advantage of more storage',
+    label: 'Lite',
+    bandwidth: '60',
     tiers: [
       {
-        flat_amount: 300,
-        unit_amount: 0,
-        up_to: 15,
+        flatAmount: 300,
+        unitAmount: 0,
+        upTo: 15,
       },
       {
-        flat_amount: null,
-        unit_amount: 20,
-        up_to: null,
+        flatAmount: null,
+        unitAmount: 20,
+        upTo: null,
       },
     ],
   },
   {
     id: /** @type {const} */ ('pro'),
-    metadata: {
-      Description: 'Our lowest price per GiB stored. For those with use cases that require scale.',
-      'UI Label': 'Expert',
-      Bandwidth: '24',
-    },
+    description: 'Our lowest price per GiB stored. For those with use cases that require scale.',
+    label: 'Expert',
+    bandwidth: '24',
     tiers: [
       {
-        flat_amount: 1000,
-        unit_amount: null,
-        up_to: 60,
+        flatAmount: 1000,
+        unitAmount: null,
+        upTo: 60,
       },
       {
-        flat_amount: null,
-        unit_amount: 20,
-        up_to: null,
+        flatAmount: null,
+        unitAmount: 20,
+        upTo: null,
       },
     ],
   },
@@ -76,32 +74,29 @@ export const sharedPlans = [
 
 export const freePlan = {
   id: /** @type {const} */ ('free'),
-  metadata: {
-    Description: 'You are currently on the free tier. You can use our service up to 5GiB/mo without being charged.',
-    'UI Label': 'Free',
-    Bandwidth: '10',
-  },
+  description: 'You are currently on the free tier. You can use our service up to 5GiB/mo without being charged.',
+  label: 'Free',
+  bandwidth: '10',
   tiers: [
     {
-      flat_amount: 0,
-      unit_amount: 0,
-      up_to: 5,
+      flatAmount: 0,
+      unitAmount: 0,
+      upTo: 5,
     },
     {
-      flat_amount: 0,
-      unit_amount: 20,
-      up_to: null,
+      flatAmount: 0,
+      unitAmount: 20,
+      upTo: null,
     },
   ],
 };
 
 export const earlyAdopterPlan = {
   id: /** @type {const} */ ('earlyAdopter'),
-  metadata: {
-    Description:
-      'As an early adopter we appreciate your support and can continue to use the storage you are already accustomed to.',
-    'UI Label': 'Early Adopter',
-  },
+  isPreferred: true,
+  description:
+    'As an early adopter we appreciate your support and can continue to use the storage you are already accustomed to.',
+  label: 'Early Adopter',
   tiers: [],
 };
 

--- a/packages/website/components/contexts/plansContext.js
+++ b/packages/website/components/contexts/plansContext.js
@@ -4,7 +4,7 @@
 
 /**
  * @typedef {object} StorageSubscription
- * @property {StoragePrice} price
+ * @property {StoragePrice|Plan} price
  */
 
 /**
@@ -18,76 +18,93 @@
  */
 
 /**
+ * @typedef {object} StripeTier
+ * @property {number|null} flat_amount
+ * @property {number|null} unit_amount
+ * @property {number|null} up_to
+ */
+
+/**
  * @typedef {object} Plan
- * @property {StoragePrice|EarlyAdopterPlanId} id
- * @property {string} title
- * @property {string} description
- * @property {string} price
- * @property {string} baseStorage
- * @property {string} additionalStorage
- * @property {string} bandwidth
- * @property {string} blockLimit
+ * @property {string} id
+ * @property {import("@stripe/stripe-js").Metadata} metadata
+ * @property {StripeTier[]} [tiers]
  */
 
 export const sharedPlans = [
   {
     id: /** @type {const} */ ('lite'),
-    title: 'Lite',
-    description: 'For those that want to take advantage of more storage',
-    price: '$3/mo',
-    baseStorage: '30GiB',
-    additionalStorage: '$0.10 / GiB',
-    bandwidth: '60GiB / month',
-    blockLimit: '10,000 / GiB',
+    metadata: {
+      Description: 'For those that want to take advantage of more storage',
+      'UI Label': 'Lite',
+      Bandwidth: '60',
+    },
+    tiers: [
+      {
+        flat_amount: 300,
+        unit_amount: 0,
+        up_to: 15,
+      },
+      {
+        flat_amount: null,
+        unit_amount: 20,
+        up_to: null,
+      },
+    ],
   },
   {
     id: /** @type {const} */ ('pro'),
-    title: 'Expert',
-    description: 'Our lowest price per GiB stored. For those with use cases that require scale.',
-    price: '$10/mo',
-    baseStorage: '120GiB',
-    additionalStorage: '$0.08 / GiB',
-    bandwidth: '240GiB / month',
-    blockLimit: '10,000 / GiB',
+    metadata: {
+      Description: 'Our lowest price per GiB stored. For those with use cases that require scale.',
+      'UI Label': 'Expert',
+      Bandwidth: '24',
+    },
+    tiers: [
+      {
+        flat_amount: 1000,
+        unit_amount: null,
+        up_to: 60,
+      },
+      {
+        flat_amount: null,
+        unit_amount: 20,
+        up_to: null,
+      },
+    ],
   },
 ];
 
 export const freePlan = {
   id: /** @type {const} */ ('free'),
-  title: 'Free',
-  description: 'You are currently on the free tier. You can use our service up to 5GiB/mo without being charged.',
-  price: '$0/mo',
-  baseStorage: '5GiB',
-  additionalStorage: 'N/A',
-  bandwidth: '10GiB / month',
-  blockLimit: '2,500 / GiB',
+  metadata: {
+    Description: 'You are currently on the free tier. You can use our service up to 5GiB/mo without being charged.',
+    'UI Label': 'Free',
+    Bandwidth: '10',
+  },
+  tiers: [
+    {
+      flat_amount: 0,
+      unit_amount: 0,
+      up_to: 5,
+    },
+    {
+      flat_amount: 0,
+      unit_amount: 20,
+      up_to: null,
+    },
+  ],
 };
 
 export const earlyAdopterPlan = {
   id: /** @type {const} */ ('earlyAdopter'),
-  title: 'Early Adopter',
-  description:
-    'As an early adopter we appreciate your support and can continue to use the storage you are already accustomed to.',
-  price: '$0/mo',
-  baseStorage: '25GiB',
-  additionalStorage: 'NA',
-  bandwidth: '10Gib / month',
-  blockLimit: '2,500 / GiB',
+  metadata: {
+    Description:
+      'As an early adopter we appreciate your support and can continue to use the storage you are already accustomed to.',
+    'UI Label': 'Early Adopter',
+  },
+  tiers: [],
 };
 
 export const plans = [freePlan, ...sharedPlans];
 export const plansEarly = [earlyAdopterPlan, ...sharedPlans];
 export const plansAll = [freePlan, earlyAdopterPlan, ...sharedPlans];
-
-/**
- * Given a plan id, return the corresponding storage subscription object
- * that can be sent to /user/payment api (which doesn't have 'plans')
- * @param {Plan['id']} planId
- * @returns {StorageSubscription|EarlyAdopterStorageSubscription}
- */
-export function planIdToStorageSubscription(planId) {
-  if (planId === 'earlyAdopter') {
-    return null;
-  }
-  return { price: planId };
-}

--- a/packages/website/hooks/use-payment.js
+++ b/packages/website/hooks/use-payment.js
@@ -75,9 +75,15 @@ export const usePayment = () => {
       // user has no storage subscription, show early adopter plan
       return earlyAdopterPlan;
     }
-    return planList.find(plan => {
+    const matchingStandardPlan = planList.find(plan => {
       return plan.id === storageSubscription.price;
     });
+
+    if (!matchingStandardPlan && typeof storageSubscription.price !== 'string') {
+      return storageSubscription.price;
+    }
+
+    return matchingStandardPlan;
   }, [planList, paymentSettings, optimisticCurrentPlan]);
 
   const savedPaymentMethod = useMemo(() => {

--- a/packages/website/lib/utils.js
+++ b/packages/website/lib/utils.js
@@ -14,6 +14,31 @@ export const formatTimestamp = timestamp => {
   return formattedDate;
 };
 
+/**
+ * Returns the amount in TiBs if the amount is a multiple of 1024, otherwise returns the amount in GiBs
+ * @param {number} amountInGiB
+ * @returns {string}
+ */
+export const formatAsStorageAmount = amountInGiB =>
+  amountInGiB % 1024 === 0 ? `${amountInGiB / 1024} TiB` : `${amountInGiB} GiB`;
+
+/**
+ * Formats an amount (in dollars) as a currency
+ * @param {number} amount
+ * @param {boolean} shouldTruncateToDollar
+ * @returns {string}
+ */
+export const formatCurrency = (amount, shouldTruncateToDollar = false) => {
+  if (isNaN(amount)) return '';
+
+  const formatter = new Intl.NumberFormat('en-US', {
+    style: 'currency',
+    currency: 'USD',
+    minimumFractionDigits: shouldTruncateToDollar ? 0 : 2,
+  });
+  return formatter.format(amount);
+};
+
 export const formatTimestampFull = timestamp => {
   const formattedDate = new Date(timestamp).toLocaleDateString(undefined, {
     year: 'numeric',

--- a/packages/website/lib/utils.js
+++ b/packages/website/lib/utils.js
@@ -38,7 +38,7 @@ export const formatAsStorageAmount = amountInGiB => {
 export const formatCurrency = (amount, shouldTruncateToDollar = false) => {
   if (isNaN(amount)) return '';
 
-  const formatter = new Intl.NumberFormat('en-US', {
+  const formatter = new Intl.NumberFormat(undefined, {
     style: 'currency',
     currency: 'USD',
     minimumFractionDigits: shouldTruncateToDollar ? 0 : 2,

--- a/packages/website/lib/utils.js
+++ b/packages/website/lib/utils.js
@@ -19,8 +19,15 @@ export const formatTimestamp = timestamp => {
  * @param {number} amountInGiB
  * @returns {string}
  */
-export const formatAsStorageAmount = amountInGiB =>
-  amountInGiB % 1024 === 0 ? `${amountInGiB / 1024} TiB` : `${amountInGiB} GiB`;
+export const formatAsStorageAmount = amountInGiB => {
+  if (amountInGiB % 1024 === 0) {
+    return `${amountInGiB / 1024} TiB`;
+  } else if (amountInGiB > 1024) {
+    return `${(amountInGiB / 1024).toFixed(2)} TiB`;
+  } else {
+    return `${amountInGiB} GiB`;
+  }
+};
 
 /**
  * Formats an amount (in dollars) as a currency

--- a/packages/website/pages/account/index.scss
+++ b/packages/website/pages/account/index.scss
@@ -268,40 +268,52 @@
     margin: 0;
   }
 
-  &.early-adopter {
-    .billing-play-key {
-      display: none;
-    }
+  .billing-card:nth-child(2) {
+    grid-row: 1;
+    grid-column: 1;
+  }
+  .billing-card:nth-child(3) {
+    grid-row: 2;
+    grid-column: 1;
+  }
+  .billing-card:nth-child(4) {
+    grid-row: 3;
+    grid-column: 1;
+  }
+  @media screen and (min-width: 901px) {
     .billing-card:nth-child(2) {
       grid-row: 1;
-      grid-column: 1;
+      grid-column: 2;
     }
     .billing-card:nth-child(3) {
-      grid-row: 2;
-      grid-column: 1;
+      grid-row: 1;
+      grid-column: 3;
     }
     .billing-card:nth-child(4) {
-      grid-row: 3;
-      grid-column: 1;
+      grid-row: 1;
+      grid-column: 4;
+    }
+  }
+  .billing-card:not(.current) {
+    opacity: 1;
+  }
+
+  &.no-tiers {
+    .billing-play-key {
+      display: none;
     }
     @media screen and (min-width: 901px) {
       grid-template-columns: 1fr 1fr 1fr;
 
       .billing-card:nth-child(2) {
-        grid-row: 1;
         grid-column: 1;
       }
       .billing-card:nth-child(3) {
-        grid-row: 1;
         grid-column: 2;
       }
       .billing-card:nth-child(4) {
-        grid-row: 1;
         grid-column: 3;
       }
-    }
-    .billing-card:not(.current) {
-      opacity: 1;
     }
     .billing-card.current {
       p {
@@ -311,11 +323,11 @@
     }
   }
 
-  .early-adopter-ui-block {
+  .preferred-ui-block {
     grid-column: 1;
     grid-row: 2/5;
     @media screen and (min-width: 901px) {
-      grid-column: 2/4;
+      grid-column: 3/5;
       grid-row: 1/2;
     }
     padding: 5rem;
@@ -329,6 +341,12 @@
     flex-direction: column;
     gap: 18px;
     justify-content: center;
+  }
+}
+
+.no-tiers .preferred-ui-block {
+  @media screen and (min-width: 901px) {
+    grid-column: 2/4;
   }
 }
 
@@ -355,7 +373,7 @@
       min-width: 150px;
       width: 50%;
       margin-bottom: 0.5rem;
-      &.early-adopter-desc {
+      &.preferred-desc {
         width: 100%;
       }
       &:before {

--- a/packages/website/pages/account/payment.js
+++ b/packages/website/pages/account/payment.js
@@ -129,9 +129,11 @@ const PaymentSettingsPage = props => {
       // user has no storage subscription, show early adopter plan
       return earlyAdopterPlan;
     }
-    return planList.find(plan => {
-      return plan.id === storageSubscription.price;
-    });
+    return typeof storageSubscription.price === 'string'
+      ? planList.find(plan => {
+          return plan.id === storageSubscription.price;
+        })
+      : storageSubscription.price;
   }, [planList, paymentSettings, optimisticCurrentPlan]);
   const savedPaymentMethod = useMemo(() => {
     return paymentSettings?.paymentMethod;


### PR DESCRIPTION
This continues to only allow the _selection_ of a standard plan, but if a user is associated with a non-standard plan in Stripe we will now return this data (specifically tier information and metadata) to the UI in order to populate custom cards.  This will be necessary as we migrate early adopters to custom plans as well as for custom plan functionality in general.

![image](https://user-images.githubusercontent.com/99349687/206032261-07afeb5b-cdd9-4b5b-bb42-a8c713ef71c8.png)

This also includes an API change to ensure that all of our users have at least a subscription to the Free tier.  We want to migrate away from modeling early adopters as users without a subscription and instead explicitly put them into a tier.

Update UIs
See [here](https://www.notion.so/UIs-for-custom-plans-post-migration-df237239d19049e999e2284478ed372d)

- [x] Handle description metadata from Stripe
- [x] Include Stripe metadata to prevent selecting other plans in the UI
- [x] Add "View your plan details here." text
