### PR TITLE
fix: apply workaround to Simple Analytics blocking navigation to /docs

### DIFF
--- a/packages/website/pages/_app.js
+++ b/packages/website/pages/_app.js
@@ -29,7 +29,10 @@ const App = ({ Component, pageProps }) => {
       <Metadata {...pageProps} />
       <RestrictedRoute {...pageProps}>
         <Script src="https://track.web3.storage/latest.js" data-hostname="web3.storage" data-ignore-pages="/callback" />
-        <Script src="https://track.web3.storage/auto-events.js" />
+        {/* We're specifying download extensions here because the 'doc' extension conflicts
+            with the /docs URL path for our docs pages.  This is a workaround for a bad regex on
+            the Simple Analytics side.  See https://docs.simpleanalytics.com/automated-events */}
+        <Script data-extensions="pdf,csv,docx,xlsx,zip,xls" src="https://track.web3.storage/auto-events.js" />
         <noscript>
           {/* eslint-disable @next/next/no-img-element */}
           <img


### PR DESCRIPTION
The Simple Analytics event handlers being attached to all of our links is interpreting the path `/docs` as a link to a download and blocking the default action of this event.  It appears this is because it's mistaking this path as a link to a .doc file.  Explicitly setting the file extensions to their defaults but removing the `doc` extension seems to fix this.  Probably a bad regex on their end.

See #2237 