### PR TITLE
feat: remove 'whats the data layer?' cta2 from website homepage

### DIFF
--- a/packages/website/content/pages/index.json
+++ b/packages/website/content/pages/index.json
@@ -34,13 +34,6 @@
               "event": "",
               "ui": "HOME_HERO",
               "action": "Get Started"
-            },
-            "cta2": {
-              "url": "https://blog.web3.storage/posts/say-hello-to-the-data-layer-1-3-intro-to-web3-storage",
-              "text": "WHAT'S THE DATA LAYER?",
-              "event": "",
-              "ui": "HOME_HERO",
-              "action": "Data Layer Blog Link"
             }
           }
         ]


### PR DESCRIPTION
Motivation:
* https://github.com/web3-storage/secrets/issues/26