### PR TITLE
feat: add w3up-launch announcement banner (when env.NEXT_PUBLIC_W3UP_LAUNCH_SUNSET_ANNOUNCEMENT_START is set)

### DIFF
--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -177,6 +177,9 @@ jobs:
               core.setFailed('e2e tests did not succeed')
   preview:
     name: Preview
+    environment:
+      name: ${{ (github.ref_name == 'main') && 'staging' || format('preview-{0}', github.ref_name) }}
+      url: ${{ (github.ref_name == 'main') && 'https://staging.web3.storage/' || steps.cloudflare_url.outputs.stdout }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/package-lock.json
+++ b/package-lock.json
@@ -23830,7 +23830,7 @@
     },
     "packages/api": {
       "name": "@web3-storage/api",
-      "version": "7.18.1",
+      "version": "7.20.0",
       "license": "(Apache-2.0 OR MIT)",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.53.1",
@@ -26650,7 +26650,7 @@
     },
     "packages/website": {
       "name": "@web3-storage/website",
-      "version": "2.36.1",
+      "version": "2.36.3",
       "dependencies": {
         "@docsearch/react": "^3.0.0",
         "@fortawesome/free-brands-svg-icons": "^6.1.2",

--- a/packages/website/components/messagebanner/messagebanner.scss
+++ b/packages/website/components/messagebanner/messagebanner.scss
@@ -75,6 +75,10 @@
   }
 }
 
+.message-banner-underline-links *:link {
+  text-decoration: underline;
+}
+
 .message-banner-close-button {
   position: absolute;
   display: flex;

--- a/packages/website/components/page-banner/page-banner-portal.js
+++ b/packages/website/components/page-banner/page-banner-portal.js
@@ -32,7 +32,6 @@ export function MessageBannerStyled({ children }) {
  * that component (since it needs to be atop the page).
  */
 export const PageBannerPortal = ({ id, contentsRef, contentsClassName = defaultContentsClassName }) => {
-  console.log('contentsRef', contentsRef);
   return (
     <div id={id}>
       <div className={contentsClassName} ref={contentsRef}></div>
@@ -56,6 +55,5 @@ export const PageBanner = ({ children }) => {
       <MessageBannerStyled>{children}</MessageBannerStyled>
     </div>
   );
-  console.log('PageBanner render', { container, bannerChild });
   return <>{container && children && ReactDOM.createPortal(bannerChild, container)}</>;
 };

--- a/packages/website/components/page-banner/page-banner-portal.js
+++ b/packages/website/components/page-banner/page-banner-portal.js
@@ -31,24 +31,31 @@ export function MessageBannerStyled({ children }) {
  * Other components will use ReactDOM.createPortal() to render into this even though it isn't a child of
  * that component (since it needs to be atop the page).
  */
-export const PageBannerPortal = ({ id, contentsClassName = defaultContentsClassName }) => {
+export const PageBannerPortal = ({ id, contentsRef, contentsClassName = defaultContentsClassName }) => {
+  console.log('contentsRef', contentsRef);
   return (
     <div id={id}>
-      <div className={contentsClassName}></div>
+      <div className={contentsClassName} ref={contentsRef}></div>
     </div>
   );
 };
 
 /**
+ * React Context used for passing around the HTMLElement for the PageBannerPortal
+ * so that the PageBanner component can pass it to React.createPortal.
+ */
+export const PageBannerPortalContainerContext = React.createContext(undefined);
+
+/**
  * render children into a PageBannerPortal at the top of the page
  */
 export const PageBanner = ({ children }) => {
-  const pageBannerPortal = globalThis?.document?.querySelector(defaultPortalQuerySelector);
+  const container = React.useContext(PageBannerPortalContainerContext);
   const bannerChild = (
-    <div style={{ width: '100%' }}>
+    <div>
       <MessageBannerStyled>{children}</MessageBannerStyled>
     </div>
   );
-  console.log('PageBanner render', { pageBannerPortal, bannerChild });
-  return <>{pageBannerPortal && children && ReactDOM.createPortal(bannerChild, pageBannerPortal)}</>;
+  console.log('PageBanner render', { container, bannerChild });
+  return <>{container && children && ReactDOM.createPortal(bannerChild, container)}</>;
 };

--- a/packages/website/components/page-banner/page-banner-portal.js
+++ b/packages/website/components/page-banner/page-banner-portal.js
@@ -44,11 +44,11 @@ export const PageBannerPortal = ({ id, contentsClassName = defaultContentsClassN
  */
 export const PageBanner = ({ children }) => {
   const pageBannerPortal = globalThis?.document?.querySelector(defaultPortalQuerySelector);
-  return (
-    <>
-      {pageBannerPortal &&
-        children &&
-        ReactDOM.createPortal(<MessageBannerStyled>{children}</MessageBannerStyled>, pageBannerPortal)}
-    </>
+  const bannerChild = (
+    <div style={{ width: '100%' }}>
+      <MessageBannerStyled>{children}</MessageBannerStyled>
+    </div>
   );
+  console.log('PageBanner render', { pageBannerPortal, bannerChild });
+  return <>{pageBannerPortal && children && ReactDOM.createPortal(bannerChild, pageBannerPortal)}</>;
 };

--- a/packages/website/components/page-banner/page-banner-portal.js
+++ b/packages/website/components/page-banner/page-banner-portal.js
@@ -43,12 +43,7 @@ export const PageBannerPortal = ({ id, contentsClassName = defaultContentsClassN
  * render children into a PageBannerPortal at the top of the page
  */
 export const PageBanner = ({ children }) => {
-  const pageBannerPortal = React.useMemo(() => {
-    if (!globalThis?.document) return;
-    return document.querySelector(defaultPortalQuerySelector);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [globalThis?.document]);
-  // const pageBannerPortal = globalThis?.document?.querySelector(defaultPortalQuerySelector);
+  const pageBannerPortal = globalThis?.document?.querySelector(defaultPortalQuerySelector);
   return (
     <>
       {pageBannerPortal &&

--- a/packages/website/components/page-banner/page-banner-portal.js
+++ b/packages/website/components/page-banner/page-banner-portal.js
@@ -4,10 +4,11 @@
  */
 
 import clsx from 'clsx';
-import * as React from 'react-dom';
+import * as React from 'react';
+import * as ReactDOM from 'react-dom';
 
 export const defaultPortalElementId = 'page-banner-portal';
-export const defaultContentsClassName = 'contents';
+export const defaultContentsClassName = 'page-banner-contents';
 export const defaultPortalQuerySelector = `#${defaultPortalElementId} .${defaultContentsClassName}`;
 
 /**
@@ -15,27 +16,25 @@ export const defaultPortalQuerySelector = `#${defaultPortalElementId} .${default
  */
 export function MessageBannerStyled({ children }) {
   return (
-    <>
-      <div className={clsx('message-banner-wrapper')}>
-        <div className="message-banner-container" style={{ padding: '0.5em' }}>
-          <div className={clsx('message-banner-content', 'message-banner-underline-links', 'mb-reduced-fontsize')}>
-            {children}
-          </div>
+    <div className={clsx('message-banner-wrapper')}>
+      <div className="message-banner-container" style={{ padding: '0.5em' }}>
+        <div className={clsx('message-banner-content', 'message-banner-underline-links', 'mb-reduced-fontsize')}>
+          {children}
         </div>
       </div>
-    </>
+    </div>
   );
 }
 
 /**
  * component for an element across the top of page that can host banner messages on a per-page basis.
- * Other components will use React.createPortal() to render into this even though it isn't a child of
+ * Other components will use ReactDOM.createPortal() to render into this even though it isn't a child of
  * that component (since it needs to be atop the page).
  */
 export const PageBannerPortal = ({ id, contentsClassName = defaultContentsClassName }) => {
   return (
     <div id={id}>
-      <span className={contentsClassName}></span>
+      <div className={contentsClassName}></div>
     </div>
   );
 };
@@ -44,23 +43,17 @@ export const PageBannerPortal = ({ id, contentsClassName = defaultContentsClassN
  * render children into a PageBannerPortal at the top of the page
  */
 export const PageBanner = ({ children }) => {
-  const pageBannerPortal = document.querySelector(defaultPortalQuerySelector);
-  console.log('in PageBanner component', {
-    pageBannerPortal,
-    children,
-    defaultPortalQuerySelector,
-    found: document.querySelector(defaultPortalQuerySelector),
-  });
+  const pageBannerPortal = React.useMemo(() => {
+    if (!globalThis?.document) return;
+    return document.querySelector(defaultPortalQuerySelector);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [globalThis?.document]);
+  // const pageBannerPortal = globalThis?.document?.querySelector(defaultPortalQuerySelector);
   return (
     <>
       {pageBannerPortal &&
         children &&
-        React.createPortal(
-          <>
-            <MessageBannerStyled>{children}</MessageBannerStyled>
-          </>,
-          pageBannerPortal
-        )}
+        ReactDOM.createPortal(<MessageBannerStyled>{children}</MessageBannerStyled>, pageBannerPortal)}
     </>
   );
 };

--- a/packages/website/components/page-banner/page-banner-portal.js
+++ b/packages/website/components/page-banner/page-banner-portal.js
@@ -1,0 +1,43 @@
+/**
+ * @fileoverview component that contains a 'page banner', i.e. a banner across the whole
+ * web page that shows a prominent message to the end-user.
+ */
+
+import clsx from 'clsx';
+
+export const defaultPortalElementId = 'page-banner-portal';
+export const defaultContentsClassName = 'contents';
+
+/**
+ * wrap children in stiles like a .message-banner (see ../messagebanner/messagebanner.scss)
+ */
+function MessageBannerStyled({ children }) {
+  return (
+    <>
+      <div className={clsx('message-banner-wrapper')}>
+        <div className="grid-noGutter">
+          <div className="col">
+            <div className="message-banner-container">
+              <div className={clsx('message-banner-content', 'mb-reduced-fontsize')}>{children}</div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </>
+  );
+}
+
+/**
+ * component for an element across the top of page that can host banner messages on a per-page basis.
+ * Other components will use React.createPortal() to render into this even though it isn't a child of
+ * that component (since it needs to be atop the page).
+ */
+export const PageBannerPortal = ({ id, contentsClassName = defaultContentsClassName }) => {
+  return (
+    <div id={id}>
+      <MessageBannerStyled>
+        <span className={contentsClassName}></span>
+      </MessageBannerStyled>
+    </div>
+  );
+};

--- a/packages/website/components/page-banner/page-banner-portal.js
+++ b/packages/website/components/page-banner/page-banner-portal.js
@@ -4,22 +4,22 @@
  */
 
 import clsx from 'clsx';
+import * as React from 'react-dom';
 
 export const defaultPortalElementId = 'page-banner-portal';
 export const defaultContentsClassName = 'contents';
+export const defaultPortalQuerySelector = `#${defaultPortalElementId} .${defaultContentsClassName}`;
 
 /**
  * wrap children in stiles like a .message-banner (see ../messagebanner/messagebanner.scss)
  */
-function MessageBannerStyled({ children }) {
+export function MessageBannerStyled({ children }) {
   return (
     <>
       <div className={clsx('message-banner-wrapper')}>
-        <div className="grid-noGutter">
-          <div className="col">
-            <div className="message-banner-container">
-              <div className={clsx('message-banner-content', 'mb-reduced-fontsize')}>{children}</div>
-            </div>
+        <div className="message-banner-container" style={{ padding: '0.5em' }}>
+          <div className={clsx('message-banner-content', 'message-banner-underline-links', 'mb-reduced-fontsize')}>
+            {children}
           </div>
         </div>
       </div>
@@ -35,9 +35,32 @@ function MessageBannerStyled({ children }) {
 export const PageBannerPortal = ({ id, contentsClassName = defaultContentsClassName }) => {
   return (
     <div id={id}>
-      <MessageBannerStyled>
-        <span className={contentsClassName}></span>
-      </MessageBannerStyled>
+      <span className={contentsClassName}></span>
     </div>
+  );
+};
+
+/**
+ * render children into a PageBannerPortal at the top of the page
+ */
+export const PageBanner = ({ children }) => {
+  const pageBannerPortal = document.querySelector(defaultPortalQuerySelector);
+  console.log('in PageBanner component', {
+    pageBannerPortal,
+    children,
+    defaultPortalQuerySelector,
+    found: document.querySelector(defaultPortalQuerySelector),
+  });
+  return (
+    <>
+      {pageBannerPortal &&
+        children &&
+        React.createPortal(
+          <>
+            <MessageBannerStyled>{children}</MessageBannerStyled>
+          </>,
+          pageBannerPortal
+        )}
+    </>
   );
 };

--- a/packages/website/components/w3up-launch.js
+++ b/packages/website/components/w3up-launch.js
@@ -1,0 +1,26 @@
+import * as React from 'react';
+
+/**
+ * copy for banner message across top of some web3.storage pages when w3up ships
+ */
+export const W3upMigrationRecommendationCopy = () => {
+  const createNewAccountHref = 'https://console.web3.storage/?intent=create-account';
+  const learnWhatsNewHref = 'https://console.web3.storage/?intent=learn-new-web3storage-experience';
+  return (
+    <>
+      This web3.storage product will sunset on January 9, 2024. We recommend migrating your usage of web3.storage to the
+      new web3.storage. <a href={createNewAccountHref}>Click here to create a new account</a> and&nbsp;
+      <a href={learnWhatsNewHref}>here to read about what’s awesome</a> about the new web3.storage experience.
+    </>
+  );
+};
+
+const prelaunchStartEnv = process.env.NEXT_PUBLIC_W3UP_PRELAUNCH_START;
+
+export const w3upLaunchContextDefaults = {
+  stages: {
+    prelaunch: {
+      start: prelaunchStartEnv ? new Date(Date.parse(prelaunchStartEnv)) : undefined,
+    },
+  },
+};

--- a/packages/website/components/w3up-launch.js
+++ b/packages/website/components/w3up-launch.js
@@ -1,26 +1,55 @@
 import * as React from 'react';
 
+const sunsetStartEnv = process.env.NEXT_PUBLIC_W3UP_LAUNCH_SUNSET_START ?? '2023-01-09T00:00:00Z';
+const sunsetStartDate = new Date(Date.parse(sunsetStartEnv));
+
+/**
+ * If this isn't set, no announcements will appear
+ */
+const sunsetAnnouncementStartEnv = process.env.NEXT_PUBLIC_W3UP_LAUNCH_SUNSET_ANNOUNCEMENT_START;
+
+/**
+ * after this datetime, show announcements that web3.storage is sunset
+ * and end-users should switch to w3up/console.web3.storage
+ */
+const sunsetAnnouncementStartDate = sunsetAnnouncementStartEnv
+  ? new Date(Date.parse(sunsetAnnouncementStartEnv))
+  : undefined;
+
+export const w3upLaunchContextDefaults = {
+  stages: {
+    sunsetAnnouncement: {
+      start: sunsetAnnouncementStartDate,
+    },
+  },
+};
+
+/**
+ * Return whether sunset announcements related to w3up-launch should be shown.
+ * An announcement date must be explicitly configured via env var, and now must be after that date.
+ * @param {Date} at - time at which to return whether to show the announcement
+ * @param {Date|undefined} [announcementStartDate] - when to begin showing announcements.
+ * If not provided, always return false.
+ */
+export const shouldShowSunsetAnnouncement = (at = new Date(), announcementStartDate = sunsetAnnouncementStartDate) => {
+  return announcementStartDate && at > announcementStartDate;
+};
+
 /**
  * copy for banner message across top of some web3.storage pages when w3up ships
  */
 export const W3upMigrationRecommendationCopy = () => {
+  console.log('rendering W3upMigrationRecommendationCopy', w3upLaunchContextDefaults);
   const createNewAccountHref = 'https://console.web3.storage/?intent=create-account';
   const learnWhatsNewHref = 'https://console.web3.storage/?intent=learn-new-web3storage-experience';
+  const sunsetDateFormatter = new Intl.DateTimeFormat(undefined, { dateStyle: 'long' });
   return (
     <>
-      This web3.storage product will sunset on January 9, 2024. We recommend migrating your usage of web3.storage to the
-      new web3.storage. <a href={createNewAccountHref}>Click here to create a new account</a> and&nbsp;
+      This web3.storage product will sunset on {sunsetDateFormatter.format(sunsetStartDate)}. We recommend migrating
+      your usage of web3.storage to the new web3.storage.
+      <br />
+      <a href={createNewAccountHref}>Click here to create a new account</a> and&nbsp;
       <a href={learnWhatsNewHref}>here to read about what’s awesome</a> about the new web3.storage experience.
     </>
   );
-};
-
-const prelaunchStartEnv = process.env.NEXT_PUBLIC_W3UP_PRELAUNCH_START;
-
-export const w3upLaunchContextDefaults = {
-  stages: {
-    prelaunch: {
-      start: prelaunchStartEnv ? new Date(Date.parse(prelaunchStartEnv)) : undefined,
-    },
-  },
 };

--- a/packages/website/components/w3up-launch.js
+++ b/packages/website/components/w3up-launch.js
@@ -16,14 +16,6 @@ const sunsetAnnouncementStartDate = sunsetAnnouncementStartEnv
   ? new Date(Date.parse(sunsetAnnouncementStartEnv))
   : undefined;
 
-export const w3upLaunchContextDefaults = {
-  stages: {
-    sunsetAnnouncement: {
-      start: sunsetAnnouncementStartDate,
-    },
-  },
-};
-
 /**
  * Return whether sunset announcements related to w3up-launch should be shown.
  * An announcement date must be explicitly configured via env var, and now must be after that date.
@@ -33,6 +25,19 @@ export const w3upLaunchContextDefaults = {
  */
 export const shouldShowSunsetAnnouncement = (at = new Date(), announcementStartDate = sunsetAnnouncementStartDate) => {
   return announcementStartDate && at > announcementStartDate;
+};
+
+export const w3upLaunchConfig = {
+  type: 'W3upLaunchConfig',
+  stages: {
+    sunsetAnnouncement: {
+      start: sunsetAnnouncementStartDate,
+    },
+    sunset: {
+      start: sunsetStartDate,
+    },
+  },
+  shouldShowSunsetAnnouncement: shouldShowSunsetAnnouncement(),
 };
 
 /**

--- a/packages/website/components/w3up-launch.js
+++ b/packages/website/components/w3up-launch.js
@@ -39,7 +39,6 @@ export const shouldShowSunsetAnnouncement = (at = new Date(), announcementStartD
  * copy for banner message across top of some web3.storage pages when w3up ships
  */
 export const W3upMigrationRecommendationCopy = () => {
-  console.log('rendering W3upMigrationRecommendationCopy', w3upLaunchContextDefaults);
   const createNewAccountHref = 'https://console.web3.storage/?intent=create-account';
   const learnWhatsNewHref = 'https://console.web3.storage/?intent=learn-new-web3storage-experience';
   const sunsetDateFormatter = new Intl.DateTimeFormat(undefined, { dateStyle: 'long' });

--- a/packages/website/modules/docs-theme/index.js
+++ b/packages/website/modules/docs-theme/index.js
@@ -94,7 +94,7 @@ export default function Docs(props) {
         <>
           {shouldShowSunsetAnnouncement() && (
             <PageBannerPortal.PageBanner>
-                <W3upMigrationRecommendationCopy />
+              <W3upMigrationRecommendationCopy />
             </PageBannerPortal.PageBanner>
           )}
           {sharedHead}

--- a/packages/website/modules/docs-theme/index.js
+++ b/packages/website/modules/docs-theme/index.js
@@ -1,6 +1,5 @@
 import React, { useEffect } from 'react';
 import { MDXProvider } from '@mdx-js/react';
-
 import Head from 'next/head';
 import { useRouter } from 'next/router';
 import hljs from 'highlight.js/lib/core';
@@ -9,10 +8,13 @@ import powershell from 'highlight.js/lib/languages/powershell';
 import bash from 'highlight.js/lib/languages/bash';
 import go from 'highlight.js/lib/languages/go';
 import json from 'highlight.js/lib/languages/json';
+
 import Sidebar from './sidebar/sidebar';
 import Feedback from './feedback/feedback';
 import Toc from './toc/toc';
 import DocsPagination from './docspagination/docspagination';
+import { W3upMigrationRecommendationCopy, shouldShowSunsetAnnouncement } from '../../components/w3up-launch.js';
+import * as PageBannerPortal from '../../components/page-banner/page-banner-portal.js';
 
 hljs.registerLanguage('javascript', javascript);
 hljs.registerLanguage('powershell', powershell);
@@ -27,7 +29,7 @@ export default function Docs(props) {
   useEffect(() => {
     const pres = document.querySelectorAll('pre');
 
-    pres.forEach((pre) => {
+    pres.forEach(pre => {
       const code = pre.firstElementChild?.innerHTML;
       if (code) {
         const button = document.createElement('button');
@@ -39,7 +41,7 @@ export default function Docs(props) {
         button.classList.add('code-copy-button');
         document.body.appendChild(textarea);
 
-        button.addEventListener('click', (event) => {
+        button.addEventListener('click', event => {
           if (!navigator.clipboard) {
             textarea.focus({ preventScroll: true });
             textarea.select();
@@ -63,7 +65,6 @@ export default function Docs(props) {
 
         pre.appendChild(button);
       }
-
     });
 
     hljs.highlightAll();
@@ -91,6 +92,11 @@ export default function Docs(props) {
     return function Layout({ children }) {
       return (
         <>
+          {shouldShowSunsetAnnouncement() && (
+            <PageBannerPortal.PageBanner>
+                <W3upMigrationRecommendationCopy />
+            </PageBannerPortal.PageBanner>
+          )}
           {sharedHead}
           <div className="docs-container">
             <Sidebar openMenu={null} />

--- a/packages/website/pages/_app.js
+++ b/packages/website/pages/_app.js
@@ -7,6 +7,7 @@ import Script from 'next/script';
 import Metadata from 'components/general/metadata';
 import RestrictedRoute from 'components/general/restrictedRoute';
 import AppProviders from 'components/general/appProviders';
+import { PageBannerPortal, defaultPortalElementId } from '../components/page-banner/page-banner-portal.js';
 import MessageBanner from '../components/messagebanner/messagebanner.js';
 import Navigation from '../components/navigation/navigation.js';
 import Footer from '../components/footer/footer.js';
@@ -43,6 +44,15 @@ const App = ({ Component, pageProps }) => {
         </noscript>
         <div id="master-container" className={clsx(pageClass)}>
           {productApp && <div className="corkscrew-background"></div>}
+          {/* use react-dom createPortal to render page-specific banners into this */}
+          <div
+            style={{
+              // needed so this banner is above .corkscrew-background
+              zIndex: 1,
+            }}
+          >
+            <PageBannerPortal id={defaultPortalElementId} />
+          </div>
           <MessageBanner />
           <Navigation isProductApp={productApp} breadcrumbs={pageProps.breadcrumbs} />
           <Component {...pageProps} />

--- a/packages/website/pages/_app.js
+++ b/packages/website/pages/_app.js
@@ -42,17 +42,21 @@ const App = ({ Component, pageProps }) => {
             referrerPolicy="no-referrer-when-downgrade"
           />
         </noscript>
-        <div id="master-container" className={clsx(pageClass)}>
+
+        <div
+          style={{
+            // needed so this banner is above .corkscrew-background
+            zIndex: 1,
+            // must be positioned for zIndex to take effect
+            position: 'relative',
+          }}
+        >
+          <PageBannerPortal id={defaultPortalElementId}></PageBannerPortal>
+        </div>
+
+        <div id="master-container" className={clsx(pageClass)} style={{ zIndex: 0 }}>
           {productApp && <div className="corkscrew-background"></div>}
-          {/* use react-dom createPortal to render page-specific banners into this */}
-          <div
-            style={{
-              // needed so this banner is above .corkscrew-background
-              zIndex: 1,
-            }}
-          >
-            <PageBannerPortal id={defaultPortalElementId} />
-          </div>
+
           <MessageBanner />
           <Navigation isProductApp={productApp} breadcrumbs={pageProps.breadcrumbs} />
           <Component {...pageProps} />

--- a/packages/website/pages/_app.js
+++ b/packages/website/pages/_app.js
@@ -1,13 +1,17 @@
 import '../styles/global.scss';
 import { useRouter } from 'next/router';
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import clsx from 'clsx';
 import Script from 'next/script';
 
 import Metadata from 'components/general/metadata';
 import RestrictedRoute from 'components/general/restrictedRoute';
 import AppProviders from 'components/general/appProviders';
-import { PageBannerPortal, defaultPortalElementId } from '../components/page-banner/page-banner-portal.js';
+import {
+  PageBannerPortal,
+  defaultPortalElementId,
+  PageBannerPortalContainerContext,
+} from '../components/page-banner/page-banner-portal.js';
 import MessageBanner from '../components/messagebanner/messagebanner.js';
 import Navigation from '../components/navigation/navigation.js';
 import Footer from '../components/footer/footer.js';
@@ -20,6 +24,7 @@ const App = ({ Component, pageProps }) => {
   const productRoutes = ['/login', '/account', '/account/payment', '/tokens', '/callback'];
   const productApp = productRoutes.includes(pathname);
   const pageClass = pathname.includes('docs') ? 'docs-site' : productApp ? 'product-app' : 'marketing-site';
+  const [pageBannerPortalEl, setPageBannerPortalEl] = useState();
 
   useEffect(() => {
     document.querySelector('body')?.classList.add(pageClass);
@@ -51,17 +56,19 @@ const App = ({ Component, pageProps }) => {
             position: 'relative',
           }}
         >
-          <PageBannerPortal id={defaultPortalElementId}></PageBannerPortal>
+          <PageBannerPortal id={defaultPortalElementId} contentsRef={setPageBannerPortalEl}></PageBannerPortal>
         </div>
 
-        <div id="master-container" className={clsx(pageClass)} style={{ zIndex: 0 }}>
-          {productApp && <div className="corkscrew-background"></div>}
+        <PageBannerPortalContainerContext.Provider value={pageBannerPortalEl}>
+          <div id="master-container" className={clsx(pageClass)} style={{ zIndex: 0 }}>
+            {productApp && <div className="corkscrew-background"></div>}
 
-          <MessageBanner />
-          <Navigation isProductApp={productApp} breadcrumbs={pageProps.breadcrumbs} />
-          <Component {...pageProps} />
-          <Footer isProductApp={productApp} />
-        </div>
+            <MessageBanner />
+            <Navigation isProductApp={productApp} breadcrumbs={pageProps.breadcrumbs} />
+            <Component {...pageProps} />
+            <Footer isProductApp={productApp} />
+          </div>
+        </PageBannerPortalContainerContext.Provider>
       </RestrictedRoute>
     </AppProviders>
   );

--- a/packages/website/pages/_document.js
+++ b/packages/website/pages/_document.js
@@ -1,5 +1,7 @@
 import Document, { Html, Head, Main, NextScript } from 'next/document';
 
+import { w3upLaunchConfig } from '../components/w3up-launch.js';
+
 class MyDocument extends Document {
   /**
    * @param {import("next/document").DocumentContext} ctx
@@ -28,6 +30,11 @@ class MyDocument extends Document {
           <Main />
           <NextScript />
           <div id="modal-root"></div>
+          {/* add this for debuggability of launch announcements that only appear when configured */}
+          <script
+            type="application/json"
+            dangerouslySetInnerHTML={{ __html: JSON.stringify(w3upLaunchConfig) }}
+          ></script>
         </body>
       </Html>
     );

--- a/packages/website/pages/account/index.js
+++ b/packages/website/pages/account/index.js
@@ -10,6 +10,8 @@ import FileUploader from '../../components/account/fileUploader/fileUploader';
 import GradientBackground from '../../components/gradientbackground/gradientbackground.js';
 import AppData from '../../content/pages/app/account.json';
 import GeneralPageData from '../../content/pages/general.json';
+import { W3upMigrationRecommendationCopy, shouldShowSunsetAnnouncement } from '../../components/w3up-launch.js';
+import * as PageBannerPortal from '../../components/page-banner/page-banner-portal.js';
 
 export const CTACardTypes = {
   API_TOKENS: 'API_TOKENS',
@@ -79,6 +81,11 @@ const Account = () => {
 
   return (
     <>
+      {shouldShowSunsetAnnouncement() && (
+        <PageBannerPortal.PageBanner>
+          <W3upMigrationRecommendationCopy />
+        </PageBannerPortal.PageBanner>
+      )}
       <div className="page-container account-container">
         <h1 className="table-heading">{dashboard.heading}</h1>
         <div className="account-content">

--- a/packages/website/pages/account/payment.js
+++ b/packages/website/pages/account/payment.js
@@ -5,6 +5,7 @@
 import { parse as queryParse } from 'querystring';
 
 import { useState, useEffect, useMemo } from 'react';
+import { createPortal } from 'react-dom';
 import { Elements, ElementsConsumer } from '@stripe/react-stripe-js';
 import { loadStripe } from '@stripe/stripe-js';
 
@@ -18,6 +19,8 @@ import { plans, freePlan } from '../../components/contexts/plansContext';
 import { userBillingSettings } from '../../lib/api';
 import GeneralPageData from '../../content/pages/general.json';
 import constants from '../../lib/constants.js';
+import { W3upMigrationRecommendationCopy } from '../../components/w3up-launch.js';
+import * as PageBannerPortal from '../../components/page-banner/page-banner-portal.js';
 
 /**
  * @typedef {import('../../components/contexts/plansContext').Plan} Plan
@@ -123,9 +126,19 @@ const PaymentSettingsPage = props => {
   const savedPaymentMethod = useMemo(() => {
     return paymentSettings?.paymentMethod;
   }, [paymentSettings]);
-
+  const pageBannerPortal = document.querySelector(
+    `#${PageBannerPortal.defaultPortalElementId} .${PageBannerPortal.defaultContentsClassName}`
+  );
   return (
     <>
+      {pageBannerPortal &&
+        createPortal(
+          <>
+            <W3upMigrationRecommendationCopy />
+          </>,
+          pageBannerPortal
+        )}
+
       <>
         <div className="page-container billing-container">
           <div className="">

--- a/packages/website/pages/account/payment.js
+++ b/packages/website/pages/account/payment.js
@@ -5,7 +5,6 @@
 import { parse as queryParse } from 'querystring';
 
 import { useState, useEffect, useMemo } from 'react';
-import { createPortal } from 'react-dom';
 import { Elements, ElementsConsumer } from '@stripe/react-stripe-js';
 import { loadStripe } from '@stripe/stripe-js';
 
@@ -19,7 +18,7 @@ import { plans, freePlan } from '../../components/contexts/plansContext';
 import { userBillingSettings } from '../../lib/api';
 import GeneralPageData from '../../content/pages/general.json';
 import constants from '../../lib/constants.js';
-import { W3upMigrationRecommendationCopy } from '../../components/w3up-launch.js';
+import { W3upMigrationRecommendationCopy, shouldShowSunsetAnnouncement } from '../../components/w3up-launch.js';
 import * as PageBannerPortal from '../../components/page-banner/page-banner-portal.js';
 
 /**
@@ -126,19 +125,13 @@ const PaymentSettingsPage = props => {
   const savedPaymentMethod = useMemo(() => {
     return paymentSettings?.paymentMethod;
   }, [paymentSettings]);
-  const pageBannerPortal = document.querySelector(
-    `#${PageBannerPortal.defaultPortalElementId} .${PageBannerPortal.defaultContentsClassName}`
-  );
   return (
     <>
-      {pageBannerPortal &&
-        createPortal(
-          <>
-            <W3upMigrationRecommendationCopy />
-          </>,
-          pageBannerPortal
-        )}
-
+      {shouldShowSunsetAnnouncement() && (
+        <PageBannerPortal.PageBanner>
+          <W3upMigrationRecommendationCopy />
+        </PageBannerPortal.PageBanner>
+      )}
       <>
         <div className="page-container billing-container">
           <div className="">

--- a/packages/website/pages/index.js
+++ b/packages/website/pages/index.js
@@ -1,6 +1,7 @@
 import { useEffect } from 'react';
 
 import IndexPageData from '../content/pages/index.json';
+import Scroll2Top from '../components/scroll2top/scroll2top.js';
 import BlockBuilder from '../components/blockbuilder/blockbuilder.js';
 import { initFloaterAnimations } from '../lib/floater-animations.js';
 import { W3upMigrationRecommendationCopy, shouldShowSunsetAnnouncement } from '../components/w3up-launch.js';
@@ -35,6 +36,8 @@ export default function Home() {
           <BlockBuilder id={`section_${index + 1}`} key={`section_${index + 1}`} subsections={section} />
         ))}
       </main>
+
+      <Scroll2Top />
     </>
   );
 }

--- a/packages/website/pages/index.js
+++ b/packages/website/pages/index.js
@@ -1,9 +1,10 @@
 import { useEffect } from 'react';
 
 import IndexPageData from '../content/pages/index.json';
-import Scroll2Top from '../components/scroll2top/scroll2top.js';
 import BlockBuilder from '../components/blockbuilder/blockbuilder.js';
 import { initFloaterAnimations } from '../lib/floater-animations.js';
+import { W3upMigrationRecommendationCopy, shouldShowSunsetAnnouncement } from '../components/w3up-launch.js';
+import * as PageBannerPortal from '../components/page-banner/page-banner-portal.js';
 
 export default function Home() {
   const sections = IndexPageData.page_content;
@@ -23,13 +24,17 @@ export default function Home() {
 
   return (
     <>
+      {shouldShowSunsetAnnouncement() && (
+        <PageBannerPortal.PageBanner>
+          <W3upMigrationRecommendationCopy />
+        </PageBannerPortal.PageBanner>
+      )}
+
       <main className="page page-index">
         {sections.map((section, index) => (
           <BlockBuilder id={`section_${index + 1}`} key={`section_${index + 1}`} subsections={section} />
         ))}
       </main>
-
-      <Scroll2Top />
     </>
   );
 }


### PR DESCRIPTION
Motivation:
* https://github.com/web3-storage/secrets/issues/20

Tactics:
* there is a new env var `NEXT_PUBLIC_W3UP_LAUNCH_SUNSET_ANNOUNCEMENT_START` that is an ISO8601 datetime of when the announcement should appear. If unset, the announcement will never appear. My intention is to set it only on the staging environment for acceptance testing. Once we're happy on staging, we can enable it on production by setting this var to whatever datetime we want it to appear.

Scope:
* when enabled at after the appropriate time, the banner should appear on the following routes
  * /
  * /account
  * /account/payment
  * /docs
* the github actions `website` workflow now uses github environments. This is because I want to use them to configure the staging environment to have a particular value for `NEXT_PUBLIC_W3UP_LAUNCH_SUNSET_ANNOUNCEMENT_START`