### PR TITLE
feat: add IsEarlyAdopter user tag

### DIFF
--- a/packages/api/src/constants.js
+++ b/packages/api/src/constants.js
@@ -8,6 +8,7 @@ export const PIN_STATUSES = ['PinQueued', 'Pinning', 'Pinned', 'PinError']
 export const USER_TAGS = {
   ACCOUNT_RESTRICTION: 'HasAccountRestriction',
   DELETE_RESTRICTION: 'HasDeleteRestriction',
+  EARLY_ADOPTER: 'IsEarlyAdopter',
   PSA_ACCESS: 'HasPsaAccess'
 }
 export const CAR_CODE = 0x202

--- a/packages/api/src/user.js
+++ b/packages/api/src/user.js
@@ -284,6 +284,7 @@ export async function userInfoGet (request, env) {
         HasDeleteRestriction: hasTag(user, 'HasDeleteRestriction', 'true'),
         HasPsaAccess: hasTag(user, 'HasPsaAccess', 'true'),
         HasSuperHotAccess: hasTag(user, 'HasSuperHotAccess', 'true'),
+        IsEarlyAdopter: hasTag(user, 'IsEarlyAdopter', 'true'),
         StorageLimitBytes: getTagValue(user, 'StorageLimitBytes', '')
       },
       tagProposals: {

--- a/packages/db/postgres/migrations/033-add-IsEarlyAdopter-user_tag.sql
+++ b/packages/db/postgres/migrations/033-add-IsEarlyAdopter-user_tag.sql
@@ -1,0 +1,1 @@
+ALTER TYPE user_tag_type ADD VALUE 'IsEarlyAdopter';

--- a/packages/db/postgres/pg-rest-api-types.d.ts
+++ b/packages/db/postgres/pg-rest-api-types.d.ts
@@ -2505,6 +2505,7 @@ export interface definitions {
       | "HasAccountRestriction"
       | "HasDeleteRestriction"
       | "HasPsaAccess"
+      | "IsEarlyAdopter"
       | "StorageLimitBytes";
     /** Format: text */
     value: string;

--- a/packages/db/postgres/tables.sql
+++ b/packages/db/postgres/tables.sql
@@ -21,6 +21,7 @@ BEGIN
       'HasAccountRestriction',
       'HasDeleteRestriction',
       'HasPsaAccess',
+      'IsEarlyAdopter',
       'StorageLimitBytes'
     );
   END IF;


### PR DESCRIPTION
Since early adopters are no longer being modeled strictly as "users without Stripe customers," @gobengo suggested that we use our tag mechanism to keep track of who our early adopters are (so that we don't need to look at Stripe to make those inferences).

After this is merge and the included db migration is performed, there will be a separate migration to actually tag our early adopters.