### PR TITLE
fix: only recheck pin status if pinning or queued

### DIFF
--- a/packages/cron/src/jobs/pins.js
+++ b/packages/cron/src/jobs/pins.js
@@ -106,7 +106,7 @@ export async function updatePinStatuses ({ cluster, db }) {
         return null
       }
 
-      if (status !== 'Pinned') reSyncPins.push(pin)
+      if (status === 'PinQueued' || status === 'Pinning') reSyncPins.push(pin)
 
       if (status === pin.status) {
         log(`🙅 ${pin.contentCid}@${pin.location.peerId}: No status change (${status})`)


### PR DESCRIPTION
pickup will list a pin as "pinning" while it internally retries after an error. If fetching the DAG times our, or repeatedly errors for some other reason, pickup wont keep retrying it. The pin status will either be queued, pinning, pinned, or failed.

change the logic of the pins cron to only recheck pins that are queued or pinning.

License: MIT