### PR TITLE
feat: trigger block index creation

### DIFF
--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -57,7 +57,7 @@ jobs:
           - firefox
           - chromium
         os:
-          - ubuntu-18.04
+          - ubuntu-latest
         node-version:
           - 16
         test_results_path:

--- a/package-lock.json
+++ b/package-lock.json
@@ -3472,9 +3472,9 @@
       }
     },
     "node_modules/@cloudflare/workers-types": {
-      "version": "3.16.0",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-3.16.0.tgz",
-      "integrity": "sha512-gaBUSaKS65mN3iKZEgichbXYEmAa/pXkc5Gbt+1BptYphdGkj09ggdsiE4w8g0F/uI1g36QaTKrzVnBAWMipvQ==",
+      "version": "4.20230518.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-4.20230518.0.tgz",
+      "integrity": "sha512-A0w1V+5SUawGaaPRlhFhSC/SCDT9oQG8TMoWOKFLA4qbqagELqEAFD4KySBIkeVOvCBLT1DZSYBMCxbXddl0kw==",
       "dev": true
     },
     "node_modules/@cspotcode/source-map-support": {
@@ -28362,7 +28362,7 @@
     },
     "packages/api": {
       "name": "@web3-storage/api",
-      "version": "7.15.4",
+      "version": "7.16.0",
       "license": "(Apache-2.0 OR MIT)",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.53.1",
@@ -28392,7 +28392,7 @@
         "uint8arrays": "^3.0.0"
       },
       "devDependencies": {
-        "@cloudflare/workers-types": "^3.16.0",
+        "@cloudflare/workers-types": "^4.20230518.0",
         "@esbuild-plugins/node-modules-polyfill": "^0.1.4",
         "@miniflare/core": "^2.8.1",
         "@sentry/cli": "^1.72.1",
@@ -40958,9 +40958,9 @@
       }
     },
     "@cloudflare/workers-types": {
-      "version": "3.16.0",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-3.16.0.tgz",
-      "integrity": "sha512-gaBUSaKS65mN3iKZEgichbXYEmAa/pXkc5Gbt+1BptYphdGkj09ggdsiE4w8g0F/uI1g36QaTKrzVnBAWMipvQ==",
+      "version": "4.20230518.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-4.20230518.0.tgz",
+      "integrity": "sha512-A0w1V+5SUawGaaPRlhFhSC/SCDT9oQG8TMoWOKFLA4qbqagELqEAFD4KySBIkeVOvCBLT1DZSYBMCxbXddl0kw==",
       "dev": true
     },
     "@cspotcode/source-map-support": {
@@ -42798,7 +42798,7 @@
       "requires": {
         "@aws-sdk/client-s3": "^3.53.1",
         "@cfworker/json-schema": "^1.8.3",
-        "@cloudflare/workers-types": "^3.16.0",
+        "@cloudflare/workers-types": "^4.20230518.0",
         "@esbuild-plugins/node-modules-polyfill": "^0.1.4",
         "@google-cloud/precise-date": "^2.0.4",
         "@ipld/car": "^3.1.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -3741,6 +3741,7 @@
     },
     "node_modules/@ipld/dag-json": {
       "version": "8.0.10",
+      "dev": true,
       "license": "(Apache-2.0 AND MIT)",
       "dependencies": {
         "cborg": "^1.5.4",
@@ -4445,10 +4446,9 @@
       }
     },
     "node_modules/@multiformats/murmur3": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@multiformats/murmur3/-/murmur3-1.1.1.tgz",
-      "integrity": "sha512-TPIBMPX4DX7T4291bPUAn/AMW6H6mnYoI4Bza1DeX1I59dpTWBbOgxaqc+139Ph+NEgb/PNd3sFS8VFoOXzNlw==",
-      "license": "(Apache-2.0 AND MIT)",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@multiformats/murmur3/-/murmur3-1.1.3.tgz",
+      "integrity": "sha512-wAPLUErGR8g6Lt+bAZn6218k9YQPym+sjszsXL6o4zfxbA22P+gxWZuuD9wDbwL55xrKO5idpcuQUX7/E3oHcw==",
       "dependencies": {
         "multiformats": "^9.5.4",
         "murmurhash3js-revisited": "^3.0.0"
@@ -6076,49 +6076,15 @@
       "link": true
     },
     "node_modules/@web3-storage/car-block-validator": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@web3-storage/car-block-validator/-/car-block-validator-1.0.0.tgz",
-      "integrity": "sha512-UJxDnN2Sj9NuNoM1yMNsVvGg2rec5AI519HGTD+E+xXle0v9jXyh912/eKx5XUdZuJuxxAA7VSrrckZA0JLgCg==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@web3-storage/car-block-validator/-/car-block-validator-1.2.0.tgz",
+      "integrity": "sha512-KKQ/M5WtpH/JlkX+bQYKzdG4azmSF495T7vpewje2xh7MBh1d94/BLblxCcLM/larWvXDxOkbAyTTdlECAAuUw==",
       "dependencies": {
         "@multiformats/blake2": "^1.0.13",
-        "@multiformats/murmur3": "^2.1.3",
+        "@multiformats/murmur3": "^1.1.3",
         "@multiformats/sha3": "^2.0.15",
-        "multiformats": "^11.0.2",
-        "uint8arrays": "^4.0.3"
-      }
-    },
-    "node_modules/@web3-storage/car-block-validator/node_modules/@multiformats/murmur3": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/@multiformats/murmur3/-/murmur3-2.1.3.tgz",
-      "integrity": "sha512-YvLK1IrLnRckPsvXhOkZjaIGNonsEdD1dL3NPSaLilV/WjVYeBgnNZXTUsaPzFXGrIFM7motx+yCmmqzXO6gtQ==",
-      "dependencies": {
-        "multiformats": "^11.0.0",
-        "murmurhash3js-revisited": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=7.0.0"
-      }
-    },
-    "node_modules/@web3-storage/car-block-validator/node_modules/multiformats": {
-      "version": "11.0.2",
-      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-11.0.2.tgz",
-      "integrity": "sha512-b5mYMkOkARIuVZCpvijFj9a6m5wMVLC7cf/jIPd5D/ARDOfLC5+IFkbgDXQgcU2goIsTD/O9NY4DI/Mt4OGvlg==",
-      "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=7.0.0"
-      }
-    },
-    "node_modules/@web3-storage/car-block-validator/node_modules/uint8arrays": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-4.0.3.tgz",
-      "integrity": "sha512-b+aKlI2oTnxnfeSQWV1sMacqSNxqhtXySaH6bflvONGxF8V/fT3ZlYH7z2qgGfydsvpVo4JUgM/Ylyfl2YouCg==",
-      "dependencies": {
-        "multiformats": "^11.0.0"
-      },
-      "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=7.0.0"
+        "multiformats": "9.9.0",
+        "uint8arrays": "^3.1.1"
       }
     },
     "node_modules/@web3-storage/cron": {
@@ -15835,14 +15801,16 @@
       "license": "MIT"
     },
     "node_modules/linkdex": {
-      "version": "2.0.0",
-      "license": "Apache-2.0 OR MIT",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/linkdex/-/linkdex-2.1.2.tgz",
+      "integrity": "sha512-qHKt1qarFyQCOl1KpFYL/MdUhT4Kma7kQLAnRmDxTFNJZbqAql19TYcGKEbiH/zX2FH9dWGeX+FdN147T0R2Yw==",
       "dependencies": {
-        "@ipld/car": "^4.1.4",
-        "@ipld/dag-cbor": "^7.0.2",
-        "@ipld/dag-json": "^8.0.10",
-        "@ipld/dag-pb": "^2.1.17",
-        "multiformats": "^9.7.1",
+        "@ipld/car": "^5.1.1",
+        "@ipld/dag-cbor": "^9.0.0",
+        "@ipld/dag-json": "^10.0.1",
+        "@ipld/dag-pb": "^4.0.2",
+        "@web3-storage/car-block-validator": "^1.2.0",
+        "multiformats": "^11.0.2",
         "sade": "^1.8.1"
       },
       "bin": {
@@ -15850,13 +15818,108 @@
       }
     },
     "node_modules/linkdex/node_modules/@ipld/car": {
-      "version": "4.1.5",
-      "license": "(Apache-2.0 AND MIT)",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@ipld/car/-/car-5.1.1.tgz",
+      "integrity": "sha512-HoFTUqUJL9cPGhC9qRmHCvamfIsj1JllQSQ/Xu9/KN/VNJp8To9Ms4qiZPEMOwcrNFclfYqrahjGYbf4KL/d9A==",
       "dependencies": {
-        "@ipld/dag-cbor": "^7.0.0",
+        "@ipld/dag-cbor": "^9.0.0",
         "cborg": "^1.9.0",
-        "multiformats": "^9.5.4",
+        "multiformats": "^11.0.0",
         "varint": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/linkdex/node_modules/@ipld/dag-cbor": {
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/@ipld/dag-cbor/-/dag-cbor-9.0.3.tgz",
+      "integrity": "sha512-A2UFccS0+sARK9xwXiVZIaWbLbPxLGP3UZOjBeOMWfDY04SXi8h1+t4rHBzOlKYF/yWNm3RbFLyclWO7hZcy4g==",
+      "dependencies": {
+        "cborg": "^2.0.1",
+        "multiformats": "^12.0.1"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/linkdex/node_modules/@ipld/dag-cbor/node_modules/cborg": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/cborg/-/cborg-2.0.1.tgz",
+      "integrity": "sha512-ySuIj3L6VwlQf0iU82IGGH/Dm1NfNKcGUttRxtVqLKrRJoo2ZeFeLoQj8Y1tASyh5qOfWQn9MN64VsAqVyWNSQ==",
+      "bin": {
+        "cborg": "cli.js"
+      }
+    },
+    "node_modules/linkdex/node_modules/@ipld/dag-cbor/node_modules/multiformats": {
+      "version": "12.0.1",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-12.0.1.tgz",
+      "integrity": "sha512-s01wijBJoDUqESWSzePY0lvTw7J3PVO9x2Cc6ASI5AMZM2Gnhh7BC17+nlFhHKU7dDzaCaRfb+NiqNzOsgPUoQ==",
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/linkdex/node_modules/@ipld/dag-json": {
+      "version": "10.1.2",
+      "resolved": "https://registry.npmjs.org/@ipld/dag-json/-/dag-json-10.1.2.tgz",
+      "integrity": "sha512-z38JDQXzDW6mtU+ZfLO6/lXbJ4BEEDYY5cyW6+Nl7OpjWSV0mt57cE8LK6+krXlhxwuCnA+/sOtaXuJ3lImvfw==",
+      "dependencies": {
+        "cborg": "^2.0.1",
+        "multiformats": "^12.0.1"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/linkdex/node_modules/@ipld/dag-json/node_modules/cborg": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/cborg/-/cborg-2.0.1.tgz",
+      "integrity": "sha512-ySuIj3L6VwlQf0iU82IGGH/Dm1NfNKcGUttRxtVqLKrRJoo2ZeFeLoQj8Y1tASyh5qOfWQn9MN64VsAqVyWNSQ==",
+      "bin": {
+        "cborg": "cli.js"
+      }
+    },
+    "node_modules/linkdex/node_modules/@ipld/dag-json/node_modules/multiformats": {
+      "version": "12.0.1",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-12.0.1.tgz",
+      "integrity": "sha512-s01wijBJoDUqESWSzePY0lvTw7J3PVO9x2Cc6ASI5AMZM2Gnhh7BC17+nlFhHKU7dDzaCaRfb+NiqNzOsgPUoQ==",
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/linkdex/node_modules/@ipld/dag-pb": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@ipld/dag-pb/-/dag-pb-4.0.4.tgz",
+      "integrity": "sha512-lX0c6ZAwD8ZKtjbawxotP8XNyR6z7/NIk7wXuhDlFT4MrNo/AOefZEUWjAw8CGz3EG3mau4P66VpsZwToVLHDg==",
+      "dependencies": {
+        "multiformats": "^12.0.1"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/linkdex/node_modules/@ipld/dag-pb/node_modules/multiformats": {
+      "version": "12.0.1",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-12.0.1.tgz",
+      "integrity": "sha512-s01wijBJoDUqESWSzePY0lvTw7J3PVO9x2Cc6ASI5AMZM2Gnhh7BC17+nlFhHKU7dDzaCaRfb+NiqNzOsgPUoQ==",
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/linkdex/node_modules/multiformats": {
+      "version": "11.0.2",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-11.0.2.tgz",
+      "integrity": "sha512-b5mYMkOkARIuVZCpvijFj9a6m5wMVLC7cf/jIPd5D/ARDOfLC5+IFkbgDXQgcU2goIsTD/O9NY4DI/Mt4OGvlg==",
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
       }
     },
     "node_modules/lint-staged": {
@@ -19332,8 +19395,9 @@
       }
     },
     "node_modules/multiformats": {
-      "version": "9.8.1",
-      "license": "(Apache-2.0 AND MIT)"
+      "version": "9.9.0",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-9.9.0.tgz",
+      "integrity": "sha512-HoMUjhH9T8DDBNT+6xzkrd9ga/XiBI4xLr58LJACwK6G3HTOPeMz4nB4KJs33L2BelrIJa7P0VuNaVF3hMYfjg=="
     },
     "node_modules/murmurhash3js-revisited": {
       "version": "3.0.0",
@@ -26619,10 +26683,9 @@
       }
     },
     "node_modules/uint8arrays": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-3.0.0.tgz",
-      "integrity": "sha512-HRCx0q6O9Bfbp+HHSfQQKD7wU70+lydKVt4EghkdOvlK/NlrF90z+eXV34mUd48rNvVJXwkrMSPpCATkct8fJA==",
-      "license": "MIT",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-3.1.1.tgz",
+      "integrity": "sha512-+QJa8QRnbdXVpHYjLoTpJIdCTiw9Ir62nocClWuXIq2JIh4Uta0cQsTSpFL678p2CN8B+XSApwcU+pQEqVpKWg==",
       "dependencies": {
         "multiformats": "^9.4.2"
       }
@@ -28380,7 +28443,7 @@
         "cborg": "^1.6.0",
         "ipfs-car": "^0.7.0",
         "itty-router": "^2.4.8",
-        "linkdex": "^2.0.0",
+        "linkdex": "^2.1.2",
         "multiformats": "^9.5.8",
         "nanoid": "^3.1.30",
         "p-retry": "^5.1.1",
@@ -41164,6 +41227,7 @@
     },
     "@ipld/dag-json": {
       "version": "8.0.10",
+      "dev": true,
       "requires": {
         "cborg": "^1.5.4",
         "multiformats": "^9.5.4"
@@ -41659,9 +41723,9 @@
       }
     },
     "@multiformats/murmur3": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@multiformats/murmur3/-/murmur3-1.1.1.tgz",
-      "integrity": "sha512-TPIBMPX4DX7T4291bPUAn/AMW6H6mnYoI4Bza1DeX1I59dpTWBbOgxaqc+139Ph+NEgb/PNd3sFS8VFoOXzNlw==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@multiformats/murmur3/-/murmur3-1.1.3.tgz",
+      "integrity": "sha512-wAPLUErGR8g6Lt+bAZn6218k9YQPym+sjszsXL6o4zfxbA22P+gxWZuuD9wDbwL55xrKO5idpcuQUX7/E3oHcw==",
       "requires": {
         "multiformats": "^9.5.4",
         "murmurhash3js-revisited": "^3.0.0"
@@ -42826,7 +42890,7 @@
         "git-rev-sync": "^3.0.1",
         "ipfs-car": "^0.7.0",
         "itty-router": "^2.4.8",
-        "linkdex": "^2.0.0",
+        "linkdex": "2.1.2",
         "miniflare": "^2.8.1",
         "mocha": "^9.2.0",
         "multiformats": "^9.5.8",
@@ -43484,39 +43548,15 @@
       }
     },
     "@web3-storage/car-block-validator": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@web3-storage/car-block-validator/-/car-block-validator-1.0.0.tgz",
-      "integrity": "sha512-UJxDnN2Sj9NuNoM1yMNsVvGg2rec5AI519HGTD+E+xXle0v9jXyh912/eKx5XUdZuJuxxAA7VSrrckZA0JLgCg==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@web3-storage/car-block-validator/-/car-block-validator-1.2.0.tgz",
+      "integrity": "sha512-KKQ/M5WtpH/JlkX+bQYKzdG4azmSF495T7vpewje2xh7MBh1d94/BLblxCcLM/larWvXDxOkbAyTTdlECAAuUw==",
       "requires": {
         "@multiformats/blake2": "^1.0.13",
-        "@multiformats/murmur3": "^2.1.3",
+        "@multiformats/murmur3": "^1.1.3",
         "@multiformats/sha3": "^2.0.15",
-        "multiformats": "^11.0.2",
-        "uint8arrays": "^4.0.3"
-      },
-      "dependencies": {
-        "@multiformats/murmur3": {
-          "version": "2.1.3",
-          "resolved": "https://registry.npmjs.org/@multiformats/murmur3/-/murmur3-2.1.3.tgz",
-          "integrity": "sha512-YvLK1IrLnRckPsvXhOkZjaIGNonsEdD1dL3NPSaLilV/WjVYeBgnNZXTUsaPzFXGrIFM7motx+yCmmqzXO6gtQ==",
-          "requires": {
-            "multiformats": "^11.0.0",
-            "murmurhash3js-revisited": "^3.0.0"
-          }
-        },
-        "multiformats": {
-          "version": "11.0.2",
-          "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-11.0.2.tgz",
-          "integrity": "sha512-b5mYMkOkARIuVZCpvijFj9a6m5wMVLC7cf/jIPd5D/ARDOfLC5+IFkbgDXQgcU2goIsTD/O9NY4DI/Mt4OGvlg=="
-        },
-        "uint8arrays": {
-          "version": "4.0.3",
-          "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-4.0.3.tgz",
-          "integrity": "sha512-b+aKlI2oTnxnfeSQWV1sMacqSNxqhtXySaH6bflvONGxF8V/fT3ZlYH7z2qgGfydsvpVo4JUgM/Ylyfl2YouCg==",
-          "requires": {
-            "multiformats": "^11.0.0"
-          }
-        }
+        "multiformats": "9.9.0",
+        "uint8arrays": "^3.1.1"
       }
     },
     "@web3-storage/cron": {
@@ -56582,24 +56622,91 @@
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg=="
     },
     "linkdex": {
-      "version": "2.0.0",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/linkdex/-/linkdex-2.1.2.tgz",
+      "integrity": "sha512-qHKt1qarFyQCOl1KpFYL/MdUhT4Kma7kQLAnRmDxTFNJZbqAql19TYcGKEbiH/zX2FH9dWGeX+FdN147T0R2Yw==",
       "requires": {
-        "@ipld/car": "^4.1.4",
-        "@ipld/dag-cbor": "^7.0.2",
-        "@ipld/dag-json": "^8.0.10",
-        "@ipld/dag-pb": "^2.1.17",
-        "multiformats": "^9.7.1",
+        "@ipld/car": "^5.1.1",
+        "@ipld/dag-cbor": "^9.0.0",
+        "@ipld/dag-json": "^10.0.1",
+        "@ipld/dag-pb": "^4.0.2",
+        "@web3-storage/car-block-validator": "^1.2.0",
+        "multiformats": "^11.0.2",
         "sade": "^1.8.1"
       },
       "dependencies": {
         "@ipld/car": {
-          "version": "4.1.5",
+          "version": "5.1.1",
+          "resolved": "https://registry.npmjs.org/@ipld/car/-/car-5.1.1.tgz",
+          "integrity": "sha512-HoFTUqUJL9cPGhC9qRmHCvamfIsj1JllQSQ/Xu9/KN/VNJp8To9Ms4qiZPEMOwcrNFclfYqrahjGYbf4KL/d9A==",
           "requires": {
-            "@ipld/dag-cbor": "^7.0.0",
+            "@ipld/dag-cbor": "^9.0.0",
             "cborg": "^1.9.0",
-            "multiformats": "^9.5.4",
+            "multiformats": "^11.0.0",
             "varint": "^6.0.0"
           }
+        },
+        "@ipld/dag-cbor": {
+          "version": "9.0.3",
+          "resolved": "https://registry.npmjs.org/@ipld/dag-cbor/-/dag-cbor-9.0.3.tgz",
+          "integrity": "sha512-A2UFccS0+sARK9xwXiVZIaWbLbPxLGP3UZOjBeOMWfDY04SXi8h1+t4rHBzOlKYF/yWNm3RbFLyclWO7hZcy4g==",
+          "requires": {
+            "cborg": "^2.0.1",
+            "multiformats": "^12.0.1"
+          },
+          "dependencies": {
+            "cborg": {
+              "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/cborg/-/cborg-2.0.1.tgz",
+              "integrity": "sha512-ySuIj3L6VwlQf0iU82IGGH/Dm1NfNKcGUttRxtVqLKrRJoo2ZeFeLoQj8Y1tASyh5qOfWQn9MN64VsAqVyWNSQ=="
+            },
+            "multiformats": {
+              "version": "12.0.1",
+              "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-12.0.1.tgz",
+              "integrity": "sha512-s01wijBJoDUqESWSzePY0lvTw7J3PVO9x2Cc6ASI5AMZM2Gnhh7BC17+nlFhHKU7dDzaCaRfb+NiqNzOsgPUoQ=="
+            }
+          }
+        },
+        "@ipld/dag-json": {
+          "version": "10.1.2",
+          "resolved": "https://registry.npmjs.org/@ipld/dag-json/-/dag-json-10.1.2.tgz",
+          "integrity": "sha512-z38JDQXzDW6mtU+ZfLO6/lXbJ4BEEDYY5cyW6+Nl7OpjWSV0mt57cE8LK6+krXlhxwuCnA+/sOtaXuJ3lImvfw==",
+          "requires": {
+            "cborg": "^2.0.1",
+            "multiformats": "^12.0.1"
+          },
+          "dependencies": {
+            "cborg": {
+              "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/cborg/-/cborg-2.0.1.tgz",
+              "integrity": "sha512-ySuIj3L6VwlQf0iU82IGGH/Dm1NfNKcGUttRxtVqLKrRJoo2ZeFeLoQj8Y1tASyh5qOfWQn9MN64VsAqVyWNSQ=="
+            },
+            "multiformats": {
+              "version": "12.0.1",
+              "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-12.0.1.tgz",
+              "integrity": "sha512-s01wijBJoDUqESWSzePY0lvTw7J3PVO9x2Cc6ASI5AMZM2Gnhh7BC17+nlFhHKU7dDzaCaRfb+NiqNzOsgPUoQ=="
+            }
+          }
+        },
+        "@ipld/dag-pb": {
+          "version": "4.0.4",
+          "resolved": "https://registry.npmjs.org/@ipld/dag-pb/-/dag-pb-4.0.4.tgz",
+          "integrity": "sha512-lX0c6ZAwD8ZKtjbawxotP8XNyR6z7/NIk7wXuhDlFT4MrNo/AOefZEUWjAw8CGz3EG3mau4P66VpsZwToVLHDg==",
+          "requires": {
+            "multiformats": "^12.0.1"
+          },
+          "dependencies": {
+            "multiformats": {
+              "version": "12.0.1",
+              "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-12.0.1.tgz",
+              "integrity": "sha512-s01wijBJoDUqESWSzePY0lvTw7J3PVO9x2Cc6ASI5AMZM2Gnhh7BC17+nlFhHKU7dDzaCaRfb+NiqNzOsgPUoQ=="
+            }
+          }
+        },
+        "multiformats": {
+          "version": "11.0.2",
+          "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-11.0.2.tgz",
+          "integrity": "sha512-b5mYMkOkARIuVZCpvijFj9a6m5wMVLC7cf/jIPd5D/ARDOfLC5+IFkbgDXQgcU2goIsTD/O9NY4DI/Mt4OGvlg=="
         }
       }
     },
@@ -58872,7 +58979,9 @@
       }
     },
     "multiformats": {
-      "version": "9.8.1"
+      "version": "9.9.0",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-9.9.0.tgz",
+      "integrity": "sha512-HoMUjhH9T8DDBNT+6xzkrd9ga/XiBI4xLr58LJACwK6G3HTOPeMz4nB4KJs33L2BelrIJa7P0VuNaVF3hMYfjg=="
     },
     "murmurhash3js-revisited": {
       "version": "3.0.0",
@@ -63819,9 +63928,9 @@
       "peer": true
     },
     "uint8arrays": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-3.0.0.tgz",
-      "integrity": "sha512-HRCx0q6O9Bfbp+HHSfQQKD7wU70+lydKVt4EghkdOvlK/NlrF90z+eXV34mUd48rNvVJXwkrMSPpCATkct8fJA==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-3.1.1.tgz",
+      "integrity": "sha512-+QJa8QRnbdXVpHYjLoTpJIdCTiw9Ir62nocClWuXIq2JIh4Uta0cQsTSpFL678p2CN8B+XSApwcU+pQEqVpKWg==",
       "requires": {
         "multiformats": "^9.4.2"
       }

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -76,7 +76,7 @@
     "cborg": "^1.6.0",
     "ipfs-car": "^0.7.0",
     "itty-router": "^2.4.8",
-    "linkdex": "^2.0.0",
+    "linkdex": "^2.1.2",
     "multiformats": "^9.5.8",
     "nanoid": "^3.1.30",
     "p-retry": "^5.1.1",

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -35,7 +35,7 @@
     "stripe.com:fixtures": "stripe fixtures src/stripe.com/fixtures.json"
   },
   "devDependencies": {
-    "@cloudflare/workers-types": "^3.16.0",
+    "@cloudflare/workers-types": "^4.20230518.0",
     "@esbuild-plugins/node-modules-polyfill": "^0.1.4",
     "@miniflare/core": "^2.8.1",
     "@sentry/cli": "^1.72.1",

--- a/packages/api/src/car.js
+++ b/packages/api/src/car.js
@@ -178,7 +178,7 @@ export async function handleCarUpload (request, env, ctx, car, uploadType = 'Car
   // ask linkdex for the dag structure across the set of CARs in S3 for this upload.
   const checkDagStructureTask = async () => {
     /** @type {import('linkdex').Report & { cars: string[] }} */
-    const report = pRetry(async () => {
+    const report = await pRetry(async () => {
       const url = new URL(`/?key=${s3Key}`, env.LINKDEX_URL)
       const res = await fetch(url)
       if (!res.ok) {
@@ -188,7 +188,7 @@ export async function handleCarUpload (request, env, ctx, car, uploadType = 'Car
     }, { retries: 3 })
 
     if (report.structure === 'Complete') {
-      return Promise.all([
+      return await Promise.all([
         pRetry(() => env.db.upsertPins([elasticPin(report.structure)]), { retries: 3 }),
         // trigger block indexes to be built for this DAG
         pRetry(async () => {

--- a/packages/api/src/env.js
+++ b/packages/api/src/env.js
@@ -58,6 +58,7 @@ import { createMockBillingContext } from './utils/billing.js'
  * @property {import('./utils/billing-types').BillingService} billing
  * @property {import('./utils/billing-types').CustomersService} customers
  * @property {string} stripeSecretKey
+ * @property {Queue<{ root: string }>} GENDEX_QUEUE
  */
 
 /**

--- a/packages/api/src/env.js
+++ b/packages/api/src/env.js
@@ -58,7 +58,7 @@ import { createMockBillingContext } from './utils/billing.js'
  * @property {import('./utils/billing-types').BillingService} billing
  * @property {import('./utils/billing-types').CustomersService} customers
  * @property {string} stripeSecretKey
- * @property {Queue<{ root: string }>} GENDEX_QUEUE
+ * @property {Queue<{ block: string, shards: string[], root?: string, recursive?: boolean }>} GENDEX_QUEUE
  */
 
 /**

--- a/packages/api/src/utils/bucket.js
+++ b/packages/api/src/utils/bucket.js
@@ -1,18 +1,17 @@
 import { fromString } from 'uint8arrays'
 import * as Digest from 'multiformats/hashes/digest'
-import { sha256 } from 'multiformats/hashes/sha2'
 import { CID } from 'multiformats/cid'
 import { CAR_CODE } from '../constants.js'
 
 /**
- * Converts a bucket path in format `raw/<root>/<user>/<base64(car-digest)>.car`
+ * Converts a bucket path in format `raw/<root>/<user>/<base32(car-multihash)>.car`
  * to a CAR CID.
  * @param {string} path
  */
 export function rawCarPathToShardCid (path) {
   const parts = String(path).split('/')
   const filename = String(parts[3])
-  const digestBytes = fromString(filename.split('.')[0], 'base64pad')
-  const digest = Digest.create(sha256.code, digestBytes)
+  const digestBytes = fromString(filename.split('.')[0], 'base32')
+  const digest = Digest.decode(digestBytes)
   return CID.createV1(CAR_CODE, digest)
 }

--- a/packages/api/src/utils/bucket.js
+++ b/packages/api/src/utils/bucket.js
@@ -9,7 +9,7 @@ import { CAR_CODE } from '../constants.js'
  * @param {string} path
  */
 export function rawCarPathToShardCid (path) {
-  const parts = String(path).split('/')
+  const parts = path.split('/')
   const filename = String(parts[3])
   const digestBytes = fromString(filename.split('.')[0], 'base32')
   const digest = Digest.decode(digestBytes)

--- a/packages/api/src/utils/bucket.js
+++ b/packages/api/src/utils/bucket.js
@@ -1,0 +1,18 @@
+import { fromString } from 'uint8arrays'
+import * as Digest from 'multiformats/hashes/digest'
+import { sha256 } from 'multiformats/hashes/sha2'
+import { CID } from 'multiformats/cid'
+import { CAR_CODE } from '../constants.js'
+
+/**
+ * Converts a bucket path in format `raw/<root>/<user>/<base64(car-digest)>.car`
+ * to a CAR CID.
+ * @param {string} path
+ */
+export function rawCarPathToShardCid (path) {
+  const parts = String(path).split('/')
+  const filename = String(parts[3])
+  const digestBytes = fromString(filename.split('.')[0], 'base64pad')
+  const digest = Digest.create(sha256.code, digestBytes)
+  return CID.createV1(CAR_CODE, digest)
+}

--- a/packages/api/test/scripts/worker-globals.js
+++ b/packages/api/test/scripts/worker-globals.js
@@ -16,6 +16,7 @@ export const GATEWAY_URL = 'http://localhost:8080'
 export const ENABLE_ADD_TO_CLUSTER = 'true'
 export const LINKDEX_URL = 'https://fake.linkdex.net'
 export const CARPARK_URL = 'https://carpark-test.web3.storage'
+export const GENDEX_QUEUE = { send: () => {} }
 
 // Can be removed once we get a test mode for admin magic sdk.
 export const DANGEROUSLY_BYPASS_MAGIC_AUTH = true

--- a/packages/api/wrangler.toml
+++ b/packages/api/wrangler.toml
@@ -15,6 +15,10 @@ new_classes = ["NameRoom0"]
 tag = "v1"
 deleted_classes = ["NameRoom0"]
 
+[[queues.producers]]
+  queue = "gendex-dev"
+  binding = "GENDEX_QUEUE"
+
 # ---- Environment specific overrides below ! ----
 # NOTE: wrangler automatically assigns each env the root `name` with the env name suffixed on the end
 # NOTE: wrangler tries to find an account_id defined at the root if workers_dev = true is not provided on your env.
@@ -35,6 +39,10 @@ r2_buckets = [
   { binding = "SATNAV", bucket_name = "satnav-test-0" }
 ]
 
+[[env.test.queues.producers]]
+  queue = "gendex-test"
+  binding = "GENDEX_QUEUE"
+
 # PROD!
 [env.production]
 # name = "web3-storage-production"
@@ -47,6 +55,10 @@ r2_buckets = [
   { binding = "SATNAV", bucket_name = "satnav-prod-0" }
 ]
 
+[[env.production.queues.producers]]
+  queue = "gendex-prod"
+  binding = "GENDEX_QUEUE"
+
 [env.staging]
 # name = "web3-storage-staging"
 account_id = "fffa4b4363a7e5250af8357087263b3a" # Protocol Labs CF account
@@ -58,6 +70,10 @@ r2_buckets = [
   { binding = "DUDEWHERE", bucket_name = "dudewhere-staging-0" },
   { binding = "SATNAV", bucket_name = "satnav-staging-0" }
 ]
+
+[[env.staging.queues.producers]]
+  queue = "gendex-staging"
+  binding = "GENDEX_QUEUE"
 
 [env.alan]
 workers_dev = true


### PR DESCRIPTION
If linkdex says the DAG is complete, then ask gendex to generate block indexes for each block in the DAG.

This is done by sending a message to a cloudflare queue.

There's a queue consumer worker ([gendex-consumer](https://github.com/web3-storage/gendex-consumer)) that calls [gendex](https://github.com/web3-storage/gendex) to get block indexes generated.