### PR TITLE
ci: .github/workflows/api.yml test upload to staging step using api-staging.web3.storage now has continue-on-error: true 

### DIFF
--- a/.github/workflows/api.yml
+++ b/.github/workflows/api.yml
@@ -94,6 +94,8 @@ jobs:
             NEXT_PUBLIC_W3UP_LAUNCH_SUNSET_ANNOUNCEMENT_START
             NEXT_PUBLIC_W3UP_LAUNCH_SUNSET_START
       - name: Test upload to staging
+        # api-staging.web3.storage is now in read-only mode to match api.web3.storage being in 'read only' mode due to product sunset
+        continue-on-error: true
         run: |
           npm run build -w packages/client
           echo "$(date --utc --iso-8601=seconds) web3.storage upload test" > ./upload-test-small


### PR DESCRIPTION
...to be resilient to staging writes being disabled

Motivation:
* this pipeline after merging a release-please PR failed the deploy to staging job and I think this change would make it green. https://github.com/web3-storage/web3.storage/actions/runs/7616473142