### PR TITLE
feat: update to latest web3.storage@4.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28163,7 +28163,7 @@
     },
     "packages/api": {
       "name": "@web3-storage/api",
-      "version": "7.12.0",
+      "version": "7.15.1",
       "license": "(Apache-2.0 OR MIT)",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.53.1",
@@ -29247,7 +29247,7 @@
     },
     "packages/client": {
       "name": "web3.storage",
-      "version": "4.5.0",
+      "version": "4.5.4",
       "license": "(Apache-2.0 OR MIT)",
       "dependencies": {
         "@ipld/car": "^3.1.4",
@@ -29655,7 +29655,7 @@
     },
     "packages/cron": {
       "name": "@web3-storage/cron",
-      "version": "1.6.1",
+      "version": "1.7.0",
       "license": "(Apache-2.0 OR MIT)",
       "dependencies": {
         "@nftstorage/ipfs-cluster": "^5.0.1",
@@ -30456,7 +30456,7 @@
         "sade": "^1.7.4",
         "uint8arrays": "^3.0.0",
         "w3name": "^1.0.6",
-        "web3.storage": "^3.5.2"
+        "web3.storage": "^4.5.4"
       },
       "bin": {
         "w3": "bin.js"
@@ -30464,21 +30464,6 @@
       "devDependencies": {
         "execa": "^5.1.1",
         "mocha": "^8.3.2"
-      }
-    },
-    "packages/w3/node_modules/@web-std/fetch": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@web-std/fetch/-/fetch-3.0.3.tgz",
-      "integrity": "sha512-PtaKr6qvw2AmKChugzhQWuTa12dpbogHRBxwcleAZ35UhWucnfD4N+g3f7qYK2OeioSWTK3yMf6n/kOOfqxHaQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@web-std/blob": "^3.0.3",
-        "@web-std/form-data": "^3.0.2",
-        "@web3-storage/multipart-parser": "^1.0.0",
-        "data-uri-to-buffer": "^3.0.1"
-      },
-      "engines": {
-        "node": "^10.17 || >=12.3"
       }
     },
     "packages/w3/node_modules/ansi-regex": {
@@ -31333,97 +31318,6 @@
         "node": ">=8"
       }
     },
-    "packages/w3/node_modules/web3.storage": {
-      "version": "3.5.7",
-      "resolved": "https://registry.npmjs.org/web3.storage/-/web3.storage-3.5.7.tgz",
-      "integrity": "sha512-TU8wmbocthzUwi4Enr2zSw5dUN593fYrDFEDzu5MHbUrF9e/pcfCLBxDa6ABD3/8LAq2JOjRT5sxY/lRfqESzg==",
-      "license": "(Apache-2.0 OR MIT)",
-      "dependencies": {
-        "@ipld/car": "^3.1.4",
-        "@web-std/blob": "^3.0.4",
-        "@web-std/fetch": "^3.0.3",
-        "@web-std/file": "^3.0.2",
-        "@web3-storage/parse-link-header": "^3.1.0",
-        "browser-readablestream-to-it": "^1.0.3",
-        "carbites": "^1.0.6",
-        "cborg": "^1.8.0",
-        "files-from-path": "^0.2.4",
-        "ipfs-car": "^0.6.2",
-        "ipns": "^0.16.0",
-        "libp2p-crypto": "^0.21.0",
-        "p-retry": "^4.5.0",
-        "streaming-iterables": "^6.2.0",
-        "uint8arrays": "^3.0.0"
-      }
-    },
-    "packages/w3/node_modules/web3.storage/node_modules/bl": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/bl/-/bl-5.0.0.tgz",
-      "integrity": "sha512-8vxFNZ0pflFfi0WXA3WQXlj6CaMEwsmh63I1CNp0q+wWv8sD0ARx1KovSQd0l2GkwrMIOyedq0EF1FxI+RCZLQ==",
-      "license": "MIT",
-      "dependencies": {
-        "buffer": "^6.0.3",
-        "inherits": "^2.0.4",
-        "readable-stream": "^3.4.0"
-      }
-    },
-    "packages/w3/node_modules/web3.storage/node_modules/buffer": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
-      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "base64-js": "^1.3.1",
-        "ieee754": "^1.2.1"
-      }
-    },
-    "packages/w3/node_modules/web3.storage/node_modules/ipfs-car": {
-      "version": "0.6.2",
-      "resolved": "https://registry.npmjs.org/ipfs-car/-/ipfs-car-0.6.2.tgz",
-      "integrity": "sha512-tliuakkKKtCa4TTnFT3zJKjq/aD8EGKX8Y0ybCyrAW0fo/n2koZpxiLjBvtTs47Rqyji6ggXo+atPbJJ60hJmg==",
-      "license": "(Apache-2.0 AND MIT)",
-      "dependencies": {
-        "@ipld/car": "^3.2.3",
-        "@web-std/blob": "^3.0.1",
-        "bl": "^5.0.0",
-        "blockstore-core": "^1.0.2",
-        "browser-readablestream-to-it": "^1.0.2",
-        "idb-keyval": "^6.0.3",
-        "interface-blockstore": "^2.0.2",
-        "ipfs-core-types": "^0.8.3",
-        "ipfs-core-utils": "^0.12.1",
-        "ipfs-unixfs-exporter": "^7.0.4",
-        "ipfs-unixfs-importer": "^9.0.4",
-        "ipfs-utils": "^9.0.2",
-        "it-all": "^1.0.5",
-        "it-last": "^1.0.5",
-        "it-pipe": "^1.1.0",
-        "meow": "^9.0.0",
-        "move-file": "^2.1.0",
-        "multiformats": "^9.6.3",
-        "stream-to-it": "^0.2.3",
-        "streaming-iterables": "^6.0.0",
-        "uint8arrays": "^3.0.0"
-      },
-      "bin": {
-        "🚘": "dist/cjs/cli/cli.js",
-        "ipfs-car": "dist/cjs/cli/cli.js"
-      }
-    },
     "packages/w3/node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -31524,7 +31418,7 @@
     },
     "packages/website": {
       "name": "@web3-storage/website",
-      "version": "2.32.0",
+      "version": "2.35.1",
       "dependencies": {
         "@docsearch/react": "^3.0.0",
         "@fortawesome/free-brands-svg-icons": "^6.1.2",
@@ -35107,27 +35001,6 @@
       },
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "packages/website/node_modules/imagemin/node_modules/path-type": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
-      "integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
-      "license": "MIT",
-      "dependencies": {
-        "pify": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "packages/website/node_modules/imagemin/node_modules/path-type/node_modules/pify": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
-      "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
       }
     },
     "packages/website/node_modules/imagemin/node_modules/slash": {
@@ -44048,20 +43921,9 @@
         "sade": "^1.7.4",
         "uint8arrays": "^3.0.0",
         "w3name": "^1.0.6",
-        "web3.storage": "^3.5.2"
+        "web3.storage": "4.5.4"
       },
       "dependencies": {
-        "@web-std/fetch": {
-          "version": "3.0.3",
-          "resolved": "https://registry.npmjs.org/@web-std/fetch/-/fetch-3.0.3.tgz",
-          "integrity": "sha512-PtaKr6qvw2AmKChugzhQWuTa12dpbogHRBxwcleAZ35UhWucnfD4N+g3f7qYK2OeioSWTK3yMf6n/kOOfqxHaQ==",
-          "requires": {
-            "@web-std/blob": "^3.0.3",
-            "@web-std/form-data": "^3.0.2",
-            "@web3-storage/multipart-parser": "^1.0.0",
-            "data-uri-to-buffer": "^3.0.1"
-          }
-        },
         "ansi-regex": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
@@ -44620,77 +44482,6 @@
           "version": "3.0.1",
           "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-3.0.1.tgz",
           "integrity": "sha512-c1PTsA3tYrIsLGkJkzHF+w9F2EyxfXGo4UyJc4pFL++FMjnq0HJS69T3M7d//gKrFKwy429bouPescbjecU+Zw=="
-        },
-        "web3.storage": {
-          "version": "3.5.7",
-          "resolved": "https://registry.npmjs.org/web3.storage/-/web3.storage-3.5.7.tgz",
-          "integrity": "sha512-TU8wmbocthzUwi4Enr2zSw5dUN593fYrDFEDzu5MHbUrF9e/pcfCLBxDa6ABD3/8LAq2JOjRT5sxY/lRfqESzg==",
-          "requires": {
-            "@ipld/car": "^3.1.4",
-            "@web-std/blob": "^3.0.4",
-            "@web-std/fetch": "^3.0.3",
-            "@web-std/file": "^3.0.2",
-            "@web3-storage/parse-link-header": "^3.1.0",
-            "browser-readablestream-to-it": "^1.0.3",
-            "carbites": "^1.0.6",
-            "cborg": "^1.8.0",
-            "files-from-path": "^0.2.4",
-            "ipfs-car": "^0.6.2",
-            "ipns": "^0.16.0",
-            "libp2p-crypto": "^0.21.0",
-            "p-retry": "^4.5.0",
-            "streaming-iterables": "^6.2.0",
-            "uint8arrays": "^3.0.0"
-          },
-          "dependencies": {
-            "bl": {
-              "version": "5.0.0",
-              "resolved": "https://registry.npmjs.org/bl/-/bl-5.0.0.tgz",
-              "integrity": "sha512-8vxFNZ0pflFfi0WXA3WQXlj6CaMEwsmh63I1CNp0q+wWv8sD0ARx1KovSQd0l2GkwrMIOyedq0EF1FxI+RCZLQ==",
-              "requires": {
-                "buffer": "^6.0.3",
-                "inherits": "^2.0.4",
-                "readable-stream": "^3.4.0"
-              }
-            },
-            "buffer": {
-              "version": "6.0.3",
-              "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
-              "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
-              "requires": {
-                "base64-js": "^1.3.1",
-                "ieee754": "^1.2.1"
-              }
-            },
-            "ipfs-car": {
-              "version": "0.6.2",
-              "resolved": "https://registry.npmjs.org/ipfs-car/-/ipfs-car-0.6.2.tgz",
-              "integrity": "sha512-tliuakkKKtCa4TTnFT3zJKjq/aD8EGKX8Y0ybCyrAW0fo/n2koZpxiLjBvtTs47Rqyji6ggXo+atPbJJ60hJmg==",
-              "requires": {
-                "@ipld/car": "^3.2.3",
-                "@web-std/blob": "^3.0.1",
-                "bl": "^5.0.0",
-                "blockstore-core": "^1.0.2",
-                "browser-readablestream-to-it": "^1.0.2",
-                "idb-keyval": "^6.0.3",
-                "interface-blockstore": "^2.0.2",
-                "ipfs-core-types": "^0.8.3",
-                "ipfs-core-utils": "^0.12.1",
-                "ipfs-unixfs-exporter": "^7.0.4",
-                "ipfs-unixfs-importer": "^9.0.4",
-                "ipfs-utils": "^9.0.2",
-                "it-all": "^1.0.5",
-                "it-last": "^1.0.5",
-                "it-pipe": "^1.1.0",
-                "meow": "^9.0.0",
-                "move-file": "^2.1.0",
-                "multiformats": "^9.6.3",
-                "stream-to-it": "^0.2.3",
-                "streaming-iterables": "^6.0.0",
-                "uint8arrays": "^3.0.0"
-              }
-            }
-          }
         },
         "which": {
           "version": "2.0.2",
@@ -47274,21 +47065,6 @@
                 "regex-not": "^1.0.0",
                 "snapdragon": "^0.8.1",
                 "to-regex": "^3.0.2"
-              }
-            },
-            "path-type": {
-              "version": "3.0.0",
-              "resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
-              "integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
-              "requires": {
-                "pify": "^3.0.0"
-              },
-              "dependencies": {
-                "pify": {
-                  "version": "3.0.0",
-                  "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
-                  "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
-                }
               }
             },
             "slash": {

--- a/packages/w3/package.json
+++ b/packages/w3/package.json
@@ -33,7 +33,7 @@
     "sade": "^1.7.4",
     "uint8arrays": "^3.0.0",
     "w3name": "^1.0.6",
-    "web3.storage": "^3.5.2"
+    "web3.storage": "^4.5.4"
   },
   "devDependencies": {
     "execa": "^5.1.1",


### PR DESCRIPTION
To start using the 50MB chunk size.

Thank you to @hammertoe for the nudge. This was overlooked when we made the change to the client lib, and increase the max size of files we can serve through freeway.

License: MIT