### PR TITLE
feat: recheck pin status on GET /pins/:req-id

### DIFF
--- a/packages/api/src/pins.js
+++ b/packages/api/src/pins.js
@@ -144,6 +144,24 @@ export async function pinGet (request, env, ctx) {
     throw new PSAErrorResourceNotFound()
   }
 
+  /** @type {(() => Promise<any>)[]} */
+  const tasks = []
+
+  const inProgress = pinRequest.pins.filter((p) => p.status === 'PinQueued' || p.status === 'Pinning')
+  if (inProgress.length > 0) {
+    tasks.push(
+      waitAndUpdateOkPins.bind(
+        null,
+        pinRequest.contentCid,
+        env.cluster,
+        env.db)
+    )
+  }
+
+  if (ctx.waitUntil) {
+    tasks.forEach(t => ctx.waitUntil(t()))
+  }
+
   /** @type { PsaPinStatusResponse } */
   return new JSONResponse(toPinStatusResponse(pinRequest))
 }


### PR DESCRIPTION
When using kubo to `ipfs remote pin add` we get a GET request every second checking for an update to the pin status.

Here we use that as a trigger to ask pickup for a status update. This will be handled by a lambda invocation and a single item db read, and will be pretty low impact.

In return we will be able to inform the user as soon as their pin is complete rather than having to wait up to an hour for an async pin update job to complete.

fixes https://github.com/web3-storage/web3.storage/issues/2213

License: MIT