### PR TITLE
feat: bump db package to 4.1.0 and use dep on that new version from cron, api packages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24202,7 +24202,7 @@
     },
     "packages/api": {
       "name": "@web3-storage/api",
-      "version": "7.22.0",
+      "version": "7.24.0",
       "license": "(Apache-2.0 OR MIT)",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.53.1",
@@ -24217,7 +24217,7 @@
         "@ucanto/principal": "^8.0.0",
         "@web3-storage/car-block-validator": "^1.0.0",
         "@web3-storage/content-claims": "^3.0.1",
-        "@web3-storage/db": "^4.0.0",
+        "@web3-storage/db": "^4.1.0",
         "@web3-storage/multipart-parser": "^1.0.0",
         "@web3-storage/w3up-launch": "^1.0.0",
         "cardex": "^2.3.1",
@@ -25507,7 +25507,7 @@
       "dependencies": {
         "@nftstorage/ipfs-cluster": "^5.0.1",
         "@web-std/fetch": "^2.0.1",
-        "@web3-storage/db": "^4.0.0",
+        "@web3-storage/db": "^4.1.0",
         "debug": "^4.3.1",
         "dotenv": "^9.0.2",
         "limiter": "2.0.1",
@@ -25962,7 +25962,7 @@
     },
     "packages/db": {
       "name": "@web3-storage/db",
-      "version": "4.0.4",
+      "version": "4.1.0",
       "license": "(Apache-2.0 OR MIT)",
       "dependencies": {
         "@supabase/postgrest-js": "^0.37.0",
@@ -27054,7 +27054,7 @@
     },
     "packages/website": {
       "name": "@web3-storage/website",
-      "version": "2.38.2",
+      "version": "2.39.4",
       "dependencies": {
         "@docsearch/react": "^3.0.0",
         "@fortawesome/free-brands-svg-icons": "^6.1.2",

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -74,7 +74,7 @@
     "@ucanto/principal": "^8.0.0",
     "@web3-storage/car-block-validator": "^1.0.0",
     "@web3-storage/content-claims": "^3.0.1",
-    "@web3-storage/db": "^4.0.0",
+    "@web3-storage/db": "^4.1.0",
     "@web3-storage/w3up-launch": "^1.0.0",
     "@web3-storage/multipart-parser": "^1.0.0",
     "cardex": "^2.3.1",

--- a/packages/cron/package.json
+++ b/packages/cron/package.json
@@ -21,7 +21,7 @@
   "dependencies": {
     "@nftstorage/ipfs-cluster": "^5.0.1",
     "@web-std/fetch": "^2.0.1",
-    "@web3-storage/db": "^4.0.0",
+    "@web3-storage/db": "^4.1.0",
     "debug": "^4.3.1",
     "dotenv": "^9.0.2",
     "limiter": "2.0.1",

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@web3-storage/db",
-  "version": "4.0.4",
+  "version": "4.1.0",
   "description": "Database schema and tools.",
   "private": "true",
   "main": "index.js",


### PR DESCRIPTION
Motivation:
* I want to release the db change from here https://github.com/web3-storage/web3.storage/pull/2352 in a way that the api also gets released and making use of it
* When I merged that last PR, there was no release-please PR generated for api. iiuc, that's because the PR only touched the db package, but not the api package (that depends on db)
  * hoping that this change that touches the api package.json will release things as desired