### PR TITLE
chore: update CODEOWNERS replacing error @web3-storage/dag-house team with /…

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -6,7 +6,7 @@
 
 # github's syntax docs: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners#codeowners-syntax
 
-* @web3-storage/dag-house
+* @web3-storage/dag-house-devs
 
 # @web3-storage/website is maintained by multiple teams
-/packages/website/  @web3-storage/dag-house @web3-storage/website-codeowners
+/packages/website/  @web3-storage/dag-house-devs @web3-storage/website-codeowners


### PR DESCRIPTION
…dag-house-devs

Motivation:
* this PR was still awaiting PR by website-codeowners even though I'd approved https://github.com/web3-storage/web3.storage/pull/2221

Reasoning:
* I think by adding dag-house-devs team here, github will detect that my approval was enough since I'm in that team