### PR TITLE
fix: hide pricing info

### DIFF
--- a/packages/website/pages/pricing.js
+++ b/packages/website/pages/pricing.js
@@ -476,7 +476,7 @@ export default function Home() {
         <div className="sectionals" id="tiered_pricing_section_1">
           <GradientBackground variant="light" />
           <PricingHeader />
-          <PricingTiers />
+          {/* <PricingTiers /> */}
         </div>
         <FaqSection />
         <LinkSection />

--- a/packages/website/pages/pricing.js
+++ b/packages/website/pages/pricing.js
@@ -143,6 +143,7 @@ const Card = props => {
   );
 };
 
+// eslint-disable-next-line
 const PricingTiers = () => {
   const [isEnterpriseRequestModelOpen, setIsEnterpriseRequestModelOpen] = useState(false);
 


### PR DESCRIPTION
You can no longer pay for storage with the legacy API.