### PR TITLE
fix: add types to package.json exports

### DIFF
--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -75,6 +75,7 @@
   "main": "./dist/src/lib.cjs",
   "exports": {
     ".": {
+			      "types": "./dist/src/lib.d.ts",
       "browser": "./src/lib.js",
       "require": "./dist/src/lib.cjs",
       "node": "./src/lib.js"


### PR DESCRIPTION
Needed for newer typescript with certain moduleResolution settings.

Found the explanation & solution here:
https://github.com/gxmari007/vite-plugin-eslint/pull/60

& the docs for the option here:
https://nodejs.org/api/packages.html#packages_exports (with `types` being defined here: https://nodejs.org/api/packages.html#conditional-exports)