### PR TITLE
fix: remove unnecessary compatibility flags

### DIFF
--- a/packages/api/wrangler.toml
+++ b/packages/api/wrangler.toml
@@ -2,10 +2,6 @@
 name = "web3-storage"
 main = "./dist/worker.js"
 compatibility_date = "2023-06-14"
-compatibility_flags = [
-  "streams_enable_constructors",
-  "transformstream_enable_standard_constructor"
-]
 no_bundle = true
 
 [build]


### PR DESCRIPTION
Getting error when deploying to staging/production:

```
  The compatibility flag streams_enable_constructors became the default as of 2022-11-30 so does not need to be specified anymore.
  The compatibility flag transformstream_enable_standard_constructor became the default as of 2022-11-30 so does not need to be specified anymore.
   [code: 10021]
```