### PR TITLE
feat: website has /.well-known/did.json so did:web can resolve in prod

### DIFF
--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -192,6 +192,8 @@ jobs:
           NEXT_PUBLIC_COUNTLY_URL: ${{ secrets.COUNTLY_URL }}
           NEXT_PUBLIC_COUNTLY_KEY: ${{ secrets.COUNTLY_KEY }}
           NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY: ${{ secrets.TESTING_STRIPE_PUBLISHABLE_KEY }}
+          DID_DOCUMENT_ID: ${{ secrets.STAGING_DID_DOCUMENT_ID }}
+          DID_DOCUMENT_ALSO_KNOWN_AS: ${{ secrets.STAGING_DID_DOCUMENT_ALSO_KNOWN_AS }}
       - name: Add to web3.storage
         uses: web3-storage/add-to-web3@v2
         id: ipfs
@@ -285,6 +287,8 @@ jobs:
           NEXT_PUBLIC_COUNTLY_URL: ${{ secrets.COUNTLY_URL }}
           NEXT_PUBLIC_COUNTLY_KEY: ${{ secrets.COUNTLY_KEY }}
           NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY: ${{ secrets.STRIPE_PUBLISHABLE_KEY }}
+          DID_DOCUMENT_ID: ${{ secrets.PRODUCTION_DID_DOCUMENT_ID }}
+          DID_DOCUMENT_ALSO_KNOWN_AS: ${{ secrets.PRODUCTION_DID_DOCUMENT_ALSO_KNOWN_AS }}
       - name: Add to web3.storage
         uses: web3-storage/add-to-web3@v2
         id: ipfs

--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -193,7 +193,7 @@ jobs:
           NEXT_PUBLIC_COUNTLY_KEY: ${{ secrets.COUNTLY_KEY }}
           NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY: ${{ secrets.TESTING_STRIPE_PUBLISHABLE_KEY }}
           DID_DOCUMENT_ID: ${{ secrets.STAGING_DID_DOCUMENT_ID }}
-          DID_DOCUMENT_ALSO_KNOWN_AS: ${{ secrets.STAGING_DID_DOCUMENT_ALSO_KNOWN_AS }}
+          DID_DOCUMENT_PRIMARY_DID_KEY: ${{ secrets.STAGING_DID_DOCUMENT_PRIMARY_DID_KEY }}
       - name: Add to web3.storage
         uses: web3-storage/add-to-web3@v2
         id: ipfs
@@ -288,7 +288,7 @@ jobs:
           NEXT_PUBLIC_COUNTLY_KEY: ${{ secrets.COUNTLY_KEY }}
           NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY: ${{ secrets.STRIPE_PUBLISHABLE_KEY }}
           DID_DOCUMENT_ID: ${{ secrets.PRODUCTION_DID_DOCUMENT_ID }}
-          DID_DOCUMENT_ALSO_KNOWN_AS: ${{ secrets.PRODUCTION_DID_DOCUMENT_ALSO_KNOWN_AS }}
+          DID_DOCUMENT_PRIMARY_DID_KEY: ${{ secrets.PRODUCTION_DID_DOCUMENT_PRIMARY_DID_KEY }}
       - name: Add to web3.storage
         uses: web3-storage/add-to-web3@v2
         id: ipfs

--- a/packages/website/package.json
+++ b/packages/website/package.json
@@ -9,7 +9,7 @@
     "did-document": "ts-node -O '{\"module\": \"commonjs\"}' scripts/did-document.ts",
     "start": "env-cmd -f ../../.env next dev -p 4000",
     "prebuild": "sh ./scripts/prebuild.sh",
-    "build": "next build && npm run build:did-document && next-sitemap && next export",
+    "build": "next build && npm run build:did.json && next-sitemap && next export",
     "build:did.json": "npm run -s did-document > public/.well-known/did.json",
     "postbuild": "sh ./scripts/postbuild.sh",
     "export": "next export",

--- a/packages/website/package.json
+++ b/packages/website/package.json
@@ -6,9 +6,11 @@
   "scripts": {
     "ci:envfile": "ts-node -O '{\"module\": \"commonjs\"}' scripts/envfile.ts ",
     "dev": "rm -rf .next && next dev -p 4000",
+    "did-document": "ts-node -O '{\"module\": \"commonjs\"}' scripts/did-document.ts",
     "start": "env-cmd -f ../../.env next dev -p 4000",
     "prebuild": "sh ./scripts/prebuild.sh",
-    "build": "next build && next-sitemap && next export",
+    "build": "next build && npm run build:did-document && next-sitemap && next export",
+    "build:did.json": "npm run -s did-document > public/.well-known/did.json",
     "postbuild": "sh ./scripts/postbuild.sh",
     "export": "next export",
     "test": "eslint './**/*.js' && tsc --build",

--- a/packages/website/public/.well-known/.gitignore
+++ b/packages/website/public/.well-known/.gitignore
@@ -1,0 +1,1 @@
+/did.json

--- a/packages/website/scripts/did-document.ts
+++ b/packages/website/scripts/did-document.ts
@@ -1,0 +1,14 @@
+export async function main() {
+  console.error('generating did document');
+  const didDocument = createDidDocument();
+  console.log(JSON.stringify(didDocument, null, 2));
+}
+
+main();
+
+function createDidDocument(env=process.env) {
+  return {
+    id: env.DID_DOCUMENT_ID,
+    alsoKnownAs: env.DID_DOCUMENT_ALSO_KNOWN_AS,
+  };
+}

--- a/packages/website/scripts/did-document.ts
+++ b/packages/website/scripts/did-document.ts
@@ -6,9 +6,17 @@ export async function main() {
 
 main();
 
-function createDidDocument(env=process.env) {
+function createDidDocument(env = process.env) {
+  const id = env.DID_DOCUMENT_ID;
+  const context: Array<string | Record<string, string>> = ['https://www.w3.org/ns/did/v1'];
+  if (id) {
+    context.push({
+      '@base': id,
+    });
+  }
   return {
-    id: env.DID_DOCUMENT_ID,
-    alsoKnownAs: env.DID_DOCUMENT_ALSO_KNOWN_AS,
+    '@context': context,
+    id,
+    alsoKnownAs: env.DID_DOCUMENT_PRIMARY_DID_KEY,
   };
 }


### PR DESCRIPTION
Motivation:
* this json file is the did doc when `did:web:{domain}` is resolved https://w3c-ccg.github.io/did-method-web/#read-resolve
* the did document sets `alsoKnownAs` to the did key
* add this simple did doc, just to make sure we can resolvce it via https://dev.uniresolver.io/
  * once it resolves, we can iterate on exactly what's in the did doc