### PR TITLE
fix: update price displayed in UI to reflect advertised price

### DIFF
--- a/packages/website/components/contexts/plansContext.js
+++ b/packages/website/components/contexts/plansContext.js
@@ -45,11 +45,11 @@ export const sharedPlans = [
       {
         flatAmount: 300,
         unitAmount: 0,
-        upTo: 15,
+        upTo: 30,
       },
       {
         flatAmount: null,
-        unitAmount: 20,
+        unitAmount: 10,
         upTo: null,
       },
     ],
@@ -58,17 +58,17 @@ export const sharedPlans = [
     id: /** @type {const} */ ('pro'),
     description: 'Our lowest price per GiB stored. For those with use cases that require scale.',
     label: 'Expert',
-    bandwidth: '24',
+    bandwidth: '240',
     isPreferred: false,
     tiers: [
       {
         flatAmount: 1000,
         unitAmount: null,
-        upTo: 60,
+        upTo: 120,
       },
       {
         flatAmount: null,
-        unitAmount: 20,
+        unitAmount: 8,
         upTo: null,
       },
     ],
@@ -86,11 +86,6 @@ export const freePlan = {
       flatAmount: 0,
       unitAmount: 0,
       upTo: 5,
-    },
-    {
-      flatAmount: 0,
-      unitAmount: 20,
-      upTo: null,
     },
   ],
 };


### PR DESCRIPTION
closes #2205 

Note that this *only* changes the price information in the UI.  Before we begin sending usage information to Stripe for calculating overages we'll need to migrate users from their current prices to ones that match pricing structure of the ones we're displaying in the UI. (Stripe prices are immutable and so it appears this migration is necessary.)