### PR TITLE
fix: set client default chunk size to 50MB

### DIFF
--- a/packages/client/src/lib.js
+++ b/packages/client/src/lib.js
@@ -31,7 +31,7 @@ import {
 
 const MAX_PUT_RETRIES = 5
 const MAX_CONCURRENT_UPLOADS = 3
-const DEFAULT_CHUNK_SIZE = 1024 * 1024 * 10 // chunk to ~10MB CARs
+const DEFAULT_CHUNK_SIZE = 1024 * 1024 * 50 // chunk to ~50MB CARs
 const MAX_BLOCK_SIZE = 1048576
 const MAX_CHUNK_SIZE = 104857600
 // These match what is enforced server-side

--- a/packages/client/test/put.spec.js
+++ b/packages/client/test/put.spec.js
@@ -144,7 +144,7 @@ describe('put', () => {
         uploadedChunks++
       }
     })
-    assert.ok(uploadedChunks >= 100)
+    assert.ok(uploadedChunks >= 20)
   })
 
   it('aborts', async () => {


### PR DESCRIPTION
Per talk async with @alanshaw , setting default chunk size to 50MB to save us 5x in number of indexes needed to write/read R2