### PR TITLE
chore: use staging pickup in staging cron-pins job

### DIFF
--- a/.github/workflows/cron-pins.yml
+++ b/.github/workflows/cron-pins.yml
@@ -12,6 +12,11 @@ jobs:
     strategy:
       matrix:
         env: ['staging', 'production']
+        include:
+          - env: production
+            pickup_url: http://pickup.dag.haus
+          - env: staging
+            pickup_url: http://staging.pickup.dag.haus
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@v2
@@ -37,10 +42,8 @@ jobs:
           STAGING_PG_REST_JWT: ${{ secrets.STAGING_PG_REST_JWT }}
           PROD_PG_REST_URL: ${{ secrets.PROD_PG_REST_URL }}
           STAGING_PG_REST_URL: ${{ secrets.STAGING_PG_REST_URL }}
-          CLUSTER_API_URL: ${{ secrets.CLUSTER_API_URL }}
+          CLUSTER_API_URL: ${{ matrix.pickup_url }}
           CLUSTER_BASIC_AUTH_TOKEN: ${{ secrets.CLUSTER_BASIC_AUTH_TOKEN }}
-          CLUSTER_IPFS_PROXY_API_URL: ${{ secrets.CLUSTER_IPFS_PROXY_API_URL }}
-          CLUSTER_IPFS_PROXY_BASIC_AUTH_TOKEN: ${{ secrets.CLUSTER_IPFS_PROXY_BASIC_AUTH_TOKEN }}
         run: npm run start:pins -w packages/cron
 
       - name: Heartbeat

--- a/packages/cron/test/email.spec.js
+++ b/packages/cron/test/email.spec.js
@@ -13,9 +13,6 @@ import { User100PercentStorage } from '../src/lib/email/types.js'
 const env = {
   DEBUG: '*',
   ENV: 'dev',
-  CLUSTER_API_URL: 'http://localhost:9094',
-  CLUSTER_IPFS_PROXY_API_URL: 'http://127.0.0.1:9095/api/v0/',
-  CLUSTER_BASIC_AUTH_TOKEN: 'dGVzdDp0ZXN0',
   DATABASE: 'postgres',
   PG_REST_URL: 'http://localhost:3000',
   PG_REST_JWT: 'eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJzdXBhYmFzZSIsImlhdCI6MTYwMzk2ODgzNCwiZXhwIjoyNTUwNjUzNjM0LCJyb2xlIjoic2VydmljZV9yb2xlIn0.necIJaiP7X2T2QjGeV-FhpkizcNTX8HjDDBAxpgQTEI'

--- a/packages/cron/test/pins.spec.js
+++ b/packages/cron/test/pins.spec.js
@@ -11,7 +11,6 @@ const env = {
   DEBUG: '*',
   ENV: 'dev',
   CLUSTER_API_URL: 'http://localhost:9094',
-  CLUSTER_IPFS_PROXY_API_URL: 'http://127.0.0.1:9095/api/v0/',
   CLUSTER_BASIC_AUTH_TOKEN: 'dGVzdDp0ZXN0',
   DATABASE: 'postgres',
   PG_REST_URL: 'http://localhost:3000',


### PR DESCRIPTION
Change cron-pins ci workflow to use staging pickup for the staging run and prod for prod.
- uses `includes` to add `pickup_url` per env. see: https://docs.github.com/en/actions/using-jobs/using-a-matrix-for-your-jobs#expanding-or-adding-matrix-configurations
- we can't use github environments here as you can only have 1 of those set on the job, you can't use them in a matrix.

Previously we used the same cluster url for both. We now want to see staging traffic hitting staging pickup.

Also cleans out some unused old cluster vars.

License: MIT
Signed-off-by: Oli Evans <oli@protocol.ai>