### PR TITLE
ci: api.yml upgrade wrangler-action to 3.3.2 to use vars var

### DIFF
--- a/.github/workflows/api.yml
+++ b/.github/workflows/api.yml
@@ -77,7 +77,7 @@ jobs:
           node-version: 18
       - uses: bahmutov/npm-install@v1
       - name: Publish api worker
-        uses: cloudflare/wrangler-action@3.3.2
+        uses: cloudflare/wrangler-action@v3
         env:
           ENV: 'staging' # inform the build process what the env is
           SENTRY_TOKEN: ${{ secrets.SENTRY_TOKEN}}
@@ -117,7 +117,7 @@ jobs:
           registry-url: https://registry.npmjs.org/
       - uses: bahmutov/npm-install@v1
       - name: API - Deploy to Cloudflare
-        uses: cloudflare/wrangler-action@3.3.2
+        uses: cloudflare/wrangler-action@v3
         env:
           ENV: 'production' # inform the build process what the env is
           SENTRY_TOKEN: ${{ secrets.SENTRY_TOKEN}}

--- a/.github/workflows/api.yml
+++ b/.github/workflows/api.yml
@@ -77,7 +77,7 @@ jobs:
           node-version: 18
       - uses: bahmutov/npm-install@v1
       - name: Publish api worker
-        uses: cloudflare/wrangler-action@2.0.0
+        uses: cloudflare/wrangler-action@3.3.2
         env:
           ENV: 'staging' # inform the build process what the env is
           SENTRY_TOKEN: ${{ secrets.SENTRY_TOKEN}}
@@ -117,7 +117,7 @@ jobs:
           registry-url: https://registry.npmjs.org/
       - uses: bahmutov/npm-install@v1
       - name: API - Deploy to Cloudflare
-        uses: cloudflare/wrangler-action@2.0.0
+        uses: cloudflare/wrangler-action@3.3.2
         env:
           ENV: 'production' # inform the build process what the env is
           SENTRY_TOKEN: ${{ secrets.SENTRY_TOKEN}}


### PR DESCRIPTION
Motivation:
* i want to use `vars` for https://github.com/web3-storage/web3.storage/pull/2328 but it didn't work due to old wrangler action