### PR TITLE
feat: bypass maintenance mode for allowed tokens

### DIFF
--- a/packages/api/src/auth.js
+++ b/packages/api/src/auth.js
@@ -266,7 +266,7 @@ function verifyAuthToken (token, decoded, env) {
   return env.db.getKey(decoded.sub, token)
 }
 
-function getTokenFromRequest (request, { magic }) {
+export function getTokenFromRequest (request, { magic }) {
   const authHeader = request.headers.get('Authorization') || ''
   if (!authHeader) {
     throw new NoTokenError()

--- a/packages/api/src/env.js
+++ b/packages/api/src/env.js
@@ -41,6 +41,7 @@ import { Factory as ClaimFactory } from './utils/content-claims.js'
  * @property {string} [SENTRY_RELEASE]
  * @property {string} [LOGTAIL_TOKEN]
  * @property {string} MAINTENANCE_MODE
+ * @property {string} [MODE_SKIP_LIST]
  * @property {string} [DANGEROUSLY_BYPASS_MAGIC_AUTH]
  * @property {string} [ELASTIC_IPFS_PEER_ID]
  * @property {string} [ENABLE_ADD_TO_CLUSTER]
@@ -71,6 +72,7 @@ import { Factory as ClaimFactory } from './utils/content-claims.js'
  * @property {import('./utils/billing-types').CustomersService} customers
  * @property {string} stripeSecretKey
  * @property {string[]} gatewayUrls
+ * @property {string[]} modeSkipList
  * @property {import('./utils/content-claims').Factory} [claimFactory]
  */
 
@@ -149,6 +151,8 @@ export async function envAll (req, env, ctx) {
 
   // @ts-ignore
   env.MODE = env.MAINTENANCE_MODE || DEFAULT_MODE
+
+  env.modeSkipList = env.MODE_SKIP_LIST ? JSON.parse(env.MODE_SKIP_LIST) : []
 
   env.ELASTIC_IPFS_PEER_ID = env.ELASTIC_IPFS_PEER_ID ?? 'bafzbeibhqavlasjc7dvbiopygwncnrtvjd2xmryk5laib7zyjor6kf3avm'
 

--- a/packages/api/src/maintenance.js
+++ b/packages/api/src/maintenance.js
@@ -1,4 +1,5 @@
 import { HTTPError, MaintenanceError } from './errors.js'
+import { getTokenFromRequest } from './auth.js'
 
 /**
  * @typedef {'rw' | 'r-' | '--'} Mode
@@ -61,8 +62,22 @@ export function withMode (mode) {
       })
     }
 
+    const modeSkip = () => {
+      if (!request.headers) {
+        return false
+      }
+
+      const list = env.modeSkipList
+      const token = getTokenFromRequest(request, env)
+
+      if (list.includes(token)) {
+        return true
+      }
+      return false
+    }
+
     // Not enabled, use maintenance handler.
-    if (!enabled()) {
+    if (!enabled() && !modeSkip()) {
       return maintenanceHandler()
     }
   }

--- a/packages/api/test/maintenance.spec.js
+++ b/packages/api/test/maintenance.spec.js
@@ -1,11 +1,23 @@
 /* eslint-env mocha */
 import assert from 'assert'
+import { CID } from 'multiformats/cid'
+import { sha256 } from 'multiformats/hashes/sha2'
+import fetch from '@web-std/fetch'
+
 import {
   withMode,
   READ_WRITE,
   READ_ONLY,
   NO_READ_OR_WRITE
 } from '../src/maintenance.js'
+import { CAR_CODE } from '../src/constants.js'
+
+import { endpoint } from './scripts/constants.js'
+import { createCar } from './scripts/car.js'
+import { getTestJWT } from './scripts/helpers.js'
+
+// client needs global fetch
+Object.assign(global, { fetch })
 
 describe('maintenance middleware', () => {
   it('should throw error when in maintenance for a READ_ONLY route', () => {
@@ -50,6 +62,36 @@ describe('maintenance middleware', () => {
     assert.throws(() => block(() => { }, {
       MODE: NO_READ_OR_WRITE
     }), /API undergoing maintenance/)
+  })
+
+  it('should bypass maintenance mode with a allowed token', async () => {
+    const issuer = 'test-upload'
+    const token = await getTestJWT(issuer, issuer)
+    const { root, car: carBody } = await createCar('dude where\'s my CAR')
+    const carBytes = new Uint8Array(await carBody.arrayBuffer())
+    const expectedCid = root.toString()
+    const expectedCarCid = CID.createV1(CAR_CODE, await sha256.digest(carBytes)).toString()
+
+    /** @type {import('miniflare').Miniflare} */
+    const mf = globalThis.miniflare
+    const bindings = await mf.getBindings()
+    bindings.MAINTENANCE_MODE = 'r-'
+    bindings.MODE_SKIP_LIST = JSON.stringify([token])
+
+    const res = await fetch(new URL('car', endpoint), {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${token}`,
+        'Content-Type': 'application/vnd.ipld.car'
+      },
+      body: carBody
+    })
+    const { cid, carCid } = await res.json()
+    assert.strictEqual(cid, expectedCid, 'Server responded with expected CID')
+    assert.strictEqual(carCid, expectedCarCid, 'Server responded with expected CAR CID')
+
+    // fallback maintenance mode
+    bindings.MAINTENANCE_MODE = 'rw'
   })
 
   it('should throw for invalid maintenance mode', () => {


### PR DESCRIPTION
We are currently running a verification job to get report of what in `dotstorage-prod-1/raw/*` still needs to be migrated. It has been running for 10 days and looks like it will still take some time until finishing.

We want to rely on maintenance mode to disable writes, so adding a way to bypass maintenance mode for list of allowed tokens, so that we can still write the report when done for this bucket.

TODO:
- [x] needs secret