### PR TITLE
feat: use pickup as `CLUSTER_API_URL`

### DIFF
--- a/packages/api/wrangler.toml
+++ b/packages/api/wrangler.toml
@@ -40,7 +40,7 @@ r2_buckets = [
 # name = "web3-storage-production"
 account_id = "fffa4b4363a7e5250af8357087263b3a" # Protocol Labs CF account
 route = { pattern = "https://api.web3.storage/*", zone_id = "7eee3323c1b35b6650568604c65f441e" }
-vars = { CARPARK_URL = "https://carpark.web3.storage", CLUSTER_API_URL = "https://web3.storage.ipfscluster.io/api/", ENV = "production", PG_REST_URL = "https://web3-storage-pgrest-prod.herokuapp.com", GATEWAY_URL = "https://ipfs.io" }
+vars = { CARPARK_URL = "https://carpark.web3.storage", CLUSTER_API_URL = "https://pickup.dag.haus", ENV = "production", PG_REST_URL = "https://web3-storage-pgrest-prod.herokuapp.com", GATEWAY_URL = "https://ipfs.io" }
 r2_buckets = [
   { binding = "CARPARK", bucket_name = "carpark-prod-0" },
   { binding = "DUDEWHERE", bucket_name = "dudewhere-prod-0" },
@@ -52,7 +52,7 @@ r2_buckets = [
 account_id = "fffa4b4363a7e5250af8357087263b3a" # Protocol Labs CF account
 route = { pattern = "https://api-staging.web3.storage/*", zone_id = "7eee3323c1b35b6650568604c65f441e" }
 # nft.storage.ipfscluster.io is the staging cluster
-vars = { CARPARK_URL = "https://carpark-staging.web3.storage", CLUSTER_API_URL = "https://nft.storage.ipfscluster.io/api/", ENV = "staging", PG_REST_URL = "https://web3-storage-pgrest-staging.herokuapp.com", GATEWAY_URL = "https://ipfs.io" }
+vars = { CARPARK_URL = "https://carpark-staging.web3.storage", CLUSTER_API_URL = "https://staging.pickup.dag.haus", ENV = "staging", PG_REST_URL = "https://web3-storage-pgrest-staging.herokuapp.com", GATEWAY_URL = "https://ipfs.io" }
 r2_buckets = [
   { binding = "CARPARK", bucket_name = "carpark-staging-0" },
   { binding = "DUDEWHERE", bucket_name = "dudewhere-staging-0" },


### PR DESCRIPTION
Update `CLUSTER_API_URL` in wrangler.toml to have the api use pickup in place of cluster for handling pinning service requests.

The prod pickup is currently configured to proxy all requests back over to cluster. The plan is to get pickup in the loop so we can control what fraction of requests it should handle from pickyup config.

Note: Merging this PR will trigger a staging deployment, which will apply the change to the staging config. Merging the release-please PR will trigger a prod deploy and the prod config change will be applied then.

TODO
- [ ] update `CLUSTER_API_URL` secret on repo so cron-pins uses the same endpoint as the web3.storage api worker.
- [x] implement handler in pickup for `GET /pins?cids=baf1,...,bafN`

License: MIT
Signed-off-by: Oli Evans <oli@protocol.ai>