### PR TITLE
fix: use dag-staging gateway from staging api

### DIFF
--- a/packages/api/wrangler.toml
+++ b/packages/api/wrangler.toml
@@ -52,7 +52,7 @@ r2_buckets = [
 account_id = "fffa4b4363a7e5250af8357087263b3a" # Protocol Labs CF account
 route = { pattern = "https://api-staging.web3.storage/*", zone_id = "7eee3323c1b35b6650568604c65f441e" }
 # nft.storage.ipfscluster.io is the staging cluster
-vars = { CARPARK_URL = "https://carpark-staging.web3.storage", CLUSTER_API_URL = "https://staging.pickup.dag.haus", ENV = "staging", PG_REST_URL = "https://web3-storage-pgrest-staging.herokuapp.com", GATEWAY_URL = "https://dag.w3s.link,https://ipfs.io" }
+vars = { CARPARK_URL = "https://carpark-staging.web3.storage", CLUSTER_API_URL = "https://staging.pickup.dag.haus", ENV = "staging", PG_REST_URL = "https://web3-storage-pgrest-staging.herokuapp.com", GATEWAY_URL = "https://dag-staging.w3s.link,https://ipfs.io" }
 r2_buckets = [
   { binding = "CARPARK", bucket_name = "carpark-staging-0" },
   { binding = "DUDEWHERE", bucket_name = "dudewhere-staging-0" },


### PR DESCRIPTION
Fix to use the staging gateway from the staging api

License: MIT