### PR TITLE
fix: update docs for PSA with IPLD codec info

### DIFF
--- a/packages/website/pages/docs/how-tos/pinning-services-api.md
+++ b/packages/website/pages/docs/how-tos/pinning-services-api.md
@@ -3,6 +3,8 @@ title: Pinning Services API
 description: Learn how to pin a file to IPFS using the Pinning Services API
 ---
 
+import Callout from 'components/callout/callout';
+
 # Pinning Services API
 
 [IPFS](https://ipfs.io/) is a distributed storage network. Data is cached on IPFS nodes. All content uploaded to web3.storage's IPFS nodes are persisted until told otherwise, but some nodes might garbage collect to make room for new content. A remote pinning service allows users to save and persist data that is already available on the IPFS network on its set of IPFS nodes. For instance, if you uploaded a file to your local IPFS node but don't want to make sure your computer is always connected to IPFS and this file is always served, you can remote pin it to a pinning service.
@@ -10,6 +12,12 @@ description: Learn how to pin a file to IPFS using the Pinning Services API
 web3.storage provides a pinning service that complies with the [IPFS Pinning Service API specification](https://ipfs.github.io/pinning-services-api-spec/).
 
 For a full list and documentation of all the available pinning service endpoints, visit the [IPFS Pinning Service API endpoint documentation](https://ipfs.github.io/pinning-services-api-spec/#tag/pins).
+
+<Callout type="info">
+### IPLD codecs
+Web3.storage Pinning APIs only support raw, dag-pb, dag-cbor and dag-json IPLD codecs.
+The APIs doesn't support pinning content by providing IPNS records pointing to it.
+</Callout>
 
 ## Requesting access
 

--- a/packages/website/pages/docs/how-tos/pinning-services-api.md
+++ b/packages/website/pages/docs/how-tos/pinning-services-api.md
@@ -13,12 +13,6 @@ web3.storage provides a pinning service that complies with the [IPFS Pinning Ser
 
 For a full list and documentation of all the available pinning service endpoints, visit the [IPFS Pinning Service API endpoint documentation](https://ipfs.github.io/pinning-services-api-spec/#tag/pins).
 
-<Callout type="info">
-### IPLD codecs
-Web3.storage Pinning APIs only support raw, dag-pb, dag-cbor and dag-json IPLD codecs.
-The API doesn't support pinning content by providing IPNS records pointing to it.
-</Callout>
-
 ## Requesting access
 
 To request access to the pinning service for your web3.storage account, you will need to navigate to [your token management page](https://web3.storage/tokens) and click the button labeled "Request API Pinning Access". Fill out the form and then, once approved, you will be able to access the pinning service API endpoints using your [API token](/docs/how-tos/generate-api-token).
@@ -26,6 +20,12 @@ To request access to the pinning service for your web3.storage account, you will
 ## Using the HTTP API
 
 The web3.storage pinning service endpoint for all requests is [https://api.web3.storage/pins](https://api.web3.storage/pins).
+
+<Callout type="info">
+### IPLD codecs
+Web3.storage Pinning APIs only support raw, dag-pb, dag-cbor and dag-json IPLD codecs.
+The API doesn't support pinning content by providing IPNS records pointing to it.
+</Callout>
 
 ### Add a pin
 

--- a/packages/website/pages/docs/how-tos/pinning-services-api.md
+++ b/packages/website/pages/docs/how-tos/pinning-services-api.md
@@ -16,7 +16,7 @@ For a full list and documentation of all the available pinning service endpoints
 <Callout type="info">
 ### IPLD codecs
 Web3.storage Pinning APIs only support raw, dag-pb, dag-cbor and dag-json IPLD codecs.
-The APIs doesn't support pinning content by providing IPNS records pointing to it.
+The API doesn't support pinning content by providing IPNS records pointing to it.
 </Callout>
 
 ## Requesting access


### PR DESCRIPTION
related to #2154 

This PR specifically covers updating the [docs](https://web3.storage/docs/how-tos/pinning-services-api/) part.