### PR TITLE
ci: .github/workflows/api.yml when using wrangler-action passes with vars

### DIFF
--- a/.github/workflows/api.yml
+++ b/.github/workflows/api.yml
@@ -14,6 +14,19 @@ on:
       - 'packages/db/**'
       - '.github/workflows/api.yml'
       - 'package-lock.json'
+  workflow_dispatch:
+    inputs:
+      force_deploy_staging:
+        description: whether to deploy to staging even if the job wouldn't normally run
+        required: true
+        type: boolean
+        default: false
+      force_deploy_production:
+        description: whether to deploy to production even if the job wouldn't normally run
+        required: true
+        type: boolean
+        default: false
+
 jobs:
   test:
     runs-on: ubuntu-latest
@@ -52,7 +65,7 @@ jobs:
 
   deploy-staging:
     name: Deploy Staging
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    if: (github.event_name == 'push' && github.ref == 'refs/heads/main') || inputs.force_deploy_staging
     runs-on: ubuntu-latest
     needs: test
     environment:
@@ -88,7 +101,7 @@ jobs:
   
   deploy-production:
     name: Deploy Production
-    if: (github.event_name == 'push' && github.ref == 'refs/heads/main' && needs.changelog.outputs.releases_created) || inputs.force_release
+    if: (github.event_name == 'push' && github.ref == 'refs/heads/main' && needs.changelog.outputs.releases_created) || inputs.force_deploy_production
     runs-on: ubuntu-latest
     needs:
       - test

--- a/.github/workflows/api.yml
+++ b/.github/workflows/api.yml
@@ -76,6 +76,10 @@ jobs:
           apiToken: ${{ secrets.CF_TOKEN }}
           workingDirectory: 'packages/api'
           environment: 'staging'
+          vars: |
+            NEXT_PUBLIC_W3UP_LAUNCH_LIMITED_AVAILABILITY_START
+            NEXT_PUBLIC_W3UP_LAUNCH_SUNSET_ANNOUNCEMENT_START
+            NEXT_PUBLIC_W3UP_LAUNCH_SUNSET_START
       - name: Test upload to staging
         run: |
           npm run build -w packages/client
@@ -112,3 +116,7 @@ jobs:
           apiToken: ${{ secrets.CF_TOKEN }}
           workingDirectory: 'packages/api'
           environment: 'production'
+          vars: |
+            NEXT_PUBLIC_W3UP_LAUNCH_LIMITED_AVAILABILITY_START
+            NEXT_PUBLIC_W3UP_LAUNCH_SUNSET_ANNOUNCEMENT_START
+            NEXT_PUBLIC_W3UP_LAUNCH_SUNSET_START

--- a/packages/api/test/user.spec.js
+++ b/packages/api/test/user.spec.js
@@ -570,7 +570,7 @@ describe('userLoginPost', function () {
   })
 
   it('should not create new users once date is after NEXT_PUBLIC_W3UP_LAUNCH_LIMITED_AVAILABILITY_START', async function () {
-    if ( ! process.env.CI_DONT_ACCOMODATE_LONG_TESTS) {
+    if (!process.env.CI_DONT_ACCOMODATE_LONG_TESTS) {
       // this times out on CI in the default 5 seconds.
       // It's not surprising this may take some time, since it relies on creating a whole new miniflare server.
       this.timeout(60 * 1000)


### PR DESCRIPTION
…vars so that the env vars like NEXT_PUBLIC_W3UP_LAUNCH_ get added to cf worker vars

Motivation:
* https://github.com/web3-storage/web3.storage/issues/2327
    * tldr fix so that gh env vars get released with packages/api to staging/production environments on cloudflare

